### PR TITLE
Add checkpoint event replay for governance state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-drift go-build go-test init-node clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test init-node clean
 
 help:
 	@echo ""
@@ -17,6 +17,7 @@ help:
 	@echo "  governance-queue Score a registry of proposals: make governance-queue REGISTRY=examples/proposals/registry.json"
 	@echo "  governance-trends Cluster portfolio-level governance trends"
 	@echo "  governance-remediation Emit structured mitigation bundles for active trends"
+	@echo "  governance-replay Replay checkpoint event logs into deterministic current state"
 	@echo "  governance-drift Compare a proposal against governance history"
 	@echo "  go-build         Build the 0aid binary"
 	@echo "  go-test          Run Go unit tests"
@@ -50,6 +51,10 @@ governance-remediation:
 	@test -n "$(REGISTRY)" || (echo "Usage: make governance-remediation REGISTRY=examples/proposals/registry.json HISTORY=examples/proposals/history.json" && exit 1)
 	@test -n "$(HISTORY)" || (echo "Usage: make governance-remediation REGISTRY=examples/proposals/registry.json HISTORY=examples/proposals/history.json" && exit 1)
 	PYTHONPATH=src $(PYTHON) -m assurancectl.cli governance-remediation --registry $(REGISTRY) --history $(HISTORY) $(if $(STATUS),--status $(STATUS),)
+
+governance-replay:
+	@test -n "$(STATUS)" || (echo "Usage: make governance-replay STATUS=examples/proposals/checkpoint-events.json" && exit 1)
+	PYTHONPATH=src $(PYTHON) -m assurancectl.cli governance-replay --status $(STATUS)
 
 governance-drift:
 	@test -n "$(PROPOSAL)" || (echo "Usage: make governance-drift PROPOSAL=examples/proposals/emergency-pause.json HISTORY=examples/proposals/history.json" && exit 1)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ make -C projects/0ai-assurance-network governance-sim PROPOSAL=examples/proposal
 make -C projects/0ai-assurance-network governance-queue REGISTRY=examples/proposals/registry.json
 make -C projects/0ai-assurance-network governance-trends REGISTRY=examples/proposals/registry.json HISTORY=examples/proposals/history.json
 make -C projects/0ai-assurance-network governance-remediation REGISTRY=examples/proposals/registry.json HISTORY=examples/proposals/history.json
+make -C projects/0ai-assurance-network governance-replay STATUS=examples/proposals/checkpoint-events.json
 make -C projects/0ai-assurance-network governance-drift PROPOSAL=examples/proposals/emergency-pause.json HISTORY=examples/proposals/history.json
 make -C projects/0ai-assurance-network go-build
 make -C projects/0ai-assurance-network go-test
@@ -112,12 +113,19 @@ owner roles, completion criteria, dependency ordering between phases, and
 status-aware rollups for current execution readiness. That keeps the governance
 path operationally useful once the engine detects an unstable cluster.
 
-Status files are transition-aware. Each non-pending checkpoint update should
+`governance-replay` reconstructs deterministic current checkpoint state from an
+append-only event log or a derived snapshot. Event logs are stricter than
+snapshots: each event must include `checkpoint_id`, `previous_status`,
+`new_status`, `updated_at`, and `recorded_by`, and replay rejects duplicate,
+contradictory, or out-of-order history.
+
+Status inputs are transition-aware. Each non-pending checkpoint update should
 include `previous_status`, `updated_at`, and `recorded_by`, and the engine only
 accepts lifecycle moves that stay inside the deterministic path
 `pending -> in_progress -> completed`. It also validates dependency timestamp
 ordering so downstream checkpoints cannot appear to complete before the latest
-completed prerequisite.
+completed prerequisite. Remediation accepts either a derived checkpoint snapshot
+or a replayable append-only event log via `--status`.
 
 `go-build` and `go-test` operate on the `0aid` binary skeleton and the internal
 Go project package.
@@ -156,6 +164,8 @@ PYTHONPATH=src python -m assurancectl.cli governance-remediation \
   --registry examples/proposals/registry.json \
   --history examples/proposals/history.json \
   --status examples/proposals/checkpoint-status.json
+PYTHONPATH=src python -m assurancectl.cli governance-replay \
+  --status examples/proposals/checkpoint-events.json
 PYTHONPATH=src python -m assurancectl.cli governance-drift \
   --proposal examples/proposals/emergency-pause.json \
   --history examples/proposals/history.json

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ path operationally useful once the engine detects an unstable cluster.
 `governance-replay` reconstructs deterministic current checkpoint state from an
 append-only event log or a derived snapshot. Event logs are stricter than
 snapshots: each event must include `checkpoint_id`, `previous_status`,
-`new_status`, `updated_at`, and `recorded_by`, and replay rejects duplicate,
-contradictory, or out-of-order history.
+`new_status`, `updated_at`, `recorded_by`, and `rationale`, and replay rejects
+duplicate, contradictory, illegal, or out-of-order history.
 
 Status inputs are transition-aware. Each non-pending checkpoint update should
 include `previous_status`, `updated_at`, and `recorded_by`, and the engine only

--- a/docs/governance-inference.md
+++ b/docs/governance-inference.md
@@ -157,6 +157,7 @@ Each event must include:
 - `new_status`
 - `updated_at`
 - `recorded_by`
+- `rationale`
 
 The status file is not treated as an arbitrary snapshot. For non-pending
 updates, operators should provide `previous_status`, `updated_at`, and
@@ -175,9 +176,9 @@ updates without actor attribution or timestamps, and it rejects checkpoint
 updates whose `updated_at` value predates the latest completed dependency.
 
 Event logs add another deterministic guarantee: replay rejects duplicate,
-contradictory, or out-of-order history. That means remediation can consume an
-event log directly without trusting a mutable current-state file as the source
-of truth.
+contradictory, illegal, or out-of-order history. That means remediation can
+consume an event log directly without trusting a mutable current-state file as
+the source of truth.
 
 ## Future Direction
 

--- a/docs/governance-inference.md
+++ b/docs/governance-inference.md
@@ -143,6 +143,21 @@ computes a progress-aware rollup:
 That makes the remediation output usable as a deterministic execution-progress
 view instead of a static advisory bundle only.
 
+`governance-replay` sits underneath that path. It reconstructs deterministic
+checkpoint state from either:
+
+- an append-only event log
+- a derived snapshot of current checkpoint state
+
+The event-log path is stricter and is the preferred long-term operator format.
+Each event must include:
+
+- `checkpoint_id`
+- `previous_status`
+- `new_status`
+- `updated_at`
+- `recorded_by`
+
 The status file is not treated as an arbitrary snapshot. For non-pending
 updates, operators should provide `previous_status`, `updated_at`, and
 `recorded_by`, and the engine validates the transition against the policy
@@ -158,6 +173,11 @@ readiness to `invalid`.
 Audit gaps are treated the same way. The remediation engine rejects non-pending
 updates without actor attribution or timestamps, and it rejects checkpoint
 updates whose `updated_at` value predates the latest completed dependency.
+
+Event logs add another deterministic guarantee: replay rejects duplicate,
+contradictory, or out-of-order history. That means remediation can consume an
+event log directly without trusting a mutable current-state file as the source
+of truth.
 
 ## Future Direction
 

--- a/examples/proposals/checkpoint-events.json
+++ b/examples/proposals/checkpoint-events.json
@@ -1,0 +1,37 @@
+{
+  "version": "checkpoint-event-log-example-2026-04-17",
+  "events": [
+    {
+      "checkpoint_id": "treasury-grant-0ai-core-immediate_action-1",
+      "previous_status": "pending",
+      "new_status": "in_progress",
+      "updated_at": "2026-04-16T11:51:00Z",
+      "recorded_by": "treasury-program-manager",
+      "rationale": "Started milestone release planning."
+    },
+    {
+      "checkpoint_id": "treasury-grant-0ai-core-immediate_action-1",
+      "previous_status": "in_progress",
+      "new_status": "completed",
+      "updated_at": "2026-04-16T12:01:00Z",
+      "recorded_by": "treasury-program-manager",
+      "rationale": "Milestone release plan approved."
+    },
+    {
+      "checkpoint_id": "treasury-grant-0ai-core-immediate_action-2",
+      "previous_status": "pending",
+      "new_status": "in_progress",
+      "updated_at": "2026-04-16T11:52:00Z",
+      "recorded_by": "treasury-program-manager",
+      "rationale": "Started staged release split."
+    },
+    {
+      "checkpoint_id": "treasury-grant-0ai-core-immediate_action-2",
+      "previous_status": "in_progress",
+      "new_status": "completed",
+      "updated_at": "2026-04-16T12:02:00Z",
+      "recorded_by": "treasury-program-manager",
+      "rationale": "Funding was broken into staged releases."
+    }
+  ]
+}

--- a/src/assurancectl/cli.py
+++ b/src/assurancectl/cli.py
@@ -18,6 +18,7 @@ from .inference import (
     load_inference_policy,
     load_proposal,
     load_registry,
+    replay_checkpoint_state,
 )
 from .readiness import build_readiness_report
 from .render import write_localnet_artifacts
@@ -57,6 +58,13 @@ def _parser() -> argparse.ArgumentParser:
     remediation.add_argument("--history", required=True, help="governance history JSON file path")
     remediation.add_argument("--status", help="checkpoint status JSON file path")
     remediation.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+
+    replay = subparsers.add_parser(
+        "governance-replay",
+        help="replay a checkpoint event log or snapshot into current checkpoint state",
+    )
+    replay.add_argument("--status", required=True, help="checkpoint state or event log JSON file path")
+    replay.add_argument("--json", action="store_true", help="emit machine-readable JSON")
 
     drift = subparsers.add_parser("governance-drift", help="compare a proposal against governance history")
     drift.add_argument("--proposal", required=True, help="proposal JSON file path")
@@ -296,6 +304,46 @@ def _print_governance_trends(trends, emit_json: bool) -> None:
         print(f"   summary: {trend.summary}")
 
 
+def _print_governance_replay(replay, emit_json: bool) -> None:
+    payload = {
+        "source_kind": replay.source_kind,
+        "replay_event_count": replay.replay_event_count,
+        "invalid_event_count": replay.invalid_event_count,
+        "event_alerts": replay.event_alerts,
+        "checkpoints": [
+            {
+                "checkpoint_id": checkpoint_id,
+                "previous_status": checkpoint_state.get("previous_status"),
+                "updated_at": checkpoint_state.get("updated_at"),
+                "recorded_by": checkpoint_state.get("recorded_by"),
+                "status": checkpoint_state.get("status"),
+            }
+            for checkpoint_id, checkpoint_state in sorted(replay.checkpoints.items())
+        ],
+    }
+    if emit_json:
+        print(json.dumps(payload, indent=2))
+        return
+
+    print(f"Replay source: {replay.source_kind}")
+    print(f"Replayed events: {replay.replay_event_count}")
+    print(f"Invalid events: {replay.invalid_event_count}")
+    if replay.event_alerts:
+        print("Event alerts:")
+        for item in replay.event_alerts:
+            print(f"  - {item}")
+    print(f"Checkpoint states: {len(replay.checkpoints)}")
+    for checkpoint_id, checkpoint_state in sorted(replay.checkpoints.items()):
+        print(
+            f"  - {checkpoint_id}: {checkpoint_state.get('previous_status')} -> "
+            f"{checkpoint_state.get('status')}"
+        )
+        if checkpoint_state.get("updated_at"):
+            print(f"    updated: {checkpoint_state.get('updated_at')}")
+        if checkpoint_state.get("recorded_by"):
+            print(f"    by: {checkpoint_state.get('recorded_by')}")
+
+
 def _print_governance_remediation(plans, emit_json: bool) -> None:
     payload = [
         {
@@ -309,8 +357,11 @@ def _print_governance_remediation(plans, emit_json: bool) -> None:
             "current_release_readiness": plan.current_release_readiness,
             "owner_roles": plan.owner_roles,
             "checkpoint_status_counts": plan.checkpoint_status_counts,
+            "replay_event_count": plan.replay_event_count,
+            "invalid_event_count": plan.invalid_event_count,
             "invalid_transition_count": plan.invalid_transition_count,
             "invalid_audit_count": plan.invalid_audit_count,
+            "event_alerts": plan.event_alerts,
             "transition_alerts": plan.transition_alerts,
             "audit_alerts": plan.audit_alerts,
             "progress_summary": plan.progress_summary,
@@ -355,10 +406,13 @@ def _print_governance_remediation(plans, emit_json: bool) -> None:
         print(f"   owner: {plan.owner}")
         print(f"   release readiness: {plan.release_readiness}")
         print(f"   current readiness: {plan.current_release_readiness}")
+        print(f"   replayed events: {plan.replay_event_count}")
         if plan.owner_roles:
             print(f"   owner roles: {', '.join(plan.owner_roles)}")
         if plan.triggers:
             print(f"   triggers: {', '.join(plan.triggers)}")
+        if plan.event_alerts:
+            print(f"   event alerts: {'; '.join(plan.event_alerts)}")
         if plan.transition_alerts:
             print(f"   transition alerts: {'; '.join(plan.transition_alerts)}")
         if plan.audit_alerts:
@@ -509,6 +563,12 @@ def main(argv: list[str] | None = None) -> int:
             if all(plan.current_release_readiness in {"monitoring", "complete"} for plan in plans)
             else 2
         )
+
+    if args.command == "governance-replay":
+        checkpoint_statuses = load_checkpoint_statuses(args.status)
+        replay = replay_checkpoint_state(checkpoint_statuses)
+        _print_governance_replay(replay, emit_json=args.json)
+        return 0 if replay.invalid_event_count == 0 else 2
 
     if args.command == "governance-drift":
         proposal = load_proposal(args.proposal)

--- a/src/assurancectl/inference.py
+++ b/src/assurancectl/inference.py
@@ -97,8 +97,11 @@ class GovernanceRemediationPlan:
     current_release_readiness: str
     owner_roles: list[str]
     checkpoint_status_counts: dict[str, int]
+    replay_event_count: int
+    invalid_event_count: int
     invalid_transition_count: int
     invalid_audit_count: int
+    event_alerts: list[str]
     transition_alerts: list[str]
     audit_alerts: list[str]
     progress_summary: str
@@ -129,6 +132,15 @@ class GovernanceRemediationCheckpoint:
     ready_to_start: bool
     depends_on: list[str]
     completion_criteria: str
+
+
+@dataclass(frozen=True)
+class GovernanceCheckpointReplay:
+    source_kind: str
+    replay_event_count: int
+    invalid_event_count: int
+    event_alerts: list[str]
+    checkpoints: dict[str, dict[str, str | None]]
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -189,9 +201,22 @@ def _checkpoint_slug(value: str) -> str:
     return "".join(ch.lower() if ch.isalnum() else "-" for ch in value).strip("-")
 
 
-def _normalize_checkpoint_statuses(statuses: dict[str, Any] | None) -> dict[str, dict[str, str | None]]:
+def replay_checkpoint_state(
+    statuses: dict[str, Any] | None,
+) -> GovernanceCheckpointReplay:
     if not statuses:
-        return {}
+        return GovernanceCheckpointReplay(
+            source_kind="empty",
+            replay_event_count=0,
+            invalid_event_count=0,
+            event_alerts=[],
+            checkpoints={},
+        )
+
+    raw_events = statuses.get("events")
+    if isinstance(raw_events, list):
+        return _replay_checkpoint_events(raw_events)
+
     raw_checkpoints = statuses.get("checkpoints", statuses)
     normalized: dict[str, dict[str, str | None]] = {}
     allowed_statuses = {"pending", "in_progress", "completed"}
@@ -204,7 +229,13 @@ def _normalize_checkpoint_statuses(statuses: dict[str, Any] | None) -> dict[str,
                 "recorded_by": None,
                 "status": status_name if status_name in allowed_statuses else "pending",
             }
-        return normalized
+        return GovernanceCheckpointReplay(
+            source_kind="snapshot",
+            replay_event_count=0,
+            invalid_event_count=0,
+            event_alerts=[],
+            checkpoints=normalized,
+        )
     if isinstance(raw_checkpoints, list):
         for entry in raw_checkpoints:
             if not isinstance(entry, dict) or "checkpoint_id" not in entry:
@@ -229,7 +260,95 @@ def _normalize_checkpoint_statuses(statuses: dict[str, Any] | None) -> dict[str,
                 ),
                 "status": status if status in allowed_statuses else "pending",
             }
-    return normalized
+    return GovernanceCheckpointReplay(
+        source_kind="snapshot",
+        replay_event_count=0,
+        invalid_event_count=0,
+        event_alerts=[],
+        checkpoints=normalized,
+    )
+
+
+def _replay_checkpoint_events(events: list[Any]) -> GovernanceCheckpointReplay:
+    allowed_statuses = {"pending", "in_progress", "completed"}
+    replayed: dict[str, dict[str, str | None]] = {}
+    replayed_timestamps: dict[str, datetime] = {}
+    event_alerts: list[str] = []
+    replay_event_count = 0
+
+    for index, raw_event in enumerate(events, start=1):
+        replay_event_count += 1
+        if not isinstance(raw_event, dict):
+            event_alerts.append(f"Event {index}: event must be an object.")
+            continue
+
+        checkpoint_id = str(raw_event.get("checkpoint_id", "")).strip()
+        if not checkpoint_id:
+            event_alerts.append(f"Event {index}: missing checkpoint_id.")
+            continue
+
+        previous_status = raw_event.get("previous_status")
+        previous_name = str(previous_status).strip().lower() if previous_status is not None else None
+        new_status = raw_event.get("new_status", raw_event.get("status"))
+        new_name = str(new_status).strip().lower() if new_status is not None else ""
+        updated_at = str(raw_event.get("updated_at")).strip() if raw_event.get("updated_at") is not None else None
+        recorded_by = str(raw_event.get("recorded_by")).strip() if raw_event.get("recorded_by") is not None else None
+
+        if previous_name not in allowed_statuses:
+            event_alerts.append(
+                f"Event {index} ({checkpoint_id}): previous_status must be one of pending, in_progress, completed."
+            )
+            continue
+        if new_name not in allowed_statuses:
+            event_alerts.append(
+                f"Event {index} ({checkpoint_id}): new_status must be one of pending, in_progress, completed."
+            )
+            continue
+        if previous_name == new_name:
+            event_alerts.append(
+                f"Event {index} ({checkpoint_id}): duplicate or no-op events are not allowed in the append-only log."
+            )
+            continue
+
+        parsed_timestamp = _parse_timestamp(updated_at)
+        if parsed_timestamp is None:
+            event_alerts.append(f"Event {index} ({checkpoint_id}): invalid or missing updated_at timestamp.")
+            continue
+        if not recorded_by:
+            event_alerts.append(f"Event {index} ({checkpoint_id}): missing recorded_by.")
+            continue
+
+        current_state = replayed.get(checkpoint_id)
+        expected_previous = str(current_state.get("status", "pending")) if current_state is not None else "pending"
+        if previous_name != expected_previous:
+            event_alerts.append(
+                f"Event {index} ({checkpoint_id}): contradictory event history, expected previous_status "
+                f"{expected_previous} but received {previous_name}."
+            )
+            continue
+
+        prior_timestamp = replayed_timestamps.get(checkpoint_id)
+        if prior_timestamp is not None and parsed_timestamp <= prior_timestamp:
+            event_alerts.append(
+                f"Event {index} ({checkpoint_id}): out-of-order updated_at {updated_at}."
+            )
+            continue
+
+        replayed[checkpoint_id] = {
+            "previous_status": previous_name,
+            "updated_at": updated_at,
+            "recorded_by": recorded_by,
+            "status": new_name,
+        }
+        replayed_timestamps[checkpoint_id] = parsed_timestamp
+
+    return GovernanceCheckpointReplay(
+        source_kind="event_log",
+        replay_event_count=replay_event_count,
+        invalid_event_count=len(event_alerts),
+        event_alerts=event_alerts,
+        checkpoints=replayed,
+    )
 
 
 def _validate_checkpoint_transition(
@@ -884,7 +1003,8 @@ def infer_governance_remediation_plans(
     require_actor_for_non_pending = bool(audit_requirements.get("require_actor_for_non_pending", True))
     require_timestamp_for_non_pending = bool(audit_requirements.get("require_timestamp_for_non_pending", True))
     enforce_dependency_timestamp_order = bool(audit_requirements.get("enforce_dependency_timestamp_order", True))
-    normalized_statuses = _normalize_checkpoint_statuses(checkpoint_statuses)
+    checkpoint_replay = replay_checkpoint_state(checkpoint_statuses)
+    normalized_statuses = checkpoint_replay.checkpoints
 
     cluster_entries: dict[str, list[GovernanceQueueEntry]] = {}
     for entry in entries:
@@ -1002,6 +1122,7 @@ def infer_governance_remediation_plans(
         build_checkpoints("monitoring", monitoring_actions, blocking=False)
 
         checkpoints: list[GovernanceRemediationCheckpoint] = []
+        event_alerts = list(checkpoint_replay.event_alerts)
         transition_alerts: list[str] = []
         audit_alerts: list[str] = []
         checkpoint_timestamps: dict[str, datetime | None] = {}
@@ -1140,9 +1261,10 @@ def infer_governance_remediation_plans(
             "in_progress": sum(1 for checkpoint in checkpoints if checkpoint.status == "in_progress"),
             "completed": sum(1 for checkpoint in checkpoints if checkpoint.status == "completed"),
         }
+        invalid_event_count = checkpoint_replay.invalid_event_count
         invalid_transition_count = sum(1 for checkpoint in checkpoints if not checkpoint.transition_valid)
         invalid_audit_count = sum(1 for checkpoint in checkpoints if not checkpoint.audit_valid)
-        if invalid_transition_count > 0 or invalid_audit_count > 0:
+        if invalid_event_count > 0 or invalid_transition_count > 0 or invalid_audit_count > 0:
             current_release_readiness = "invalid"
         elif any(checkpoint.blocking and checkpoint.status != "completed" for checkpoint in checkpoints):
             current_release_readiness = "blocked"
@@ -1169,6 +1291,8 @@ def infer_governance_remediation_plans(
             f"{checkpoint_status_counts['in_progress']} in progress, "
             f"{checkpoint_status_counts['pending']} pending."
         )
+        if invalid_event_count > 0:
+            progress_summary += f" {invalid_event_count} invalid event(s) detected."
         if invalid_transition_count > 0:
             progress_summary += f" {invalid_transition_count} invalid transition(s) detected."
         if invalid_audit_count > 0:
@@ -1192,8 +1316,11 @@ def infer_governance_remediation_plans(
                 current_release_readiness=current_release_readiness,
                 owner_roles=owner_roles,
                 checkpoint_status_counts=checkpoint_status_counts,
+                replay_event_count=checkpoint_replay.replay_event_count,
+                invalid_event_count=invalid_event_count,
                 invalid_transition_count=invalid_transition_count,
                 invalid_audit_count=invalid_audit_count,
+                event_alerts=event_alerts,
                 transition_alerts=transition_alerts,
                 audit_alerts=audit_alerts,
                 progress_summary=progress_summary,

--- a/src/assurancectl/inference.py
+++ b/src/assurancectl/inference.py
@@ -213,9 +213,18 @@ def replay_checkpoint_state(
             checkpoints={},
         )
 
+    has_events_key = "events" in statuses
     raw_events = statuses.get("events")
-    if isinstance(raw_events, list):
-        return _replay_checkpoint_events(raw_events)
+    if has_events_key:
+        if isinstance(raw_events, list):
+            return _replay_checkpoint_events(raw_events)
+        return GovernanceCheckpointReplay(
+            source_kind="event_log",
+            replay_event_count=0,
+            invalid_event_count=1,
+            event_alerts=["Invalid event log schema: 'events' must be a list."],
+            checkpoints={},
+        )
 
     raw_checkpoints = statuses.get("checkpoints", statuses)
     normalized: dict[str, dict[str, str | None]] = {}
@@ -271,6 +280,10 @@ def replay_checkpoint_state(
 
 def _replay_checkpoint_events(events: list[Any]) -> GovernanceCheckpointReplay:
     allowed_statuses = {"pending", "in_progress", "completed"}
+    allowed_transitions = {
+        ("pending", "in_progress"),
+        ("in_progress", "completed"),
+    }
     replayed: dict[str, dict[str, str | None]] = {}
     replayed_timestamps: dict[str, datetime] = {}
     event_alerts: list[str] = []
@@ -293,6 +306,7 @@ def _replay_checkpoint_events(events: list[Any]) -> GovernanceCheckpointReplay:
         new_name = str(new_status).strip().lower() if new_status is not None else ""
         updated_at = str(raw_event.get("updated_at")).strip() if raw_event.get("updated_at") is not None else None
         recorded_by = str(raw_event.get("recorded_by")).strip() if raw_event.get("recorded_by") is not None else None
+        rationale = str(raw_event.get("rationale")).strip() if raw_event.get("rationale") is not None else None
 
         if previous_name not in allowed_statuses:
             event_alerts.append(
@@ -309,6 +323,11 @@ def _replay_checkpoint_events(events: list[Any]) -> GovernanceCheckpointReplay:
                 f"Event {index} ({checkpoint_id}): duplicate or no-op events are not allowed in the append-only log."
             )
             continue
+        if (previous_name, new_name) not in allowed_transitions:
+            event_alerts.append(
+                f"Event {index} ({checkpoint_id}): illegal lifecycle transition {previous_name} -> {new_name}."
+            )
+            continue
 
         parsed_timestamp = _parse_timestamp(updated_at)
         if parsed_timestamp is None:
@@ -316,6 +335,9 @@ def _replay_checkpoint_events(events: list[Any]) -> GovernanceCheckpointReplay:
             continue
         if not recorded_by:
             event_alerts.append(f"Event {index} ({checkpoint_id}): missing recorded_by.")
+            continue
+        if not rationale:
+            event_alerts.append(f"Event {index} ({checkpoint_id}): missing rationale.")
             continue
 
         current_state = replayed.get(checkpoint_id)

--- a/tests/test_assurancectl.py
+++ b/tests/test_assurancectl.py
@@ -464,6 +464,49 @@ class AssuranceCtlTests(unittest.TestCase):
         self.assertTrue(payload["event_alerts"])
         self.assertIn("contradictory event history", payload["event_alerts"][0])
 
+    def test_governance_replay_rejects_illegal_lifecycle_transition(self) -> None:
+        invalid_transition_payload = {
+            "version": "checkpoint-event-log-illegal-transition-test",
+            "events": [
+                {
+                    "checkpoint_id": "treasury-grant-0ai-core-immediate_action-1",
+                    "previous_status": "pending",
+                    "new_status": "completed",
+                    "updated_at": "2026-04-16T11:01:00Z",
+                    "recorded_by": "treasury-program-manager",
+                    "rationale": "Skipping in-progress should be rejected.",
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events-illegal-transition.json"
+            event_path.write_text(json.dumps(invalid_transition_payload), encoding="utf-8")
+            result = self.run_cli("governance-replay", "--status", str(event_path), "--json")
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["source_kind"], "event_log")
+        self.assertEqual(payload["invalid_event_count"], 1)
+        self.assertIn("illegal lifecycle transition pending -> completed", payload["event_alerts"][0])
+
+    def test_governance_replay_rejects_invalid_event_log_schema(self) -> None:
+        invalid_schema_payload = {
+            "version": "checkpoint-event-log-invalid-schema-test",
+            "events": {"unexpected": "object"},
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events-invalid-schema.json"
+            event_path.write_text(json.dumps(invalid_schema_payload), encoding="utf-8")
+            result = self.run_cli("governance-replay", "--status", str(event_path), "--json")
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["source_kind"], "event_log")
+        self.assertEqual(payload["invalid_event_count"], 1)
+        self.assertEqual(payload["event_alerts"], ["Invalid event log schema: 'events' must be a list."])
+
     def test_governance_remediation_event_log_updates_current_readiness(self) -> None:
         baseline = self.run_cli(
             "governance-remediation",

--- a/tests/test_assurancectl.py
+++ b/tests/test_assurancectl.py
@@ -24,6 +24,50 @@ class AssuranceCtlTests(unittest.TestCase):
             check=False,
         )
 
+    def build_treasury_event_log(self, checkpoints: list[dict[str, object]]) -> dict[str, object]:
+        event_payload: dict[str, object] = {"version": "checkpoint-event-log-test", "events": []}
+        events = event_payload["events"]
+        assert isinstance(events, list)
+        completed_counter = 0
+        for checkpoint in checkpoints:
+            checkpoint_id = str(checkpoint["checkpoint_id"])
+            owner_role = str(checkpoint["owner_role"])
+            phase = str(checkpoint["phase"])
+            if phase in {"immediate_action", "approval_guardrail"}:
+                completed_counter += 1
+                events.append(
+                    {
+                        "checkpoint_id": checkpoint_id,
+                        "previous_status": "pending",
+                        "new_status": "in_progress",
+                        "updated_at": f"2026-04-16T11:{completed_counter:02d}:00Z",
+                        "recorded_by": owner_role,
+                        "rationale": f"Started {checkpoint_id}.",
+                    }
+                )
+                events.append(
+                    {
+                        "checkpoint_id": checkpoint_id,
+                        "previous_status": "in_progress",
+                        "new_status": "completed",
+                        "updated_at": f"2026-04-16T12:{completed_counter:02d}:00Z",
+                        "recorded_by": owner_role,
+                        "rationale": f"Completed {checkpoint_id}.",
+                    }
+                )
+            elif phase == "monitoring" and checkpoint_id.endswith("-1"):
+                events.append(
+                    {
+                        "checkpoint_id": checkpoint_id,
+                        "previous_status": "pending",
+                        "new_status": "in_progress",
+                        "updated_at": "2026-04-16T13:00:00Z",
+                        "recorded_by": owner_role,
+                        "rationale": f"Started monitoring for {checkpoint_id}.",
+                    }
+                )
+        return event_payload
+
     def test_validate_passes(self) -> None:
         result = self.run_cli("validate")
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -352,6 +396,110 @@ class AssuranceCtlTests(unittest.TestCase):
                 if checkpoint["phase"] == "monitoring"
             )
         )
+
+    def test_governance_replay_reconstructs_checkpoint_state_from_event_log(self) -> None:
+        baseline = self.run_cli(
+            "governance-remediation",
+            "--registry",
+            "examples/proposals/registry.json",
+            "--history",
+            "examples/proposals/history.json",
+            "--json",
+        )
+        self.assertEqual(baseline.returncode, 2, baseline.stdout + baseline.stderr)
+        baseline_payload = json.loads(baseline.stdout)
+        treasury = next(item for item in baseline_payload if item["trend_cluster"] == "treasury_grant:0ai-core")
+        event_payload = self.build_treasury_event_log(treasury["checkpoints"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events.json"
+            event_path.write_text(json.dumps(event_payload), encoding="utf-8")
+            result = self.run_cli("governance-replay", "--status", str(event_path), "--json")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["source_kind"], "event_log")
+        self.assertEqual(payload["invalid_event_count"], 0)
+        self.assertGreater(payload["replay_event_count"], 0)
+        monitoring = next(
+            checkpoint
+            for checkpoint in payload["checkpoints"]
+            if checkpoint["checkpoint_id"] == "treasury-grant-0ai-core-monitoring-1"
+        )
+        self.assertEqual(monitoring["status"], "in_progress")
+        self.assertEqual(monitoring["recorded_by"], "finance-telemetry-lead")
+
+    def test_governance_replay_rejects_duplicate_events(self) -> None:
+        duplicate_payload = {
+            "version": "checkpoint-event-log-duplicate-test",
+            "events": [
+                {
+                    "checkpoint_id": "treasury-grant-0ai-core-immediate_action-1",
+                    "previous_status": "pending",
+                    "new_status": "in_progress",
+                    "updated_at": "2026-04-16T11:01:00Z",
+                    "recorded_by": "treasury-program-manager",
+                    "rationale": "Started milestone release planning.",
+                },
+                {
+                    "checkpoint_id": "treasury-grant-0ai-core-immediate_action-1",
+                    "previous_status": "pending",
+                    "new_status": "in_progress",
+                    "updated_at": "2026-04-16T11:02:00Z",
+                    "recorded_by": "treasury-program-manager",
+                    "rationale": "Duplicate write should be rejected.",
+                },
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events-duplicate.json"
+            event_path.write_text(json.dumps(duplicate_payload), encoding="utf-8")
+            result = self.run_cli("governance-replay", "--status", str(event_path), "--json")
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["source_kind"], "event_log")
+        self.assertEqual(payload["invalid_event_count"], 1)
+        self.assertTrue(payload["event_alerts"])
+        self.assertIn("contradictory event history", payload["event_alerts"][0])
+
+    def test_governance_remediation_event_log_updates_current_readiness(self) -> None:
+        baseline = self.run_cli(
+            "governance-remediation",
+            "--registry",
+            "examples/proposals/registry.json",
+            "--history",
+            "examples/proposals/history.json",
+            "--json",
+        )
+        self.assertEqual(baseline.returncode, 2, baseline.stdout + baseline.stderr)
+        baseline_payload = json.loads(baseline.stdout)
+        treasury = next(item for item in baseline_payload if item["trend_cluster"] == "treasury_grant:0ai-core")
+        event_payload = self.build_treasury_event_log(treasury["checkpoints"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events-remediation.json"
+            event_path.write_text(json.dumps(event_payload), encoding="utf-8")
+            result = self.run_cli(
+                "governance-remediation",
+                "--registry",
+                "examples/proposals/registry.json",
+                "--history",
+                "examples/proposals/history.json",
+                "--status",
+                str(event_path),
+                "--json",
+            )
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        treasury_updated = next(item for item in payload if item["trend_cluster"] == "treasury_grant:0ai-core")
+        self.assertEqual(treasury_updated["current_release_readiness"], "monitoring")
+        self.assertEqual(treasury_updated["invalid_event_count"], 0)
+        self.assertEqual(treasury_updated["invalid_transition_count"], 0)
+        self.assertEqual(treasury_updated["invalid_audit_count"], 0)
+        self.assertGreater(treasury_updated["replay_event_count"], 0)
 
     def test_governance_remediation_invalid_transition_marks_plan_invalid(self) -> None:
         baseline = self.run_cli(


### PR DESCRIPTION
## Summary
- add deterministic checkpoint event log replay beneath governance remediation
- expose a new governance-replay CLI and make target for replay inspection
- cover valid replay, duplicate rejection, and remediation rollup updates with tests

## Testing
- python -m py_compile src/assurancectl/inference.py src/assurancectl/cli.py
- python -m unittest discover -s tests -v
- make validate
- make go-test
- make go-build
- PYTHONPATH=src python -m assurancectl.cli governance-replay --status examples/proposals/checkpoint-events.json --json

Closes #1