### PR TITLE
Add cyberviser to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @0ai-Cyberviser
+* @0ai-Cyberviser @cyberviser


### PR DESCRIPTION
## Summary
- add @cyberviser to CODEOWNERS so the repo can keep code owner review enabled without self-deadlocking

## Testing
- metadata only
