### PR TITLE
Add signed checkpoint update verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,21 @@ path operationally useful once the engine detects an unstable cluster.
 append-only event log or a derived snapshot. Event logs are stricter than
 snapshots: each event must include `checkpoint_id`, `previous_status`,
 `new_status`, `updated_at`, `recorded_by`, and `rationale`, and replay rejects
-duplicate, contradictory, illegal, or out-of-order history.
+duplicate, contradictory, illegal, or out-of-order history. Signed event logs
+must also include a `signature` object with:
+
+- `format`
+- `signer_id`
+- `key_id`
+- `signature_id`
+- `signed_at`
+- `expires_at`
+- `value`
+
+Signer-to-role policy lives in
+`config/governance/checkpoint-signers.json`. The current repository ships
+development-only HMAC signers so the pre-launch testnet can exercise
+authenticated updates without pretending to solve production custody.
 
 Status inputs are transition-aware. Each non-pending checkpoint update should
 include `previous_status`, `updated_at`, and `recorded_by`, and the engine only
@@ -126,6 +140,16 @@ accepts lifecycle moves that stay inside the deterministic path
 ordering so downstream checkpoints cannot appear to complete before the latest
 completed prerequisite. Remediation accepts either a derived checkpoint snapshot
 or a replayable append-only event log via `--status`.
+
+For event logs, non-pending updates are only accepted when the signature is
+valid, the signer is authorized for the `recorded_by` role, and the update falls
+inside the signature validity window. Reused `signature_id` values are rejected
+as replay attempts.
+
+Rejected or expired signatures are surfaced as event alerts during
+`governance-replay`, and any remediation run consuming that event log moves the
+affected cluster to `current_release_readiness = invalid` until the bad update
+is replaced with a new signed record.
 
 `go-build` and `go-test` operate on the `0aid` binary skeleton and the internal
 Go project package.

--- a/config/governance/checkpoint-signers.json
+++ b/config/governance/checkpoint-signers.json
@@ -1,0 +1,68 @@
+{
+  "version": "checkpoint-signers-2026-04-17",
+  "signature_format": "0ai-hmac-sha256-v1",
+  "require_signatures_for_event_logs": true,
+  "maximum_signature_validity_seconds": 86400,
+  "signers": [
+    {
+      "signer_id": "treasury-program-manager-bot",
+      "key_id": "treasury-program-manager-dev-v1",
+      "roles": ["treasury-program-manager"],
+      "shared_secret": "dev-secret-treasury-program-manager-v1"
+    },
+    {
+      "signer_id": "treasury-review-chair-bot",
+      "key_id": "treasury-review-chair-dev-v1",
+      "roles": ["treasury-review-chair"],
+      "shared_secret": "dev-secret-treasury-review-chair-v1"
+    },
+    {
+      "signer_id": "finance-telemetry-lead-bot",
+      "key_id": "finance-telemetry-lead-dev-v1",
+      "roles": ["finance-telemetry-lead"],
+      "shared_secret": "dev-secret-finance-telemetry-lead-v1"
+    },
+    {
+      "signer_id": "validator-ops-lead-bot",
+      "key_id": "validator-ops-lead-dev-v1",
+      "roles": ["validator-ops-lead"],
+      "shared_secret": "dev-secret-validator-ops-lead-v1"
+    },
+    {
+      "signer_id": "staking-governance-reviewer-bot",
+      "key_id": "staking-governance-reviewer-dev-v1",
+      "roles": ["staking-governance-reviewer"],
+      "shared_secret": "dev-secret-staking-governance-reviewer-v1"
+    },
+    {
+      "signer_id": "network-reliability-lead-bot",
+      "key_id": "network-reliability-lead-dev-v1",
+      "roles": ["network-reliability-lead"],
+      "shared_secret": "dev-secret-network-reliability-lead-v1"
+    },
+    {
+      "signer_id": "safety-council-chair-bot",
+      "key_id": "safety-council-chair-dev-v1",
+      "roles": ["safety-council-chair"],
+      "shared_secret": "dev-secret-safety-council-chair-v1"
+    },
+    {
+      "signer_id": "incident-commander-bot",
+      "key_id": "incident-commander-dev-v1",
+      "roles": ["incident-commander"],
+      "shared_secret": "dev-secret-incident-commander-v1"
+    },
+    {
+      "signer_id": "safety-council-secretariat-bot",
+      "key_id": "safety-council-secretariat-dev-v1",
+      "roles": ["safety-council-secretariat"],
+      "shared_secret": "dev-secret-safety-council-secretariat-v1"
+    },
+    {
+      "signer_id": "security-telemetry-lead-bot",
+      "key_id": "security-telemetry-lead-dev-v1",
+      "roles": ["security-telemetry-lead"],
+      "shared_secret": "dev-secret-security-telemetry-lead-v1"
+    }
+  ]
+}

--- a/docs/governance-inference.md
+++ b/docs/governance-inference.md
@@ -158,6 +158,19 @@ Each event must include:
 - `updated_at`
 - `recorded_by`
 - `rationale`
+- `signature.format`
+- `signature.signer_id`
+- `signature.key_id`
+- `signature.signature_id`
+- `signature.signed_at`
+- `signature.expires_at`
+- `signature.value`
+
+Signer-role bindings are defined in
+`config/governance/checkpoint-signers.json`. The current implementation uses a
+development-only HMAC verifier so the permissioned testnet can exercise actor
+verification and replay protection without pretending to be a production key
+management system.
 
 The status file is not treated as an arbitrary snapshot. For non-pending
 updates, operators should provide `previous_status`, `updated_at`, and
@@ -176,9 +189,15 @@ updates without actor attribution or timestamps, and it rejects checkpoint
 updates whose `updated_at` value predates the latest completed dependency.
 
 Event logs add another deterministic guarantee: replay rejects duplicate,
-contradictory, illegal, or out-of-order history. That means remediation can
-consume an event log directly without trusting a mutable current-state file as
-the source of truth.
+contradictory, illegal, or out-of-order history. Signed event logs go further:
+replay rejects invalid signatures, wrong-role signers, expired signatures, and
+reused `signature_id` values. That means remediation can consume an event log
+directly without trusting a mutable current-state file as the source of truth.
+
+Operationally, rejected or expired signatures should not be patched in place.
+They should be superseded by a new signed update or event log segment. The CLI
+surfaces those failures as event alerts during replay, and remediation marks the
+affected cluster as `invalid` until a clean signed update is supplied.
 
 ## Future Direction
 

--- a/examples/proposals/checkpoint-events.json
+++ b/examples/proposals/checkpoint-events.json
@@ -7,7 +7,16 @@
       "new_status": "in_progress",
       "updated_at": "2026-04-16T11:51:00Z",
       "recorded_by": "treasury-program-manager",
-      "rationale": "Started milestone release planning."
+      "rationale": "Started milestone release planning.",
+      "signature": {
+        "format": "0ai-hmac-sha256-v1",
+        "signer_id": "treasury-program-manager-bot",
+        "key_id": "treasury-program-manager-dev-v1",
+        "signature_id": "example-immediate-action-1-start",
+        "signed_at": "2026-04-16T10:00:00Z",
+        "expires_at": "2026-04-17T10:00:00Z",
+        "value": "adce4ccf51ef95c7f284a77877af8346c2d40ca0aba2958c3eb322ec8a684ebf"
+      }
     },
     {
       "checkpoint_id": "treasury-grant-0ai-core-immediate_action-1",
@@ -15,7 +24,16 @@
       "new_status": "completed",
       "updated_at": "2026-04-16T12:01:00Z",
       "recorded_by": "treasury-program-manager",
-      "rationale": "Milestone release plan approved."
+      "rationale": "Milestone release plan approved.",
+      "signature": {
+        "format": "0ai-hmac-sha256-v1",
+        "signer_id": "treasury-program-manager-bot",
+        "key_id": "treasury-program-manager-dev-v1",
+        "signature_id": "example-immediate-action-1-complete",
+        "signed_at": "2026-04-16T10:00:00Z",
+        "expires_at": "2026-04-17T10:00:00Z",
+        "value": "0d796900e2f95ab5c76048422ab0f4c679fec4cc20bf0182b1724a938fd8472d"
+      }
     },
     {
       "checkpoint_id": "treasury-grant-0ai-core-immediate_action-2",
@@ -23,7 +41,16 @@
       "new_status": "in_progress",
       "updated_at": "2026-04-16T11:52:00Z",
       "recorded_by": "treasury-program-manager",
-      "rationale": "Started staged release split."
+      "rationale": "Started staged release split.",
+      "signature": {
+        "format": "0ai-hmac-sha256-v1",
+        "signer_id": "treasury-program-manager-bot",
+        "key_id": "treasury-program-manager-dev-v1",
+        "signature_id": "example-immediate-action-2-start",
+        "signed_at": "2026-04-16T10:00:00Z",
+        "expires_at": "2026-04-17T10:00:00Z",
+        "value": "8f5cde42bbd8593a297dd2f24225aa0a62eaf9aa62ed5a8161758d3de7aada78"
+      }
     },
     {
       "checkpoint_id": "treasury-grant-0ai-core-immediate_action-2",
@@ -31,7 +58,16 @@
       "new_status": "completed",
       "updated_at": "2026-04-16T12:02:00Z",
       "recorded_by": "treasury-program-manager",
-      "rationale": "Funding was broken into staged releases."
+      "rationale": "Funding was broken into staged releases.",
+      "signature": {
+        "format": "0ai-hmac-sha256-v1",
+        "signer_id": "treasury-program-manager-bot",
+        "key_id": "treasury-program-manager-dev-v1",
+        "signature_id": "example-immediate-action-2-complete",
+        "signed_at": "2026-04-16T10:00:00Z",
+        "expires_at": "2026-04-17T10:00:00Z",
+        "value": "6e0772a2fdb427a4d6717052376a0400c6fe19a62ccfb280a140ac7da49b4e31"
+      }
     }
   ]
 }

--- a/src/assurancectl/cli.py
+++ b/src/assurancectl/cli.py
@@ -13,6 +13,7 @@ from .inference import (
     infer_governance_queue,
     infer_governance_remediation_plans,
     load_checkpoint_statuses,
+    load_checkpoint_signer_policy,
     infer_governance_report,
     load_history,
     load_inference_policy,
@@ -548,6 +549,7 @@ def main(argv: list[str] | None = None) -> int:
         registry = load_registry(args.registry)
         history = load_history(args.history)
         policy = load_inference_policy(config)
+        signer_policy = load_checkpoint_signer_policy(config)
         checkpoint_statuses = load_checkpoint_statuses(args.status) if args.status else None
         entries = infer_governance_queue(config, registry, registry_path=args.registry, history=history, policy=policy)
         trends = infer_governance_portfolio_trends(entries, history=history, policy=policy)
@@ -556,6 +558,7 @@ def main(argv: list[str] | None = None) -> int:
             trends,
             policy=policy,
             checkpoint_statuses=checkpoint_statuses,
+            signature_policy=signer_policy,
         )
         _print_governance_remediation(plans, emit_json=args.json)
         return (
@@ -566,7 +569,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "governance-replay":
         checkpoint_statuses = load_checkpoint_statuses(args.status)
-        replay = replay_checkpoint_state(checkpoint_statuses)
+        signer_policy = load_checkpoint_signer_policy(config)
+        replay = replay_checkpoint_state(checkpoint_statuses, signature_policy=signer_policy)
         _print_governance_replay(replay, emit_json=args.json)
         return 0 if replay.invalid_event_count == 0 else 2
 

--- a/src/assurancectl/config.py
+++ b/src/assurancectl/config.py
@@ -20,6 +20,7 @@ class LoadedConfig:
     topology: dict[str, Any]
     genesis: dict[str, Any]
     policy: dict[str, Any]
+    checkpoint_signers: dict[str, Any]
 
 
 def root_dir(explicit_root: str | Path | None = None) -> Path:
@@ -41,6 +42,7 @@ def load_config(explicit_root: str | Path | None = None) -> LoadedConfig:
         topology=_load_json(config / "network-topology.json"),
         genesis=_load_json(config / "genesis" / "base-genesis.json"),
         policy=_load_json(config / "policy" / "release-guards.json"),
+        checkpoint_signers=_load_json(config / "governance" / "checkpoint-signers.json"),
     )
 
 
@@ -120,7 +122,44 @@ def validate_policy(policy: dict[str, Any]) -> None:
     )
 
 
+def validate_checkpoint_signers(checkpoint_signers: dict[str, Any]) -> None:
+    _assert(
+        checkpoint_signers["signature_format"] == "0ai-hmac-sha256-v1",
+        "checkpoint signer signature_format must be 0ai-hmac-sha256-v1",
+    )
+    _assert(
+        bool(checkpoint_signers["require_signatures_for_event_logs"]),
+        "checkpoint signer policy must require signatures for event logs",
+    )
+    _assert(
+        int(checkpoint_signers["maximum_signature_validity_seconds"]) > 0,
+        "checkpoint signer validity window must be positive",
+    )
+    signers = list(checkpoint_signers["signers"])
+    _assert(signers, "at least one checkpoint signer must be configured")
+
+    signer_ids: set[str] = set()
+    key_ids: set[str] = set()
+    role_bindings: set[str] = set()
+    for signer in signers:
+        signer_id = str(signer["signer_id"])
+        key_id = str(signer["key_id"])
+        shared_secret = str(signer["shared_secret"])
+        roles = [str(role) for role in signer["roles"]]
+        _assert(signer_id not in signer_ids, f"duplicate checkpoint signer_id: {signer_id}")
+        _assert(key_id not in key_ids, f"duplicate checkpoint key_id: {key_id}")
+        _assert(shared_secret != "", f"checkpoint signer {signer_id} must declare a shared_secret")
+        _assert(roles, f"checkpoint signer {signer_id} must declare at least one role")
+        for role in roles:
+            binding = f"{signer_id}:{role}"
+            _assert(binding not in role_bindings, f"duplicate checkpoint signer role binding: {binding}")
+            role_bindings.add(binding)
+        signer_ids.add(signer_id)
+        key_ids.add(key_id)
+
+
 def validate_all(config: LoadedConfig) -> None:
     validate_topology(config.topology)
     validate_genesis(config.genesis, config.topology)
     validate_policy(config.policy)
+    validate_checkpoint_signers(config.checkpoint_signers)

--- a/src/assurancectl/inference.py
+++ b/src/assurancectl/inference.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
@@ -152,6 +154,10 @@ def load_inference_policy(config: LoadedConfig) -> dict[str, Any]:
     return _load_json(config.root / "config" / "governance" / "inference-policy.json")
 
 
+def load_checkpoint_signer_policy(config: LoadedConfig) -> dict[str, Any]:
+    return _load_json(config.root / "config" / "governance" / "checkpoint-signers.json")
+
+
 def load_proposal(path: str | Path) -> dict[str, Any]:
     return _load_json(Path(path))
 
@@ -203,6 +209,8 @@ def _checkpoint_slug(value: str) -> str:
 
 def replay_checkpoint_state(
     statuses: dict[str, Any] | None,
+    *,
+    signature_policy: dict[str, Any] | None = None,
 ) -> GovernanceCheckpointReplay:
     if not statuses:
         return GovernanceCheckpointReplay(
@@ -217,7 +225,7 @@ def replay_checkpoint_state(
     raw_events = statuses.get("events")
     if has_events_key:
         if isinstance(raw_events, list):
-            return _replay_checkpoint_events(raw_events)
+            return _replay_checkpoint_events(raw_events, signature_policy=signature_policy)
         return GovernanceCheckpointReplay(
             source_kind="event_log",
             replay_event_count=0,
@@ -278,7 +286,130 @@ def replay_checkpoint_state(
     )
 
 
-def _replay_checkpoint_events(events: list[Any]) -> GovernanceCheckpointReplay:
+def _build_checkpoint_signature_message(
+    *,
+    checkpoint_id: str,
+    previous_status: str,
+    new_status: str,
+    updated_at: str,
+    recorded_by: str,
+    rationale: str,
+    signature_meta: dict[str, str],
+) -> str:
+    payload = {
+        "checkpoint_id": checkpoint_id,
+        "previous_status": previous_status,
+        "new_status": new_status,
+        "updated_at": updated_at,
+        "recorded_by": recorded_by,
+        "rationale": rationale,
+        "signature": signature_meta,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _validate_signed_checkpoint_event(
+    *,
+    event_index: int,
+    checkpoint_id: str,
+    previous_status: str,
+    new_status: str,
+    updated_at: str,
+    recorded_by: str,
+    rationale: str,
+    raw_signature: Any,
+    signature_policy: dict[str, Any] | None,
+    seen_signature_ids: set[str],
+) -> str | None:
+    if not signature_policy or not signature_policy.get("require_signatures_for_event_logs", False):
+        return None
+    if not isinstance(raw_signature, dict):
+        return f"Event {event_index} ({checkpoint_id}): missing signature."
+
+    signature_format = str(raw_signature.get("format", "")).strip()
+    signer_id = str(raw_signature.get("signer_id", "")).strip()
+    key_id = str(raw_signature.get("key_id", "")).strip()
+    signature_id = str(raw_signature.get("signature_id", "")).strip()
+    signed_at = str(raw_signature.get("signed_at", "")).strip()
+    expires_at = str(raw_signature.get("expires_at", "")).strip()
+    signature_value = str(raw_signature.get("value", "")).strip()
+
+    if not all([signature_format, signer_id, key_id, signature_id, signed_at, expires_at, signature_value]):
+        return f"Event {event_index} ({checkpoint_id}): signature metadata is incomplete."
+    if signature_format != str(signature_policy.get("signature_format", "")).strip():
+        return (
+            f"Event {event_index} ({checkpoint_id}): unsupported signature format "
+            f"{signature_format}."
+        )
+    if signature_id in seen_signature_ids:
+        return f"Event {event_index} ({checkpoint_id}): replay attempt detected for signature_id {signature_id}."
+
+    signed_timestamp = _parse_timestamp(signed_at)
+    expires_timestamp = _parse_timestamp(expires_at)
+    updated_timestamp = _parse_timestamp(updated_at)
+    if signed_timestamp is None or expires_timestamp is None or updated_timestamp is None:
+        return f"Event {event_index} ({checkpoint_id}): signature timestamps are invalid."
+    maximum_validity_seconds = int(signature_policy.get("maximum_signature_validity_seconds", 0))
+    validity_window = int((expires_timestamp - signed_timestamp).total_seconds())
+    if validity_window <= 0:
+        return f"Event {event_index} ({checkpoint_id}): signature expires before it becomes valid."
+    if maximum_validity_seconds > 0 and validity_window > maximum_validity_seconds:
+        return (
+            f"Event {event_index} ({checkpoint_id}): signature validity window exceeds policy limit."
+        )
+    if not (signed_timestamp <= updated_timestamp <= expires_timestamp):
+        return f"Event {event_index} ({checkpoint_id}): signature is expired or not yet valid for updated_at."
+
+    signer_entries = list(signature_policy.get("signers", []))
+    signer_entry = next(
+        (
+            entry
+            for entry in signer_entries
+            if str(entry.get("signer_id", "")).strip() == signer_id
+            and str(entry.get("key_id", "")).strip() == key_id
+        ),
+        None,
+    )
+    if signer_entry is None:
+        return f"Event {event_index} ({checkpoint_id}): unknown signer_id/key_id pair."
+
+    signer_roles = [str(role).strip() for role in signer_entry.get("roles", [])]
+    if recorded_by not in signer_roles:
+        return (
+            f"Event {event_index} ({checkpoint_id}): signer {signer_id} is not authorized for role {recorded_by}."
+        )
+
+    signature_meta = {
+        "format": signature_format,
+        "signer_id": signer_id,
+        "key_id": key_id,
+        "signature_id": signature_id,
+        "signed_at": signed_at,
+        "expires_at": expires_at,
+    }
+    signing_message = _build_checkpoint_signature_message(
+        checkpoint_id=checkpoint_id,
+        previous_status=previous_status,
+        new_status=new_status,
+        updated_at=updated_at,
+        recorded_by=recorded_by,
+        rationale=rationale,
+        signature_meta=signature_meta,
+    )
+    shared_secret = str(signer_entry.get("shared_secret", "")).encode("utf-8")
+    expected_value = hmac.new(shared_secret, signing_message.encode("utf-8"), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected_value, signature_value):
+        return f"Event {event_index} ({checkpoint_id}): invalid signature."
+
+    seen_signature_ids.add(signature_id)
+    return None
+
+
+def _replay_checkpoint_events(
+    events: list[Any],
+    *,
+    signature_policy: dict[str, Any] | None = None,
+) -> GovernanceCheckpointReplay:
     allowed_statuses = {"pending", "in_progress", "completed"}
     allowed_transitions = {
         ("pending", "in_progress"),
@@ -288,6 +419,7 @@ def _replay_checkpoint_events(events: list[Any]) -> GovernanceCheckpointReplay:
     replayed_timestamps: dict[str, datetime] = {}
     event_alerts: list[str] = []
     replay_event_count = 0
+    seen_signature_ids: set[str] = set()
 
     for index, raw_event in enumerate(events, start=1):
         replay_event_count += 1
@@ -338,6 +470,21 @@ def _replay_checkpoint_events(events: list[Any]) -> GovernanceCheckpointReplay:
             continue
         if not rationale:
             event_alerts.append(f"Event {index} ({checkpoint_id}): missing rationale.")
+            continue
+        signature_error = _validate_signed_checkpoint_event(
+            event_index=index,
+            checkpoint_id=checkpoint_id,
+            previous_status=previous_name,
+            new_status=new_name,
+            updated_at=updated_at,
+            recorded_by=recorded_by,
+            rationale=rationale,
+            raw_signature=raw_event.get("signature"),
+            signature_policy=signature_policy,
+            seen_signature_ids=seen_signature_ids,
+        )
+        if signature_error:
+            event_alerts.append(signature_error)
             continue
 
         current_state = replayed.get(checkpoint_id)
@@ -394,6 +541,7 @@ def _validate_checkpoint_audit(
     status: str,
     updated_at: str | None,
     recorded_by: str | None,
+    expected_owner_role: str,
     require_actor_for_non_pending: bool,
     require_timestamp_for_non_pending: bool,
 ) -> tuple[bool, str | None, datetime | None]:
@@ -406,6 +554,12 @@ def _validate_checkpoint_audit(
             return False, "Non-pending checkpoint updates must include recorded_by for audit attribution.", parsed_timestamp
         if require_timestamp_for_non_pending and not updated_at:
             return False, "Non-pending checkpoint updates must include updated_at for audit ordering.", parsed_timestamp
+        if recorded_by and recorded_by != expected_owner_role:
+            return (
+                False,
+                f"Checkpoint actor role mismatch: expected {expected_owner_role}, received {recorded_by}.",
+                parsed_timestamp,
+            )
 
     return True, None, parsed_timestamp
 
@@ -1008,6 +1162,7 @@ def infer_governance_remediation_plans(
     *,
     policy: dict[str, Any] | None = None,
     checkpoint_statuses: dict[str, Any] | None = None,
+    signature_policy: dict[str, Any] | None = None,
 ) -> list[GovernanceRemediationPlan]:
     remediation_policy = (policy or {}).get("remediation", {})
     severity_actions = remediation_policy.get("severity_actions", {})
@@ -1025,7 +1180,7 @@ def infer_governance_remediation_plans(
     require_actor_for_non_pending = bool(audit_requirements.get("require_actor_for_non_pending", True))
     require_timestamp_for_non_pending = bool(audit_requirements.get("require_timestamp_for_non_pending", True))
     enforce_dependency_timestamp_order = bool(audit_requirements.get("enforce_dependency_timestamp_order", True))
-    checkpoint_replay = replay_checkpoint_state(checkpoint_statuses)
+    checkpoint_replay = replay_checkpoint_state(checkpoint_statuses, signature_policy=signature_policy)
     normalized_statuses = checkpoint_replay.checkpoints
 
     cluster_entries: dict[str, list[GovernanceQueueEntry]] = {}
@@ -1184,6 +1339,7 @@ def infer_governance_remediation_plans(
                 status=status,
                 updated_at=updated_at,
                 recorded_by=recorded_by,
+                expected_owner_role=str(raw_checkpoint["owner_role"]),
                 require_actor_for_non_pending=require_actor_for_non_pending,
                 require_timestamp_for_non_pending=require_timestamp_for_non_pending,
             )

--- a/tests/test_assurancectl.py
+++ b/tests/test_assurancectl.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import subprocess
 import sys
@@ -24,6 +26,68 @@ class AssuranceCtlTests(unittest.TestCase):
             check=False,
         )
 
+    def load_checkpoint_signer_policy(self) -> dict[str, object]:
+        return json.loads(
+            (PROJECT_ROOT / "config" / "governance" / "checkpoint-signers.json").read_text(encoding="utf-8")
+        )
+
+    def build_signed_event(
+        self,
+        *,
+        checkpoint_id: str,
+        previous_status: str,
+        new_status: str,
+        updated_at: str,
+        recorded_by: str,
+        rationale: str,
+        signature_id: str,
+        signer_id: str | None = None,
+    ) -> dict[str, object]:
+        signer_policy = self.load_checkpoint_signer_policy()
+        signers = signer_policy["signers"]
+        if signer_id is None:
+            signer_entry = next(entry for entry in signers if recorded_by in entry["roles"])
+        else:
+            signer_entry = next(entry for entry in signers if entry["signer_id"] == signer_id)
+        signature_meta = {
+            "format": signer_policy["signature_format"],
+            "signer_id": signer_entry["signer_id"],
+            "key_id": signer_entry["key_id"],
+            "signature_id": signature_id,
+            "signed_at": "2026-04-16T10:00:00Z",
+            "expires_at": "2026-04-17T10:00:00Z",
+        }
+        message = json.dumps(
+            {
+                "checkpoint_id": checkpoint_id,
+                "previous_status": previous_status,
+                "new_status": new_status,
+                "updated_at": updated_at,
+                "recorded_by": recorded_by,
+                "rationale": rationale,
+                "signature": signature_meta,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        signature_value = hmac.new(
+            str(signer_entry["shared_secret"]).encode("utf-8"),
+            message.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return {
+            "checkpoint_id": checkpoint_id,
+            "previous_status": previous_status,
+            "new_status": new_status,
+            "updated_at": updated_at,
+            "recorded_by": recorded_by,
+            "rationale": rationale,
+            "signature": {
+                **signature_meta,
+                "value": signature_value,
+            },
+        }
+
     def build_treasury_event_log(self, checkpoints: list[dict[str, object]]) -> dict[str, object]:
         event_payload: dict[str, object] = {"version": "checkpoint-event-log-test", "events": []}
         events = event_payload["events"]
@@ -36,35 +100,38 @@ class AssuranceCtlTests(unittest.TestCase):
             if phase in {"immediate_action", "approval_guardrail"}:
                 completed_counter += 1
                 events.append(
-                    {
-                        "checkpoint_id": checkpoint_id,
-                        "previous_status": "pending",
-                        "new_status": "in_progress",
-                        "updated_at": f"2026-04-16T11:{completed_counter:02d}:00Z",
-                        "recorded_by": owner_role,
-                        "rationale": f"Started {checkpoint_id}.",
-                    }
+                    self.build_signed_event(
+                        checkpoint_id=checkpoint_id,
+                        previous_status="pending",
+                        new_status="in_progress",
+                        updated_at=f"2026-04-16T11:{completed_counter:02d}:00Z",
+                        recorded_by=owner_role,
+                        rationale=f"Started {checkpoint_id}.",
+                        signature_id=f"{checkpoint_id}-start",
+                    )
                 )
                 events.append(
-                    {
-                        "checkpoint_id": checkpoint_id,
-                        "previous_status": "in_progress",
-                        "new_status": "completed",
-                        "updated_at": f"2026-04-16T12:{completed_counter:02d}:00Z",
-                        "recorded_by": owner_role,
-                        "rationale": f"Completed {checkpoint_id}.",
-                    }
+                    self.build_signed_event(
+                        checkpoint_id=checkpoint_id,
+                        previous_status="in_progress",
+                        new_status="completed",
+                        updated_at=f"2026-04-16T12:{completed_counter:02d}:00Z",
+                        recorded_by=owner_role,
+                        rationale=f"Completed {checkpoint_id}.",
+                        signature_id=f"{checkpoint_id}-complete",
+                    )
                 )
             elif phase == "monitoring" and checkpoint_id.endswith("-1"):
                 events.append(
-                    {
-                        "checkpoint_id": checkpoint_id,
-                        "previous_status": "pending",
-                        "new_status": "in_progress",
-                        "updated_at": "2026-04-16T13:00:00Z",
-                        "recorded_by": owner_role,
-                        "rationale": f"Started monitoring for {checkpoint_id}.",
-                    }
+                    self.build_signed_event(
+                        checkpoint_id=checkpoint_id,
+                        previous_status="pending",
+                        new_status="in_progress",
+                        updated_at="2026-04-16T13:00:00Z",
+                        recorded_by=owner_role,
+                        rationale=f"Started monitoring for {checkpoint_id}.",
+                        signature_id=f"{checkpoint_id}-monitoring",
+                    )
                 )
         return event_payload
 
@@ -100,8 +167,10 @@ class AssuranceCtlTests(unittest.TestCase):
                 ("config/network-topology.json", "config/network-topology.json"),
                 ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
                 ("config/policy/release-guards.json", "config/policy/release-guards.json"),
+                ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
             ):
                 target_path = root / target
+                target_path.parent.mkdir(parents=True, exist_ok=True)
                 target_path.write_text((PROJECT_ROOT / source).read_text(encoding="utf-8"), encoding="utf-8")
 
             env = {"PYTHONPATH": PYTHONPATH}
@@ -433,22 +502,24 @@ class AssuranceCtlTests(unittest.TestCase):
         duplicate_payload = {
             "version": "checkpoint-event-log-duplicate-test",
             "events": [
-                {
-                    "checkpoint_id": "treasury-grant-0ai-core-immediate_action-1",
-                    "previous_status": "pending",
-                    "new_status": "in_progress",
-                    "updated_at": "2026-04-16T11:01:00Z",
-                    "recorded_by": "treasury-program-manager",
-                    "rationale": "Started milestone release planning.",
-                },
-                {
-                    "checkpoint_id": "treasury-grant-0ai-core-immediate_action-1",
-                    "previous_status": "pending",
-                    "new_status": "in_progress",
-                    "updated_at": "2026-04-16T11:02:00Z",
-                    "recorded_by": "treasury-program-manager",
-                    "rationale": "Duplicate write should be rejected.",
-                },
+                self.build_signed_event(
+                    checkpoint_id="treasury-grant-0ai-core-immediate_action-1",
+                    previous_status="pending",
+                    new_status="in_progress",
+                    updated_at="2026-04-16T11:01:00Z",
+                    recorded_by="treasury-program-manager",
+                    rationale="Started milestone release planning.",
+                    signature_id="duplicate-1",
+                ),
+                self.build_signed_event(
+                    checkpoint_id="treasury-grant-0ai-core-immediate_action-1",
+                    previous_status="pending",
+                    new_status="in_progress",
+                    updated_at="2026-04-16T11:02:00Z",
+                    recorded_by="treasury-program-manager",
+                    rationale="Duplicate write should be rejected.",
+                    signature_id="duplicate-2",
+                ),
             ],
         }
 
@@ -468,14 +539,15 @@ class AssuranceCtlTests(unittest.TestCase):
         invalid_transition_payload = {
             "version": "checkpoint-event-log-illegal-transition-test",
             "events": [
-                {
-                    "checkpoint_id": "treasury-grant-0ai-core-immediate_action-1",
-                    "previous_status": "pending",
-                    "new_status": "completed",
-                    "updated_at": "2026-04-16T11:01:00Z",
-                    "recorded_by": "treasury-program-manager",
-                    "rationale": "Skipping in-progress should be rejected.",
-                }
+                self.build_signed_event(
+                    checkpoint_id="treasury-grant-0ai-core-immediate_action-1",
+                    previous_status="pending",
+                    new_status="completed",
+                    updated_at="2026-04-16T11:01:00Z",
+                    recorded_by="treasury-program-manager",
+                    rationale="Skipping in-progress should be rejected.",
+                    signature_id="illegal-transition-1",
+                )
             ],
         }
 
@@ -489,6 +561,139 @@ class AssuranceCtlTests(unittest.TestCase):
         self.assertEqual(payload["source_kind"], "event_log")
         self.assertEqual(payload["invalid_event_count"], 1)
         self.assertIn("illegal lifecycle transition pending -> completed", payload["event_alerts"][0])
+
+    def test_governance_replay_rejects_invalid_signature(self) -> None:
+        signed_event = self.build_signed_event(
+            checkpoint_id="treasury-grant-0ai-core-immediate_action-1",
+            previous_status="pending",
+            new_status="in_progress",
+            updated_at="2026-04-16T11:01:00Z",
+            recorded_by="treasury-program-manager",
+            rationale="Started milestone release planning.",
+            signature_id="invalid-signature-1",
+        )
+        signature = signed_event["signature"]
+        assert isinstance(signature, dict)
+        signature["value"] = "0" * 64
+        invalid_signature_payload = {
+            "version": "checkpoint-event-log-invalid-signature-test",
+            "events": [signed_event],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events-invalid-signature.json"
+            event_path.write_text(json.dumps(invalid_signature_payload), encoding="utf-8")
+            result = self.run_cli("governance-replay", "--status", str(event_path), "--json")
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["source_kind"], "event_log")
+        self.assertEqual(payload["invalid_event_count"], 1)
+        self.assertIn("invalid signature", payload["event_alerts"][0])
+
+    def test_governance_replay_rejects_wrong_role_signer(self) -> None:
+        wrong_role_payload = {
+            "version": "checkpoint-event-log-wrong-role-test",
+            "events": [
+                self.build_signed_event(
+                    checkpoint_id="treasury-grant-0ai-core-immediate_action-1",
+                    previous_status="pending",
+                    new_status="in_progress",
+                    updated_at="2026-04-16T11:01:00Z",
+                    recorded_by="treasury-program-manager",
+                    rationale="Started milestone release planning.",
+                    signature_id="wrong-role-1",
+                    signer_id="treasury-review-chair-bot",
+                )
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events-wrong-role.json"
+            event_path.write_text(json.dumps(wrong_role_payload), encoding="utf-8")
+            result = self.run_cli("governance-replay", "--status", str(event_path), "--json")
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["source_kind"], "event_log")
+        self.assertEqual(payload["invalid_event_count"], 1)
+        self.assertIn("is not authorized for role treasury-program-manager", payload["event_alerts"][0])
+
+    def test_governance_replay_rejects_signature_replay_attempt(self) -> None:
+        replayed_signature_payload = {
+            "version": "checkpoint-event-log-replay-test",
+            "events": [
+                self.build_signed_event(
+                    checkpoint_id="treasury-grant-0ai-core-immediate_action-1",
+                    previous_status="pending",
+                    new_status="in_progress",
+                    updated_at="2026-04-16T11:01:00Z",
+                    recorded_by="treasury-program-manager",
+                    rationale="Started milestone release planning.",
+                    signature_id="replay-attempt-1",
+                ),
+                self.build_signed_event(
+                    checkpoint_id="treasury-grant-0ai-core-immediate_action-1",
+                    previous_status="in_progress",
+                    new_status="completed",
+                    updated_at="2026-04-16T12:01:00Z",
+                    recorded_by="treasury-program-manager",
+                    rationale="Milestone release plan approved.",
+                    signature_id="replay-attempt-1",
+                ),
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events-replay-attempt.json"
+            event_path.write_text(json.dumps(replayed_signature_payload), encoding="utf-8")
+            result = self.run_cli("governance-replay", "--status", str(event_path), "--json")
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["source_kind"], "event_log")
+        self.assertEqual(payload["invalid_event_count"], 1)
+        self.assertIn("replay attempt detected", payload["event_alerts"][0])
+
+    def test_governance_remediation_rejects_checkpoint_owner_role_mismatch(self) -> None:
+        wrong_owner_payload = {
+            "version": "checkpoint-event-log-owner-mismatch-test",
+            "events": [
+                self.build_signed_event(
+                    checkpoint_id="treasury-grant-0ai-core-immediate_action-1",
+                    previous_status="pending",
+                    new_status="in_progress",
+                    updated_at="2026-04-16T11:01:00Z",
+                    recorded_by="treasury-review-chair",
+                    rationale="Wrong phase owner should be rejected during remediation.",
+                    signature_id="owner-mismatch-1",
+                    signer_id="treasury-review-chair-bot",
+                )
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events-owner-mismatch.json"
+            event_path.write_text(json.dumps(wrong_owner_payload), encoding="utf-8")
+            result = self.run_cli(
+                "governance-remediation",
+                "--registry",
+                "examples/proposals/registry.json",
+                "--history",
+                "examples/proposals/history.json",
+                "--status",
+                str(event_path),
+                "--json",
+            )
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        treasury_plan = next(item for item in payload if item["trend_cluster"] == "treasury_grant:0ai-core")
+        self.assertEqual(treasury_plan["current_release_readiness"], "invalid")
+        self.assertGreater(treasury_plan["invalid_audit_count"], 0)
+        self.assertTrue(
+            any("Checkpoint actor role mismatch" in alert for alert in treasury_plan["audit_alerts"])
+        )
 
     def test_governance_replay_rejects_invalid_event_log_schema(self) -> None:
         invalid_schema_payload = {


### PR DESCRIPTION
## Summary
- add machine-readable checkpoint signer policy and validate it during repo config checks
- require signed event log updates with signer, role, expiry, and replay protection
- cover valid signatures, invalid signatures, wrong-role signers, owner-role mismatch, and signature replay attempts with tests

## Testing
- python -m py_compile src/assurancectl/config.py src/assurancectl/inference.py src/assurancectl/cli.py
- python -m unittest discover -s tests -v
- make validate
- make go-test
- make go-build
- PYTHONPATH=src python -m assurancectl.cli governance-replay --status examples/proposals/checkpoint-events.json --json

Closes #2