### PR TITLE
Build deterministic genesis assembly and validator collection workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test init-node clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -22,6 +22,9 @@ help:
 	@echo "  go-build         Build the 0aid binary"
 	@echo "  go-test          Run Go unit tests"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
+	@echo "  collect-validator Normalize a node bundle into a collected manifest"
+	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
+	@echo "  assemble-localnet Render a reproducible localnet bundle from collected manifests"
 	@echo "  clean            Remove generated localnet artifacts"
 	@echo ""
 
@@ -70,6 +73,20 @@ go-test:
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)
 	./0aid init-node --root . --id $(ID) --out ./build/nodes/$(ID)
+
+collect-validator:
+	@test -n "$(BUNDLE)" || (echo "Usage: make collect-validator BUNDLE=build/nodes/val-1 OUT=build/collection/val-1.json" && exit 1)
+	@test -n "$(OUT)" || (echo "Usage: make collect-validator BUNDLE=build/nodes/val-1 OUT=build/collection/val-1.json" && exit 1)
+	./0aid collect-validator --bundle $(BUNDLE) --out $(OUT)
+
+assemble-genesis:
+	@test -n "$(COLLECTION)" || (echo "Usage: make assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json" && exit 1)
+	./0aid assemble-genesis --root . --collection $(COLLECTION) $(if $(OUT),--out $(OUT),)
+
+assemble-localnet:
+	@test -n "$(COLLECTION)" || (echo "Usage: make assemble-localnet COLLECTION=build/collection OUT=build/assembled" && exit 1)
+	@test -n "$(OUT)" || (echo "Usage: make assemble-localnet COLLECTION=build/collection OUT=build/assembled" && exit 1)
+	./0aid assemble-localnet --root . --collection $(COLLECTION) --out $(OUT)
 
 clean:
 	rm -rf build/localnet .cache 0aid

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ make -C projects/0ai-assurance-network governance-drift PROPOSAL=examples/propos
 make -C projects/0ai-assurance-network go-build
 make -C projects/0ai-assurance-network go-test
 make -C projects/0ai-assurance-network init-node ID=val-3
+make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
+make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
+make -C projects/0ai-assurance-network assemble-localnet COLLECTION=build/collection OUT=build/assembled
 ```
 
 `validate` checks that the topology, genesis, and governance policy files are
@@ -168,12 +171,18 @@ currently supports:
 - `render-validator`
 - `render-identity`
 - `init-node`
+- `collect-validator`
+- `assemble-genesis`
+- `assemble-localnet`
 
 Bootstrap examples:
 
 ```bash
 ./0aid render-identity --root . --id val-3
 ./0aid init-node --root . --id val-3 --out ./build/nodes/validator-3
+./0aid collect-validator --bundle ./build/nodes/validator-3 --out ./build/collection/validator-3.json
+./0aid assemble-genesis --root . --collection ./build/collection --out ./build/assembled/genesis-plan.json
+./0aid assemble-localnet --root . --collection ./build/collection --out ./build/assembled
 PYTHONPATH=src python -m assurancectl.cli governance-sim \
   --proposal examples/proposals/emergency-pause.json
 PYTHONPATH=src python -m assurancectl.cli governance-queue \
@@ -198,6 +207,12 @@ PYTHONPATH=src python -m assurancectl.cli governance-drift \
 The identity and node-init paths are explicitly development-only. They emit
 deterministic placeholder identity material so the local bootstrap flow can
 advance without pretending to solve production validator custody.
+
+The collection and assembly path is deterministic by design. Operators collect
+each validator bundle into a normalized manifest, merge the full set into a
+single genesis plan, and then render an assembled localnet bundle from that
+same collection. Assembly fails closed on duplicate validator IDs, partial
+collections, topology mismatches, and unexpected voting power.
 
 The governance inference path is explicitly advisory. It helps classify and
 score proposals, but it does not vote, sign, or bypass human review. The new

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -120,6 +120,78 @@ func run(args []string) error {
 			return err
 		}
 		return project.WriteNodeInitBundle(filepath.Clean(*out), nodeBundle)
+	case "collect-validator":
+		fs := flag.NewFlagSet("collect-validator", flag.ContinueOnError)
+		bundlePath := fs.String("bundle", "", "node bundle directory")
+		out := fs.String("out", "", "collected manifest output path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *bundlePath == "" {
+			return errors.New("collect-validator requires --bundle")
+		}
+		if *out == "" {
+			return errors.New("collect-validator requires --out")
+		}
+		manifest, err := project.CollectValidatorBundle(filepath.Clean(*bundlePath))
+		if err != nil {
+			return err
+		}
+		return project.WriteCollectedValidator(filepath.Clean(*out), manifest)
+	case "assemble-genesis":
+		fs := flag.NewFlagSet("assemble-genesis", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		collection := fs.String("collection", "", "directory containing collected validator manifests")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *collection == "" {
+			return errors.New("assemble-genesis requires --collection")
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		manifests, err := project.LoadCollectedValidators(filepath.Clean(*collection))
+		if err != nil {
+			return err
+		}
+		plan, err := project.AssembleGenesisPlan(bundle, manifests)
+		if err != nil {
+			return err
+		}
+		if *out == "" {
+			return printJSON(plan)
+		}
+		return project.WriteJSON(filepath.Clean(*out), plan)
+	case "assemble-localnet":
+		fs := flag.NewFlagSet("assemble-localnet", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		collection := fs.String("collection", "", "directory containing collected validator manifests")
+		out := fs.String("out", "", "output directory")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *collection == "" {
+			return errors.New("assemble-localnet requires --collection")
+		}
+		if *out == "" {
+			return errors.New("assemble-localnet requires --out")
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		manifests, err := project.LoadCollectedValidators(filepath.Clean(*collection))
+		if err != nil {
+			return err
+		}
+		localnetBundle, err := project.RenderCollectedLocalnetBundle(bundle, manifests)
+		if err != nil {
+			return err
+		}
+		return project.WriteCollectedLocalnetBundle(filepath.Clean(*out), localnetBundle)
 	default:
 		return usageError()
 	}
@@ -127,7 +199,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|show-plan|init-genesis|render-validator|render-identity|init-node> [flags]",
+		"usage: 0aid <version|module-map|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 

--- a/internal/project/assembly.go
+++ b/internal/project/assembly.go
@@ -1,0 +1,239 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+)
+
+type CollectedValidatorManifest struct {
+	Validator ValidatorPlanOutput `json:"validator"`
+	Identity  DevelopmentIdentity `json:"identity"`
+	Config    NodeConfigBundle    `json:"config"`
+}
+
+type GenesisAssemblyValidator struct {
+	ID              string `json:"id"`
+	Moniker         string `json:"moniker"`
+	Role            string `json:"role"`
+	VotingPower     int    `json:"voting_power"`
+	PeerID          string `json:"peer_id"`
+	ConsensusPubKey string `json:"consensus_public_key"`
+	OperatorAddress string `json:"operator_address"`
+	RewardAddress   string `json:"reward_address"`
+}
+
+type GenesisAssemblyPlan struct {
+	NetworkName           string                     `json:"network_name"`
+	ChainID               string                     `json:"chain_id"`
+	CollectedValidatorIDs []string                   `json:"collected_validator_ids"`
+	CollectedValidators   []GenesisAssemblyValidator `json:"validators"`
+	CollectedVotingPower  int                        `json:"collected_voting_power"`
+	CommitQuorumPower     int                        `json:"commit_quorum_power"`
+	Genesis               map[string]any             `json:"genesis"`
+}
+
+type CollectedLocalnetBundle struct {
+	Plan           GenesisAssemblyPlan `json:"plan"`
+	NetworkSummary map[string]any      `json:"network_summary"`
+	DockerCompose  string              `json:"docker_compose"`
+}
+
+func CollectValidatorBundle(bundlePath string) (CollectedValidatorManifest, error) {
+	var manifest CollectedValidatorManifest
+	if err := loadJSON(filepath.Join(bundlePath, "manifest.json"), &manifest); err != nil {
+		return CollectedValidatorManifest{}, err
+	}
+	return manifest, nil
+}
+
+func WriteCollectedValidator(path string, manifest CollectedValidatorManifest) error {
+	return WriteJSON(path, manifest)
+}
+
+func LoadCollectedValidators(collectionDir string) ([]CollectedValidatorManifest, error) {
+	entries, err := os.ReadDir(collectionDir)
+	if err != nil {
+		return nil, err
+	}
+
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		files = append(files, filepath.Join(collectionDir, entry.Name()))
+	}
+	sort.Strings(files)
+
+	manifests := make([]CollectedValidatorManifest, 0, len(files))
+	for _, file := range files {
+		var manifest CollectedValidatorManifest
+		if err := loadJSON(file, &manifest); err != nil {
+			return nil, err
+		}
+		manifests = append(manifests, manifest)
+	}
+	return manifests, nil
+}
+
+func AssembleGenesisPlan(bundle Bundle, manifests []CollectedValidatorManifest) (GenesisAssemblyPlan, error) {
+	if len(manifests) == 0 {
+		return GenesisAssemblyPlan{}, fmt.Errorf("no collected validator manifests were supplied")
+	}
+
+	topologyByID := make(map[string]ValidatorNode, len(bundle.Topology.Validators))
+	topologyIDs := make([]string, 0, len(bundle.Topology.Validators))
+	totalVotingPower := 0
+	for _, validator := range bundle.Topology.Validators {
+		topologyByID[validator.ID] = validator
+		topologyIDs = append(topologyIDs, validator.ID)
+		totalVotingPower += validator.VotingPower
+	}
+
+	seenIDs := make(map[string]struct{}, len(manifests))
+	collected := make([]GenesisAssemblyValidator, 0, len(manifests))
+	collectedIDs := make([]string, 0, len(manifests))
+	for _, manifest := range manifests {
+		validatorID := manifest.Identity.ValidatorID
+		if validatorID == "" {
+			validatorID = manifest.Validator.ID
+		}
+		if validatorID == "" {
+			return GenesisAssemblyPlan{}, fmt.Errorf("collected validator manifest is missing validator id")
+		}
+		if _, exists := seenIDs[validatorID]; exists {
+			return GenesisAssemblyPlan{}, fmt.Errorf("duplicate collected validator id: %s", validatorID)
+		}
+		seenIDs[validatorID] = struct{}{}
+
+		topologyValidator, exists := topologyByID[validatorID]
+		if !exists {
+			return GenesisAssemblyPlan{}, fmt.Errorf("collected validator %s does not exist in topology", validatorID)
+		}
+
+		expectedPlan, err := ValidatorPlan(bundle, validatorID)
+		if err != nil {
+			return GenesisAssemblyPlan{}, err
+		}
+		if !reflect.DeepEqual(expectedPlan, manifest.Validator) {
+			return GenesisAssemblyPlan{}, fmt.Errorf("collected validator plan mismatch for %s", validatorID)
+		}
+		if manifest.Identity.ChainID != bundle.Topology.ChainID {
+			return GenesisAssemblyPlan{}, fmt.Errorf(
+				"collected validator %s has chain id %s but topology expects %s",
+				validatorID,
+				manifest.Identity.ChainID,
+				bundle.Topology.ChainID,
+			)
+		}
+		if manifest.Identity.Moniker != topologyValidator.Moniker {
+			return GenesisAssemblyPlan{}, fmt.Errorf(
+				"collected validator %s has moniker %s but topology expects %s",
+				validatorID,
+				manifest.Identity.Moniker,
+				topologyValidator.Moniker,
+			)
+		}
+		if manifest.Identity.Mode != "development_only" {
+			return GenesisAssemblyPlan{}, fmt.Errorf(
+				"collected validator %s identity mode must be development_only",
+				validatorID,
+			)
+		}
+
+		collectedIDs = append(collectedIDs, validatorID)
+		collected = append(collected, GenesisAssemblyValidator{
+			ID:              validatorID,
+			Moniker:         topologyValidator.Moniker,
+			Role:            topologyValidator.Role,
+			VotingPower:     topologyValidator.VotingPower,
+			PeerID:          manifest.Identity.PeerID,
+			ConsensusPubKey: manifest.Identity.ConsensusPublicKey,
+			OperatorAddress: manifest.Identity.OperatorAddress,
+			RewardAddress:   manifest.Identity.RewardAddress,
+		})
+	}
+
+	sort.Strings(topologyIDs)
+	sort.Strings(collectedIDs)
+	if len(collectedIDs) != len(topologyIDs) {
+		return GenesisAssemblyPlan{}, fmt.Errorf(
+			"collected validator set is incomplete: expected %d validators, received %d",
+			len(topologyIDs),
+			len(collectedIDs),
+		)
+	}
+	for index := range topologyIDs {
+		if topologyIDs[index] != collectedIDs[index] {
+			return GenesisAssemblyPlan{}, fmt.Errorf(
+				"collected validator set does not match topology: expected %v, received %v",
+				topologyIDs,
+				collectedIDs,
+			)
+		}
+	}
+
+	sort.Slice(collected, func(i, j int) bool {
+		return collected[i].ID < collected[j].ID
+	})
+
+	collectedVotingPower := 0
+	for _, validator := range collected {
+		collectedVotingPower += validator.VotingPower
+	}
+	if collectedVotingPower != totalVotingPower {
+		return GenesisAssemblyPlan{}, fmt.Errorf(
+			"collected voting power %d does not match topology voting power %d",
+			collectedVotingPower,
+			totalVotingPower,
+		)
+	}
+
+	genesis := RenderedGenesis(bundle)
+	genesis["validators"] = collected
+
+	return GenesisAssemblyPlan{
+		NetworkName:           bundle.Topology.NetworkName,
+		ChainID:               bundle.Topology.ChainID,
+		CollectedValidatorIDs: collectedIDs,
+		CollectedValidators:   collected,
+		CollectedVotingPower:  collectedVotingPower,
+		CommitQuorumPower:     ((collectedVotingPower * 2) / 3) + 1,
+		Genesis:               genesis,
+	}, nil
+}
+
+func WriteCollectedLocalnetBundle(path string, bundle CollectedLocalnetBundle) error {
+	root := filepath.Clean(path)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return err
+	}
+	if err := WriteJSON(filepath.Join(root, "genesis.assembled.json"), bundle.Plan.Genesis); err != nil {
+		return err
+	}
+	if err := WriteJSON(filepath.Join(root, "network-summary.assembled.json"), bundle.NetworkSummary); err != nil {
+		return err
+	}
+	if err := WriteJSON(filepath.Join(root, "validator-collection.json"), bundle.Plan.CollectedValidators); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(root, "docker-compose.assembled.yml"), []byte(bundle.DockerCompose), 0o644)
+}
+
+func RenderCollectedLocalnetBundle(bundle Bundle, manifests []CollectedValidatorManifest) (CollectedLocalnetBundle, error) {
+	plan, err := AssembleGenesisPlan(bundle, manifests)
+	if err != nil {
+		return CollectedLocalnetBundle{}, err
+	}
+	return CollectedLocalnetBundle{
+		Plan:           plan,
+		NetworkSummary: NetworkSummary(bundle),
+		DockerCompose:  DockerCompose(bundle),
+	}, nil
+}

--- a/internal/project/assembly_test.go
+++ b/internal/project/assembly_test.go
@@ -1,0 +1,152 @@
+package project
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAssembleGenesisPlanDeterministic(t *testing.T) {
+	bundle, err := LoadBundle(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+
+	tempDir := t.TempDir()
+	collectionDir := filepath.Join(tempDir, "collection")
+
+	for index := len(bundle.Topology.Validators) - 1; index >= 0; index-- {
+		validator := bundle.Topology.Validators[index]
+		nodeBundle, err := NodeInitPlan(bundle, validator.ID)
+		if err != nil {
+			t.Fatalf("node init plan for %s: %v", validator.ID, err)
+		}
+		nodeDir := filepath.Join(tempDir, "nodes", validator.ID)
+		if err := WriteNodeInitBundle(nodeDir, nodeBundle); err != nil {
+			t.Fatalf("write node bundle for %s: %v", validator.ID, err)
+		}
+
+		collected, err := CollectValidatorBundle(nodeDir)
+		if err != nil {
+			t.Fatalf("collect node bundle for %s: %v", validator.ID, err)
+		}
+		outPath := filepath.Join(collectionDir, "manifest-"+validator.Moniker+".json")
+		if err := WriteCollectedValidator(outPath, collected); err != nil {
+			t.Fatalf("write collected manifest for %s: %v", validator.ID, err)
+		}
+	}
+
+	manifests1, err := LoadCollectedValidators(collectionDir)
+	if err != nil {
+		t.Fatalf("load collected validators (pass 1): %v", err)
+	}
+	plan1, err := AssembleGenesisPlan(bundle, manifests1)
+	if err != nil {
+		t.Fatalf("assemble genesis plan (pass 1): %v", err)
+	}
+
+	manifests2, err := LoadCollectedValidators(collectionDir)
+	if err != nil {
+		t.Fatalf("load collected validators (pass 2): %v", err)
+	}
+	plan2, err := AssembleGenesisPlan(bundle, manifests2)
+	if err != nil {
+		t.Fatalf("assemble genesis plan (pass 2): %v", err)
+	}
+
+	if !reflect.DeepEqual(plan1, plan2) {
+		t.Fatalf("expected deterministic assembly plan output")
+	}
+	if len(plan1.CollectedValidators) != len(bundle.Topology.Validators) {
+		t.Fatalf("expected %d validators, received %d", len(bundle.Topology.Validators), len(plan1.CollectedValidators))
+	}
+	if plan1.CommitQuorumPower != 67 {
+		t.Fatalf("expected commit quorum power 67, received %d", plan1.CommitQuorumPower)
+	}
+
+	localnetBundle, err := RenderCollectedLocalnetBundle(bundle, manifests1)
+	if err != nil {
+		t.Fatalf("render collected localnet bundle: %v", err)
+	}
+	outDir := filepath.Join(tempDir, "assembled")
+	if err := WriteCollectedLocalnetBundle(outDir, localnetBundle); err != nil {
+		t.Fatalf("write collected localnet bundle: %v", err)
+	}
+}
+
+func TestAssembleGenesisPlanRejectsDuplicateValidatorIDs(t *testing.T) {
+	bundle, err := LoadBundle(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+
+	nodeBundle, err := NodeInitPlan(bundle, bundle.Topology.Validators[0].ID)
+	if err != nil {
+		t.Fatalf("node init plan: %v", err)
+	}
+	duplicate := CollectedValidatorManifest{
+		Validator: nodeBundle.Validator,
+		Identity:  nodeBundle.Identity,
+		Config:    nodeBundle.Config,
+	}
+
+	_, err = AssembleGenesisPlan(bundle, []CollectedValidatorManifest{duplicate, duplicate})
+	if err == nil {
+		t.Fatal("expected duplicate validator id error")
+	}
+	if !strings.Contains(err.Error(), "duplicate collected validator id") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAssembleGenesisPlanRejectsTopologyMismatch(t *testing.T) {
+	bundle, err := LoadBundle(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+
+	nodeBundle, err := NodeInitPlan(bundle, bundle.Topology.Validators[0].ID)
+	if err != nil {
+		t.Fatalf("node init plan: %v", err)
+	}
+	mismatch := CollectedValidatorManifest{
+		Validator: nodeBundle.Validator,
+		Identity:  nodeBundle.Identity,
+		Config:    nodeBundle.Config,
+	}
+	mismatch.Validator.Moniker = "mismatched-moniker"
+
+	_, err = AssembleGenesisPlan(bundle, []CollectedValidatorManifest{mismatch})
+	if err == nil {
+		t.Fatal("expected topology mismatch error")
+	}
+	if !strings.Contains(err.Error(), "collected validator plan mismatch") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAssembleGenesisPlanRejectsIncompleteValidatorSet(t *testing.T) {
+	bundle, err := LoadBundle(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("load bundle: %v", err)
+	}
+
+	nodeBundle, err := NodeInitPlan(bundle, bundle.Topology.Validators[0].ID)
+	if err != nil {
+		t.Fatalf("node init plan: %v", err)
+	}
+	partial := CollectedValidatorManifest{
+		Validator: nodeBundle.Validator,
+		Identity:  nodeBundle.Identity,
+		Config:    nodeBundle.Config,
+	}
+
+	_, err = AssembleGenesisPlan(bundle, []CollectedValidatorManifest{partial})
+	if err == nil {
+		t.Fatal("expected incomplete validator set error")
+	}
+	if !strings.Contains(err.Error(), "collected validator set is incomplete") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/project/render.go
+++ b/internal/project/render.go
@@ -65,6 +65,22 @@ func NetworkPlan(bundle Bundle) Plan {
 	}
 }
 
+func NetworkSummary(bundle Bundle) map[string]any {
+	return map[string]any{
+		"network_name":    bundle.Topology.NetworkName,
+		"chain_id":        bundle.Topology.ChainID,
+		"mode":            bundle.Topology.Mode,
+		"validator_count": len(bundle.Topology.Validators),
+		"seed_count":      len(bundle.Topology.SeedNodes),
+		"validators":      validatorNames(bundle.Topology.Validators),
+		"seed_nodes":      seedNames(bundle.Topology.SeedNodes),
+		"governance": map[string]any{
+			"houses":                                 bundle.Topology.Governance.Houses,
+			"critical_actions_require_dual_approval": bundle.Topology.Governance.CriticalActionsRequireDual,
+		},
+	}
+}
+
 func RenderedGenesis(bundle Bundle) map[string]any {
 	rendered := map[string]any{
 		"chain_id":    bundle.Genesis.ChainID,
@@ -75,23 +91,23 @@ func RenderedGenesis(bundle Bundle) map[string]any {
 			"reputation": bundle.Genesis.Denoms.Reputation,
 		},
 		"staking": map[string]any{
-			"minimum_self_bond":     bundle.Genesis.Staking.MinimumSelfBond,
+			"minimum_self_bond":      bundle.Genesis.Staking.MinimumSelfBond,
 			"unbonding_time_seconds": bundle.Genesis.Staking.UnbondingTimeSec,
-			"max_validators":        bundle.Genesis.Staking.MaxValidators,
+			"max_validators":         bundle.Genesis.Staking.MaxValidators,
 		},
 		"governance": map[string]any{
-			"proposal_bond":                  bundle.Genesis.Governance.ProposalBond,
-			"standard_voting_period_seconds": bundle.Genesis.Governance.StandardVotingPeriodSec,
-			"high_impact_timelock_seconds":   bundle.Genesis.Governance.HighImpactTimelockSec,
+			"proposal_bond":                    bundle.Genesis.Governance.ProposalBond,
+			"standard_voting_period_seconds":   bundle.Genesis.Governance.StandardVotingPeriodSec,
+			"high_impact_timelock_seconds":     bundle.Genesis.Governance.HighImpactTimelockSec,
 			"safety_critical_timelock_seconds": bundle.Genesis.Governance.SafetyCriticalSec,
-			"dual_house_enabled":             bundle.Genesis.Governance.DualHouseEnabled,
+			"dual_house_enabled":               bundle.Genesis.Governance.DualHouseEnabled,
 		},
 		"attestation": map[string]any{
-			"minimum_auditor_bond": bundle.Genesis.Attest.MinimumAuditorBond,
+			"minimum_auditor_bond":  bundle.Genesis.Attest.MinimumAuditorBond,
 			"appeal_window_seconds": bundle.Genesis.Attest.AppealWindowSec,
 		},
 		"incident": map[string]any{
-			"postmortem_deadline_seconds": bundle.Genesis.Incident.PostmortemDeadlineSec,
+			"postmortem_deadline_seconds":  bundle.Genesis.Incident.PostmortemDeadlineSec,
 			"public_reason_codes_required": bundle.Genesis.Incident.PublicReasonCodes,
 		},
 		"treasury": map[string]any{


### PR DESCRIPTION
## Summary
- add validator bundle collection and deterministic genesis/localnet assembly commands to the 0aid CLI
- validate duplicate ids, incomplete collections, topology mismatches, and voting-power consistency during assembly
- document and expose the collection workflow through the standalone repo Makefile and README

Closes #3.

## Verification
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go test ./...
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go build ./cmd/0aid
- python -m unittest discover -s tests -v
- make validate
- end-to-end run: init-node -> collect-validator -> assemble-genesis -> assemble-localnet across all 7 validators