### PR TITLE
Expose governance inference outputs as versioned artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ owner roles, completion criteria, dependency ordering between phases, and
 status-aware rollups for current execution readiness. That keeps the governance
 path operationally useful once the engine detects an unstable cluster.
 
+Each governance command also supports `--artifact-out <path>` so external
+automation can consume a stable, versioned orchestration artifact without
+scraping CLI text. The artifact contract is documented in
+[docs/orchestration-artifacts.md](docs/orchestration-artifacts.md).
+
 `governance-replay` reconstructs deterministic current checkpoint state from an
 append-only event log or a derived snapshot. Event logs are stricter than
 snapshots: each event must include `checkpoint_id`, `previous_status`,
@@ -197,6 +202,10 @@ PYTHONPATH=src python -m assurancectl.cli governance-remediation \
   --registry examples/proposals/registry.json \
   --history examples/proposals/history.json \
   --status examples/proposals/checkpoint-status.json
+PYTHONPATH=src python -m assurancectl.cli governance-remediation \
+  --registry examples/proposals/registry.json \
+  --history examples/proposals/history.json \
+  --artifact-out build/artifacts/governance-remediation.json
 PYTHONPATH=src python -m assurancectl.cli governance-replay \
   --status examples/proposals/checkpoint-events.json
 PYTHONPATH=src python -m assurancectl.cli governance-drift \

--- a/docs/governance-inference.md
+++ b/docs/governance-inference.md
@@ -53,6 +53,11 @@ make governance-remediation REGISTRY=examples/proposals/registry.json HISTORY=ex
 make governance-drift PROPOSAL=examples/proposals/emergency-pause.json HISTORY=examples/proposals/history.json
 ```
 
+Every governance command also supports `--artifact-out <path>` so external
+automation can consume a versioned orchestration artifact without scraping CLI
+text. The shared artifact envelope and compatibility rules are documented in
+[orchestration-artifacts.md](orchestration-artifacts.md).
+
 ## Output
 
 The report includes:

--- a/docs/orchestration-artifacts.md
+++ b/docs/orchestration-artifacts.md
@@ -1,0 +1,68 @@
+# Governance Orchestration Artifacts
+
+`assurancectl` governance commands can emit a versioned artifact file for
+external automation:
+
+- `governance-sim`
+- `governance-queue`
+- `governance-trends`
+- `governance-remediation`
+- `governance-replay`
+- `governance-drift`
+
+Use `--artifact-out <path>` alongside the normal command arguments.
+
+Example:
+
+```bash
+PYTHONPATH=src python -m assurancectl.cli governance-remediation \
+  --registry examples/proposals/registry.json \
+  --history examples/proposals/history.json \
+  --artifact-out build/artifacts/governance-remediation.json
+```
+
+## Schema Contract
+
+Every artifact file uses the same top-level envelope:
+
+```json
+{
+  "schema": "0ai.assurance.governance.artifact",
+  "schema_version": "1.0.0",
+  "compatibility": {
+    "breaking_change": "increment major",
+    "additive_change": "increment minor",
+    "clarification_change": "increment patch"
+  },
+  "artifact_type": "governance_remediation",
+  "command": "governance-remediation",
+  "sources": {
+    "registry": "examples/proposals/registry.json",
+    "history": "examples/proposals/history.json"
+  },
+  "payload": []
+}
+```
+
+## Compatibility Rules
+
+- Major version changes are required for breaking schema changes.
+- Minor version changes are required for additive fields or new artifact types.
+- Patch version changes are limited to non-structural clarifications.
+
+External automation should treat `schema` + `schema_version` as the contract
+key. Consumers that only support `1.x` should reject artifacts with a different
+major version.
+
+## Operator Behavior
+
+- Human-readable CLI output remains the default.
+- `--json` still prints the direct payload to stdout.
+- `--artifact-out` writes the versioned artifact envelope to disk without
+  changing the stdout format.
+
+## Consumer Example
+
+See [examples/orchestrators/consume_governance_artifact.py](../examples/orchestrators/consume_governance_artifact.py)
+for a small consumer that validates the schema version and extracts
+remediation-blocking clusters.

--- a/examples/orchestrators/consume_governance_artifact.py
+++ b/examples/orchestrators/consume_governance_artifact.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+SUPPORTED_SCHEMA = "0ai.assurance.governance.artifact"
+SUPPORTED_MAJOR = "1"
+
+
+def main(path: str) -> int:
+    artifact = json.loads(Path(path).read_text(encoding="utf-8"))
+    if artifact.get("schema") != SUPPORTED_SCHEMA:
+        print("unsupported schema", file=sys.stderr)
+        return 1
+
+    version = str(artifact.get("schema_version", "0.0.0"))
+    if version.split(".", 1)[0] != SUPPORTED_MAJOR:
+        print(f"unsupported major version: {version}", file=sys.stderr)
+        return 1
+
+    if artifact.get("artifact_type") != "governance_remediation":
+        print("artifact is not a governance remediation payload", file=sys.stderr)
+        return 1
+
+    blocking_clusters = [
+        plan["trend_cluster"]
+        for plan in artifact.get("payload", [])
+        if plan.get("current_release_readiness") not in {"monitoring", "complete"}
+    ]
+    print(json.dumps({"blocking_clusters": blocking_clusters}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1]))

--- a/src/assurancectl/artifacts.py
+++ b/src/assurancectl/artifacts.py
@@ -1,0 +1,41 @@
+"""Versioned governance artifact helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+GOVERNANCE_ARTIFACT_SCHEMA = "0ai.assurance.governance.artifact"
+GOVERNANCE_ARTIFACT_SCHEMA_VERSION = "1.0.0"
+GOVERNANCE_ARTIFACT_COMPATIBILITY = {
+    "breaking_change": "increment major",
+    "additive_change": "increment minor",
+    "clarification_change": "increment patch",
+}
+
+
+def governance_artifact(
+    *,
+    artifact_type: str,
+    command: str,
+    payload: Any,
+    sources: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema": GOVERNANCE_ARTIFACT_SCHEMA,
+        "schema_version": GOVERNANCE_ARTIFACT_SCHEMA_VERSION,
+        "compatibility": GOVERNANCE_ARTIFACT_COMPATIBILITY,
+        "artifact_type": artifact_type,
+        "command": command,
+        "sources": sources or {},
+        "payload": payload,
+    }
+
+
+def write_artifact(path: str | Path, artifact: dict[str, Any]) -> Path:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(artifact, indent=2) + "\n", encoding="utf-8")
+    return target

--- a/src/assurancectl/cli.py
+++ b/src/assurancectl/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import sys
 
+from .artifacts import governance_artifact, write_artifact
 from .config import ValidationError, load_config, validate_all
 from .inference import (
     infer_governance_drift,
@@ -21,6 +22,13 @@ from .inference import (
     load_registry,
     replay_checkpoint_state,
 )
+
+
+def _add_artifact_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--artifact-out",
+        help="write a versioned machine-readable artifact to this file path",
+    )
 from .readiness import build_readiness_report
 from .render import write_localnet_artifacts
 
@@ -40,16 +48,19 @@ def _parser() -> argparse.ArgumentParser:
     governance.add_argument("--proposal", required=True, help="proposal JSON file path")
     governance.add_argument("--history", help="governance history JSON file path")
     governance.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    _add_artifact_argument(governance)
 
     queue = subparsers.add_parser("governance-queue", help="score a registry of proposals")
     queue.add_argument("--registry", required=True, help="proposal registry JSON file path")
     queue.add_argument("--history", help="governance history JSON file path")
     queue.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    _add_artifact_argument(queue)
 
     trends = subparsers.add_parser("governance-trends", help="cluster governance trends across the queue")
     trends.add_argument("--registry", required=True, help="proposal registry JSON file path")
     trends.add_argument("--history", required=True, help="governance history JSON file path")
     trends.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    _add_artifact_argument(trends)
 
     remediation = subparsers.add_parser(
         "governance-remediation",
@@ -59,6 +70,7 @@ def _parser() -> argparse.ArgumentParser:
     remediation.add_argument("--history", required=True, help="governance history JSON file path")
     remediation.add_argument("--status", help="checkpoint status JSON file path")
     remediation.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    _add_artifact_argument(remediation)
 
     replay = subparsers.add_parser(
         "governance-replay",
@@ -66,11 +78,13 @@ def _parser() -> argparse.ArgumentParser:
     )
     replay.add_argument("--status", required=True, help="checkpoint state or event log JSON file path")
     replay.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    _add_artifact_argument(replay)
 
     drift = subparsers.add_parser("governance-drift", help="compare a proposal against governance history")
     drift.add_argument("--proposal", required=True, help="proposal JSON file path")
     drift.add_argument("--history", required=True, help="governance history JSON file path")
     drift.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    _add_artifact_argument(drift)
     return parser
 
 
@@ -143,6 +157,143 @@ def _governance_drift_payload(report) -> dict[str, object]:
     }
 
 
+def _governance_queue_payload(entries) -> list[dict[str, object]]:
+    return [
+        {
+            "path": entry.path,
+            "status": entry.status,
+            "priority": entry.priority,
+            "owner": entry.owner,
+            "proposal_kind": entry.proposal_kind,
+            "submitted_at": entry.submitted_at,
+            "proposal_id": entry.report.proposal_id,
+            "title": entry.report.title,
+            "proposal_class": entry.report.proposal_class,
+            "confidence": entry.report.confidence,
+            "risk_score": entry.report.risk_score,
+            "required_houses": entry.report.required_houses,
+            "recommended_disposition": entry.report.recommended_disposition,
+            "summary": entry.report.summary,
+            "drift": _governance_drift_payload(entry.drift) if entry.drift else None,
+        }
+        for entry in entries
+    ]
+
+
+def _governance_trends_payload(trends) -> list[dict[str, object]]:
+    return [
+        {
+            "trend_cluster": trend.trend_cluster,
+            "proposal_kind": trend.proposal_kind,
+            "owner": trend.owner,
+            "active_proposals": trend.active_proposals,
+            "proposal_ids": trend.proposal_ids,
+            "historical_precedents": trend.historical_precedents,
+            "historical_outcomes": trend.historical_outcomes,
+            "recent_window_days": trend.recent_window_days,
+            "baseline_window_days": trend.baseline_window_days,
+            "recent_historical_precedents": trend.recent_historical_precedents,
+            "baseline_historical_precedents": trend.baseline_historical_precedents,
+            "recent_active_proposals": trend.recent_active_proposals,
+            "trend_velocity": trend.trend_velocity,
+            "seasonal_kind_recent_total": trend.seasonal_kind_recent_total,
+            "seasonal_kind_baseline_total": trend.seasonal_kind_baseline_total,
+            "seasonal_expected_recent": trend.seasonal_expected_recent,
+            "seasonal_pressure": trend.seasonal_pressure,
+            "highest_drift_attention": trend.highest_drift_attention,
+            "highest_drift_score": trend.highest_drift_score,
+            "proposal_classes": trend.proposal_classes,
+            "systemic_signals": trend.systemic_signals,
+            "summary": trend.summary,
+        }
+        for trend in trends
+    ]
+
+
+def _governance_replay_payload(replay) -> dict[str, object]:
+    return {
+        "source_kind": replay.source_kind,
+        "replay_event_count": replay.replay_event_count,
+        "invalid_event_count": replay.invalid_event_count,
+        "event_alerts": replay.event_alerts,
+        "checkpoints": [
+            {
+                "checkpoint_id": checkpoint_id,
+                "previous_status": checkpoint_state.get("previous_status"),
+                "updated_at": checkpoint_state.get("updated_at"),
+                "recorded_by": checkpoint_state.get("recorded_by"),
+                "status": checkpoint_state.get("status"),
+            }
+            for checkpoint_id, checkpoint_state in sorted(replay.checkpoints.items())
+        ],
+    }
+
+
+def _governance_remediation_payload(plans) -> list[dict[str, object]]:
+    return [
+        {
+            "trend_cluster": plan.trend_cluster,
+            "severity": plan.severity,
+            "proposal_kind": plan.proposal_kind,
+            "owner": plan.owner,
+            "proposal_ids": plan.proposal_ids,
+            "triggers": plan.triggers,
+            "release_readiness": plan.release_readiness,
+            "current_release_readiness": plan.current_release_readiness,
+            "owner_roles": plan.owner_roles,
+            "checkpoint_status_counts": plan.checkpoint_status_counts,
+            "replay_event_count": plan.replay_event_count,
+            "invalid_event_count": plan.invalid_event_count,
+            "invalid_transition_count": plan.invalid_transition_count,
+            "invalid_audit_count": plan.invalid_audit_count,
+            "event_alerts": plan.event_alerts,
+            "transition_alerts": plan.transition_alerts,
+            "audit_alerts": plan.audit_alerts,
+            "progress_summary": plan.progress_summary,
+            "immediate_actions": plan.immediate_actions,
+            "approval_guardrails": plan.approval_guardrails,
+            "monitoring_actions": plan.monitoring_actions,
+            "release_blockers": plan.release_blockers,
+            "checkpoints": [
+                {
+                    "checkpoint_id": checkpoint.checkpoint_id,
+                    "phase": checkpoint.phase,
+                    "phase_order": checkpoint.phase_order,
+                    "owner_role": checkpoint.owner_role,
+                    "title": checkpoint.title,
+                    "blocking": checkpoint.blocking,
+                    "previous_status": checkpoint.previous_status,
+                    "updated_at": checkpoint.updated_at,
+                    "recorded_by": checkpoint.recorded_by,
+                    "status": checkpoint.status,
+                    "transition_valid": checkpoint.transition_valid,
+                    "transition_note": checkpoint.transition_note,
+                    "audit_valid": checkpoint.audit_valid,
+                    "audit_note": checkpoint.audit_note,
+                    "ready_to_start": checkpoint.ready_to_start,
+                    "depends_on": checkpoint.depends_on,
+                    "completion_criteria": checkpoint.completion_criteria,
+                }
+                for checkpoint in plan.checkpoints
+            ],
+            "summary": plan.summary,
+        }
+        for plan in plans
+    ]
+
+
+def _maybe_write_artifact(*, path: str | None, artifact_type: str, command: str, payload, sources: dict[str, object]) -> None:
+    if not path:
+        return
+    artifact = governance_artifact(
+        artifact_type=artifact_type,
+        command=command,
+        payload=payload,
+        sources=sources,
+    )
+    write_artifact(path, artifact)
+
+
 def _print_governance_report(report, emit_json: bool) -> None:
     payload = _governance_report_payload(report)
     if emit_json:
@@ -212,24 +363,7 @@ def _print_governance_drift(report, emit_json: bool) -> None:
 
 
 def _print_governance_queue(entries, emit_json: bool) -> None:
-    payload = [
-        {
-            "path": entry.path,
-            "status": entry.status,
-            "priority": entry.priority,
-            "owner": entry.owner,
-            "proposal_id": entry.report.proposal_id,
-            "title": entry.report.title,
-            "proposal_class": entry.report.proposal_class,
-            "confidence": entry.report.confidence,
-            "risk_score": entry.report.risk_score,
-            "required_houses": entry.report.required_houses,
-            "recommended_disposition": entry.report.recommended_disposition,
-            "summary": entry.report.summary,
-            "drift": _governance_drift_payload(entry.drift) if entry.drift else None,
-        }
-        for entry in entries
-    ]
+    payload = _governance_queue_payload(entries)
     if emit_json:
         print(json.dumps(payload, indent=2))
         return
@@ -250,33 +384,7 @@ def _print_governance_queue(entries, emit_json: bool) -> None:
 
 
 def _print_governance_trends(trends, emit_json: bool) -> None:
-    payload = [
-        {
-            "trend_cluster": trend.trend_cluster,
-            "proposal_kind": trend.proposal_kind,
-            "owner": trend.owner,
-            "active_proposals": trend.active_proposals,
-            "proposal_ids": trend.proposal_ids,
-            "historical_precedents": trend.historical_precedents,
-            "historical_outcomes": trend.historical_outcomes,
-            "recent_window_days": trend.recent_window_days,
-            "baseline_window_days": trend.baseline_window_days,
-            "recent_historical_precedents": trend.recent_historical_precedents,
-            "baseline_historical_precedents": trend.baseline_historical_precedents,
-            "recent_active_proposals": trend.recent_active_proposals,
-            "trend_velocity": trend.trend_velocity,
-            "seasonal_kind_recent_total": trend.seasonal_kind_recent_total,
-            "seasonal_kind_baseline_total": trend.seasonal_kind_baseline_total,
-            "seasonal_expected_recent": trend.seasonal_expected_recent,
-            "seasonal_pressure": trend.seasonal_pressure,
-            "highest_drift_attention": trend.highest_drift_attention,
-            "highest_drift_score": trend.highest_drift_score,
-            "proposal_classes": trend.proposal_classes,
-            "systemic_signals": trend.systemic_signals,
-            "summary": trend.summary,
-        }
-        for trend in trends
-    ]
+    payload = _governance_trends_payload(trends)
     if emit_json:
         print(json.dumps(payload, indent=2))
         return
@@ -306,22 +414,7 @@ def _print_governance_trends(trends, emit_json: bool) -> None:
 
 
 def _print_governance_replay(replay, emit_json: bool) -> None:
-    payload = {
-        "source_kind": replay.source_kind,
-        "replay_event_count": replay.replay_event_count,
-        "invalid_event_count": replay.invalid_event_count,
-        "event_alerts": replay.event_alerts,
-        "checkpoints": [
-            {
-                "checkpoint_id": checkpoint_id,
-                "previous_status": checkpoint_state.get("previous_status"),
-                "updated_at": checkpoint_state.get("updated_at"),
-                "recorded_by": checkpoint_state.get("recorded_by"),
-                "status": checkpoint_state.get("status"),
-            }
-            for checkpoint_id, checkpoint_state in sorted(replay.checkpoints.items())
-        ],
-    }
+    payload = _governance_replay_payload(replay)
     if emit_json:
         print(json.dumps(payload, indent=2))
         return
@@ -346,56 +439,7 @@ def _print_governance_replay(replay, emit_json: bool) -> None:
 
 
 def _print_governance_remediation(plans, emit_json: bool) -> None:
-    payload = [
-        {
-            "trend_cluster": plan.trend_cluster,
-            "severity": plan.severity,
-            "proposal_kind": plan.proposal_kind,
-            "owner": plan.owner,
-            "proposal_ids": plan.proposal_ids,
-            "triggers": plan.triggers,
-            "release_readiness": plan.release_readiness,
-            "current_release_readiness": plan.current_release_readiness,
-            "owner_roles": plan.owner_roles,
-            "checkpoint_status_counts": plan.checkpoint_status_counts,
-            "replay_event_count": plan.replay_event_count,
-            "invalid_event_count": plan.invalid_event_count,
-            "invalid_transition_count": plan.invalid_transition_count,
-            "invalid_audit_count": plan.invalid_audit_count,
-            "event_alerts": plan.event_alerts,
-            "transition_alerts": plan.transition_alerts,
-            "audit_alerts": plan.audit_alerts,
-            "progress_summary": plan.progress_summary,
-            "immediate_actions": plan.immediate_actions,
-            "approval_guardrails": plan.approval_guardrails,
-            "monitoring_actions": plan.monitoring_actions,
-            "release_blockers": plan.release_blockers,
-            "checkpoints": [
-                {
-                    "checkpoint_id": checkpoint.checkpoint_id,
-                    "phase": checkpoint.phase,
-                    "phase_order": checkpoint.phase_order,
-                    "owner_role": checkpoint.owner_role,
-                    "title": checkpoint.title,
-                    "blocking": checkpoint.blocking,
-                    "previous_status": checkpoint.previous_status,
-                    "updated_at": checkpoint.updated_at,
-                    "recorded_by": checkpoint.recorded_by,
-                    "status": checkpoint.status,
-                    "transition_valid": checkpoint.transition_valid,
-                    "transition_note": checkpoint.transition_note,
-                    "audit_valid": checkpoint.audit_valid,
-                    "audit_note": checkpoint.audit_note,
-                    "ready_to_start": checkpoint.ready_to_start,
-                    "depends_on": checkpoint.depends_on,
-                    "completion_criteria": checkpoint.completion_criteria,
-                }
-                for checkpoint in plan.checkpoints
-            ],
-            "summary": plan.summary,
-        }
-        for plan in plans
-    ]
+    payload = _governance_remediation_payload(plans)
     if emit_json:
         print(json.dumps(payload, indent=2))
         return
@@ -491,21 +535,31 @@ def main(argv: list[str] | None = None) -> int:
         if args.history:
             history = load_history(args.history)
             drift = infer_governance_drift(config, proposal, history)
+            payload = {
+                "report": _governance_report_payload(report),
+                "drift": _governance_drift_payload(drift),
+            }
+            _maybe_write_artifact(
+                path=args.artifact_out,
+                artifact_type="governance_simulation_with_drift",
+                command=args.command,
+                payload=payload,
+                sources={"proposal": args.proposal, "history": args.history},
+            )
             if args.json:
-                print(
-                    json.dumps(
-                        {
-                            "report": _governance_report_payload(report),
-                            "drift": _governance_drift_payload(drift),
-                        },
-                        indent=2,
-                    )
-                )
+                print(json.dumps(payload, indent=2))
             else:
                 _print_governance_report(report, emit_json=False)
                 print()
                 _print_governance_drift(drift, emit_json=False)
             return 0 if report.recommended_disposition != "hold" and drift.drift_attention != "escalate" else 2
+        _maybe_write_artifact(
+            path=args.artifact_out,
+            artifact_type="governance_simulation",
+            command=args.command,
+            payload=_governance_report_payload(report),
+            sources={"proposal": args.proposal},
+        )
         _print_governance_report(report, emit_json=args.json)
         return 0 if report.recommended_disposition != "hold" else 2
 
@@ -514,6 +568,13 @@ def main(argv: list[str] | None = None) -> int:
         history = load_history(args.history) if args.history else None
         policy = load_inference_policy(config) if history else None
         entries = infer_governance_queue(config, registry, registry_path=args.registry, history=history, policy=policy)
+        _maybe_write_artifact(
+            path=args.artifact_out,
+            artifact_type="governance_queue",
+            command=args.command,
+            payload=_governance_queue_payload(entries),
+            sources={"registry": args.registry, **({"history": args.history} if args.history else {})},
+        )
         _print_governance_queue(entries, emit_json=args.json)
         if history and not args.json:
             print()
@@ -535,6 +596,13 @@ def main(argv: list[str] | None = None) -> int:
         policy = load_inference_policy(config)
         entries = infer_governance_queue(config, registry, registry_path=args.registry, history=history, policy=policy)
         trends = infer_governance_portfolio_trends(entries, history=history, policy=policy)
+        _maybe_write_artifact(
+            path=args.artifact_out,
+            artifact_type="governance_trends",
+            command=args.command,
+            payload=_governance_trends_payload(trends),
+            sources={"registry": args.registry, "history": args.history},
+        )
         _print_governance_trends(trends, emit_json=args.json)
         return (
             0
@@ -560,6 +628,16 @@ def main(argv: list[str] | None = None) -> int:
             checkpoint_statuses=checkpoint_statuses,
             signature_policy=signer_policy,
         )
+        sources = {"registry": args.registry, "history": args.history}
+        if args.status:
+            sources["status"] = args.status
+        _maybe_write_artifact(
+            path=args.artifact_out,
+            artifact_type="governance_remediation",
+            command=args.command,
+            payload=_governance_remediation_payload(plans),
+            sources=sources,
+        )
         _print_governance_remediation(plans, emit_json=args.json)
         return (
             0
@@ -571,6 +649,13 @@ def main(argv: list[str] | None = None) -> int:
         checkpoint_statuses = load_checkpoint_statuses(args.status)
         signer_policy = load_checkpoint_signer_policy(config)
         replay = replay_checkpoint_state(checkpoint_statuses, signature_policy=signer_policy)
+        _maybe_write_artifact(
+            path=args.artifact_out,
+            artifact_type="governance_replay",
+            command=args.command,
+            payload=_governance_replay_payload(replay),
+            sources={"status": args.status},
+        )
         _print_governance_replay(replay, emit_json=args.json)
         return 0 if replay.invalid_event_count == 0 else 2
 
@@ -578,6 +663,13 @@ def main(argv: list[str] | None = None) -> int:
         proposal = load_proposal(args.proposal)
         history = load_history(args.history)
         drift = infer_governance_drift(config, proposal, history)
+        _maybe_write_artifact(
+            path=args.artifact_out,
+            artifact_type="governance_drift",
+            command=args.command,
+            payload=_governance_drift_payload(drift),
+            sources={"proposal": args.proposal, "history": args.history},
+        )
         _print_governance_drift(drift, emit_json=args.json)
         return 0 if drift.drift_attention != "escalate" else 2
 

--- a/tests/test_assurancectl.py
+++ b/tests/test_assurancectl.py
@@ -289,6 +289,32 @@ class AssuranceCtlTests(unittest.TestCase):
         self.assertEqual(payload[2]["proposal_id"], "draft-grant-001")
         self.assertEqual(payload[2]["drift"]["drift_attention"], "review")
 
+    def test_governance_queue_writes_versioned_artifact_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_path = Path(tmpdir) / "queue-artifact.json"
+            result = self.run_cli(
+                "governance-queue",
+                "--registry",
+                "examples/proposals/registry.json",
+                "--history",
+                "examples/proposals/history.json",
+                "--artifact-out",
+                str(artifact_path),
+                "--json",
+            )
+            artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload[0]["proposal_id"], "draft-pause-001")
+        self.assertEqual(artifact["schema"], "0ai.assurance.governance.artifact")
+        self.assertEqual(artifact["schema_version"], "1.0.0")
+        self.assertEqual(artifact["artifact_type"], "governance_queue")
+        self.assertEqual(artifact["command"], "governance-queue")
+        self.assertEqual(artifact["sources"]["registry"], "examples/proposals/registry.json")
+        self.assertEqual(artifact["sources"]["history"], "examples/proposals/history.json")
+        self.assertEqual(artifact["payload"][0]["proposal_id"], "draft-pause-001")
+
     def test_governance_trends_clusters_portfolio_signals(self) -> None:
         result = self.run_cli(
             "governance-trends",
@@ -312,6 +338,95 @@ class AssuranceCtlTests(unittest.TestCase):
         self.assertEqual(payload[2]["highest_drift_attention"], "review")
         self.assertEqual(payload[2]["trend_velocity"], "elevated")
         self.assertEqual(payload[2]["seasonal_pressure"], "watch")
+
+    def test_governance_trends_writes_versioned_artifact_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_path = Path(tmpdir) / "trends-artifact.json"
+            result = self.run_cli(
+                "governance-trends",
+                "--registry",
+                "examples/proposals/registry.json",
+                "--history",
+                "examples/proposals/history.json",
+                "--artifact-out",
+                str(artifact_path),
+                "--json",
+            )
+            artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload[0]["trend_cluster"], "emergency_pause:safety-council")
+        self.assertEqual(artifact["artifact_type"], "governance_trends")
+        self.assertEqual(artifact["payload"][0]["trend_cluster"], "emergency_pause:safety-council")
+
+    def test_governance_sim_with_history_writes_versioned_artifact_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_path = Path(tmpdir) / "sim-artifact.json"
+            result = self.run_cli(
+                "governance-sim",
+                "--proposal",
+                "examples/proposals/treasury-grant.json",
+                "--history",
+                "examples/proposals/history.json",
+                "--artifact-out",
+                str(artifact_path),
+                "--json",
+            )
+            artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertIn("report", payload)
+        self.assertEqual(artifact["artifact_type"], "governance_simulation_with_drift")
+        self.assertEqual(artifact["payload"]["report"]["proposal_id"], "draft-grant-001")
+        self.assertEqual(artifact["payload"]["drift"]["drift_attention"], "review")
+
+    def test_governance_drift_writes_versioned_artifact_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_path = Path(tmpdir) / "drift-artifact.json"
+            result = self.run_cli(
+                "governance-drift",
+                "--proposal",
+                "examples/proposals/emergency-pause.json",
+                "--history",
+                "examples/proposals/history.json",
+                "--artifact-out",
+                str(artifact_path),
+                "--json",
+            )
+            artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["drift_attention"], "escalate")
+        self.assertEqual(artifact["artifact_type"], "governance_drift")
+        self.assertEqual(artifact["payload"]["drift_attention"], "escalate")
+
+    def test_governance_replay_writes_versioned_artifact_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events.json"
+            event_path.write_text(
+                (PROJECT_ROOT / "examples" / "proposals" / "checkpoint-events.json").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            artifact_path = Path(tmpdir) / "replay-artifact.json"
+            result = self.run_cli(
+                "governance-replay",
+                "--status",
+                str(event_path),
+                "--artifact-out",
+                str(artifact_path),
+                "--json",
+            )
+            artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["source_kind"], "event_log")
+        self.assertEqual(artifact["artifact_type"], "governance_replay")
+        self.assertEqual(artifact["sources"]["status"], str(event_path))
+        self.assertEqual(artifact["payload"]["source_kind"], "event_log")
 
     def test_governance_remediation_emits_structured_plans(self) -> None:
         result = self.run_cli(
@@ -375,6 +490,28 @@ class AssuranceCtlTests(unittest.TestCase):
                 for checkpoint in payload[2]["checkpoints"]
             )
         )
+
+    def test_governance_remediation_writes_versioned_artifact_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_path = Path(tmpdir) / "remediation-artifact.json"
+            result = self.run_cli(
+                "governance-remediation",
+                "--registry",
+                "examples/proposals/registry.json",
+                "--history",
+                "examples/proposals/history.json",
+                "--artifact-out",
+                str(artifact_path),
+                "--json",
+            )
+            artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload[0]["trend_cluster"], "emergency_pause:safety-council")
+        self.assertEqual(artifact["artifact_type"], "governance_remediation")
+        self.assertEqual(artifact["payload"][0]["trend_cluster"], "emergency_pause:safety-council")
+        self.assertEqual(artifact["compatibility"]["breaking_change"], "increment major")
 
     def test_governance_remediation_status_rollup_updates_current_readiness(self) -> None:
         baseline = self.run_cli(


### PR DESCRIPTION
## Summary
- add a versioned governance artifact envelope and file-output support across the governance CLI commands
- preserve the existing human and raw JSON stdout paths while documenting the external-orchestrator contract
- add artifact coverage for queue, trends, drift, remediation, replay, and simulation-with-history outputs

Closes #4.

## Verification
- python -m py_compile src/assurancectl/artifacts.py src/assurancectl/cli.py examples/orchestrators/consume_governance_artifact.py
- python -m unittest discover -s tests -v
- make validate
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go test ./...
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go build ./cmd/0aid
- live artifact runs for governance-queue and governance-remediation with the consumer example