### PR TITLE
Design registry and attestation milestone plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -21,6 +21,7 @@ help:
 	@echo "  governance-drift Compare a proposal against governance history"
 	@echo "  go-build         Build the 0aid binary"
 	@echo "  go-test          Run Go unit tests"
+	@echo "  module-plan      Render the first registry/attestation milestone plan"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -69,6 +70,9 @@ go-build:
 
 go-test:
 	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) go test ./...
+
+module-plan:
+	./0aid module-plan --root . $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ projects/0ai-assurance-network/
 ├── config/
 │   ├── genesis/base-genesis.json
 │   ├── governance/inference-policy.json
+│   ├── modules/milestone-1.json
 │   ├── network-topology.json
 │   └── policy/release-guards.json
 ├── docs/
@@ -70,6 +71,7 @@ make -C projects/0ai-assurance-network governance-replay STATUS=examples/proposa
 make -C projects/0ai-assurance-network governance-drift PROPOSAL=examples/proposals/emergency-pause.json HISTORY=examples/proposals/history.json
 make -C projects/0ai-assurance-network go-build
 make -C projects/0ai-assurance-network go-test
+make -C projects/0ai-assurance-network module-plan
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -171,6 +173,7 @@ currently supports:
 
 - `version`
 - `module-map`
+- `module-plan`
 - `show-plan`
 - `init-genesis`
 - `render-validator`
@@ -184,6 +187,7 @@ Bootstrap examples:
 
 ```bash
 ./0aid render-identity --root . --id val-3
+./0aid module-plan --root . --out ./build/module-plan.json
 ./0aid init-node --root . --id val-3 --out ./build/nodes/validator-3
 ./0aid collect-validator --bundle ./build/nodes/validator-3 --out ./build/collection/validator-3.json
 ./0aid assemble-genesis --root . --collection ./build/collection --out ./build/assembled/genesis-plan.json
@@ -227,6 +231,12 @@ The governance inference path is explicitly advisory. It helps classify and
 score proposals, but it does not vote, sign, or bypass human review. The new
 history-aware drift pass keeps that same posture while adding context from prior
 governance behavior.
+
+The first implementable chain milestone for registry and attestation scope is
+captured in [config/modules/milestone-1.json](config/modules/milestone-1.json)
+and documented in [docs/module-milestone-1.md](docs/module-milestone-1.md).
+`0aid module-plan` renders that milestone with the current chain and validator
+context so the next chain-code step has a bounded implementation sequence.
 
 ## Current Design
 

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -31,6 +31,22 @@ func run(args []string) error {
 		return nil
 	case "module-map":
 		return printJSON(project.ModuleMap())
+	case "module-plan":
+		fs := flag.NewFlagSet("module-plan", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		plan := project.MilestoneModulePlan(bundle)
+		if *out == "" {
+			return printJSON(plan)
+		}
+		return project.WriteJSON(filepath.Clean(*out), plan)
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -199,7 +215,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 

--- a/config/modules/milestone-1.json
+++ b/config/modules/milestone-1.json
@@ -1,0 +1,341 @@
+{
+  "version": "1.0.0",
+  "milestone": "permissioned-testnet-registry-attestation",
+  "scope": "Deliver the first narrow registry and attestation flow for the permissioned testnet without expanding into full public-market modules.",
+  "mvp_modules": [
+    {
+      "name": "registry",
+      "purpose": "Track governed AI services, model releases, and declared safety metadata for permissioned operators.",
+      "state": [
+        {
+          "key": "service_records",
+          "type": "map[service_id]ServiceRecord",
+          "description": "Canonical service and model identity, owning organization, and current lifecycle status."
+        },
+        {
+          "key": "release_channels",
+          "type": "map[service_id][]ReleaseChannel",
+          "description": "Approved release channels and deployment targets for each governed service."
+        },
+        {
+          "key": "registry_actions",
+          "type": "append_only_log",
+          "description": "Operator-submitted registry changes for audit and attestation linkage."
+        }
+      ],
+      "transactions": [
+        {
+          "name": "register_service",
+          "actor_roles": ["registry_operator"],
+          "description": "Create a new governed service record with organization ownership and declared safety profile.",
+          "requires_governance": false,
+          "requires_attestation": false
+        },
+        {
+          "name": "propose_release",
+          "actor_roles": ["registry_operator"],
+          "description": "Stage a model or agent release candidate for attestation review before validator rollout.",
+          "requires_governance": false,
+          "requires_attestation": true
+        },
+        {
+          "name": "retire_service",
+          "actor_roles": ["registry_operator", "safety_council_delegate"],
+          "description": "Retire a service or freeze distribution when governance or safety policy requires it.",
+          "requires_governance": true,
+          "requires_attestation": false
+        }
+      ],
+      "operator_permissions": [
+        {
+          "role": "registry_operator",
+          "capabilities": [
+            "submit service records",
+            "propose release updates",
+            "attach declared metadata"
+          ]
+        },
+        {
+          "role": "registry_reviewer",
+          "capabilities": [
+            "validate registry completeness",
+            "reject malformed registry updates",
+            "request attestation evidence"
+          ]
+        }
+      ],
+      "governance_dependencies": [
+        "high-impact service retirement routes through bicameral governance",
+        "emergency service freeze honors safety-council override semantics"
+      ],
+      "validator_interactions": [
+        "validators only activate releases that are registry-visible and attestation-approved",
+        "validator bootstrap must reject rollout plans for unknown or retired services"
+      ]
+    },
+    {
+      "name": "attestation",
+      "purpose": "Manage safety attestations, reviewer bonds, and appeals for governed releases before validator activation.",
+      "state": [
+        {
+          "key": "attestation_records",
+          "type": "map[attestation_id]AttestationRecord",
+          "description": "Signed attestations tied to registry release proposals and audit outcomes."
+        },
+        {
+          "key": "reviewer_bonds",
+          "type": "map[reviewer_id]BondState",
+          "description": "Reviewer bond balances and slashing exposure for attestation participants."
+        },
+        {
+          "key": "appeal_windows",
+          "type": "map[attestation_id]AppealWindow",
+          "description": "Open appeal periods and finalization timers for disputed attestations."
+        }
+      ],
+      "transactions": [
+        {
+          "name": "submit_attestation",
+          "actor_roles": ["auditor_operator"],
+          "description": "Submit a safety attestation for a proposed registry release with rationale and evidence pointers.",
+          "requires_governance": false,
+          "requires_attestation": false
+        },
+        {
+          "name": "finalize_attestation",
+          "actor_roles": ["attestation_reviewer"],
+          "description": "Finalize an attestation after quorum review and make the release eligible for validator rollout.",
+          "requires_governance": false,
+          "requires_attestation": false
+        },
+        {
+          "name": "appeal_attestation",
+          "actor_roles": ["safety_council_delegate", "registry_operator"],
+          "description": "Open an appeal when new safety evidence or rollout harm invalidates an attestation outcome.",
+          "requires_governance": true,
+          "requires_attestation": false
+        }
+      ],
+      "operator_permissions": [
+        {
+          "role": "auditor_operator",
+          "capabilities": [
+            "submit attestations",
+            "update evidence references",
+            "accept bond slashing risk"
+          ]
+        },
+        {
+          "role": "attestation_reviewer",
+          "capabilities": [
+            "finalize or reject attestation bundles",
+            "start appeal windows",
+            "recommend slashing on false attestations"
+          ]
+        }
+      ],
+      "governance_dependencies": [
+        "appeals crossing the configured threshold escalate to safety-council and token-house review",
+        "slashing recommendations remain advisory until governance authorizes enforcement"
+      ],
+      "validator_interactions": [
+        "validator rollout gates on finalized attestations for release proposals",
+        "appealed or expired attestations must pause validator activation and update local rollout plans"
+      ]
+    }
+  ],
+  "dependency_surfaces": [
+    {
+      "name": "identity_core",
+      "purpose": "Resolve organizations, operators, auditors, and role bindings referenced by the MVP modules.",
+      "state": [
+        {
+          "key": "actor_records",
+          "type": "map[actor_id]ActorRecord",
+          "description": "Operator, organization, and auditor identities referenced by registry and attestation flows."
+        },
+        {
+          "key": "role_bindings",
+          "type": "map[actor_id][]RoleBinding",
+          "description": "Scoped role assignments used to authorize MVP module transactions."
+        }
+      ],
+      "transactions": [
+        {
+          "name": "register_actor",
+          "actor_roles": ["network_admin"],
+          "description": "Register an operator or organization identity for the permissioned milestone.",
+          "requires_governance": false,
+          "requires_attestation": false
+        },
+        {
+          "name": "bind_role",
+          "actor_roles": ["network_admin"],
+          "description": "Assign a bounded role required by registry and attestation transactions.",
+          "requires_governance": false,
+          "requires_attestation": false
+        }
+      ],
+      "operator_permissions": [
+        {
+          "role": "network_admin",
+          "capabilities": [
+            "register actors",
+            "assign scoped roles",
+            "revoke stale role bindings"
+          ]
+        }
+      ],
+      "governance_dependencies": [
+        "role definitions stay aligned with bicameral governance and safety-council authorities"
+      ],
+      "validator_interactions": [
+        "validator policy checks consume actor and role records before rollout execution"
+      ]
+    },
+    {
+      "name": "governance_hooks",
+      "purpose": "Provide the explicit decision points where governance can freeze releases, approve appeals, or authorize slashing.",
+      "state": [
+        {
+          "key": "governance_links",
+          "type": "map[module_action]GovernanceLink",
+          "description": "Bindings from registry and attestation actions to governance approval requirements."
+        }
+      ],
+      "transactions": [
+        {
+          "name": "link_governance_action",
+          "actor_roles": ["governance_admin"],
+          "description": "Declare which module actions need token-house, safety-council, or dual approval.",
+          "requires_governance": false,
+          "requires_attestation": false
+        }
+      ],
+      "operator_permissions": [
+        {
+          "role": "governance_admin",
+          "capabilities": [
+            "bind module actions to governance checkpoints",
+            "update rollout freeze rules"
+          ]
+        }
+      ],
+      "governance_dependencies": [
+        "inherits the existing bicameral governance policy and critical-action dual approval rules"
+      ],
+      "validator_interactions": [
+        "validator rollout plans must respect governance freeze and appeal outcomes before activation"
+      ]
+    },
+    {
+      "name": "validator_ops_hooks",
+      "purpose": "Bridge registry and attestation outcomes into validator rollout and localnet/bootstrap planning.",
+      "state": [
+        {
+          "key": "rollout_gates",
+          "type": "map[service_id]RolloutGate",
+          "description": "Current rollout eligibility derived from registry state, attestation finality, and governance overrides."
+        }
+      ],
+      "transactions": [
+        {
+          "name": "update_rollout_gate",
+          "actor_roles": ["validator_ops_lead"],
+          "description": "Project registry, attestation, and governance outcomes into validator rollout status.",
+          "requires_governance": false,
+          "requires_attestation": false
+        }
+      ],
+      "operator_permissions": [
+        {
+          "role": "validator_ops_lead",
+          "capabilities": [
+            "consume approved release metadata",
+            "block validator rollout on unresolved attestation or governance state",
+            "publish rollout gate summaries"
+          ]
+        }
+      ],
+      "governance_dependencies": [
+        "must expose safety-council and token-house freeze decisions to validator operations"
+      ],
+      "validator_interactions": [
+        "directly controls whether validators can stage or activate governed releases"
+      ]
+    }
+  ],
+  "rollout": [
+    {
+      "phase": 1,
+      "name": "identity-foundation",
+      "depends_on": [],
+      "deliverables": [
+        "actor and role state types",
+        "bounded actor-registration transactions",
+        "role-binding permission checks"
+      ],
+      "cmd_surfaces": [
+        "0aid module-plan"
+      ],
+      "chain_surfaces": [
+        "x/identity types",
+        "x/identity keeper"
+      ]
+    },
+    {
+      "phase": 2,
+      "name": "registry-mvp",
+      "depends_on": ["identity-foundation"],
+      "deliverables": [
+        "service and release state types",
+        "register_service and propose_release transactions",
+        "registry audit log events"
+      ],
+      "cmd_surfaces": [
+        "future 0aid registry-plan"
+      ],
+      "chain_surfaces": [
+        "x/registry types",
+        "x/registry keeper",
+        "x/registry message server"
+      ]
+    },
+    {
+      "phase": 3,
+      "name": "attestation-mvp",
+      "depends_on": ["registry-mvp"],
+      "deliverables": [
+        "attestation, bond, and appeal state types",
+        "submit_attestation and finalize_attestation transactions",
+        "release eligibility outputs for validator ops"
+      ],
+      "cmd_surfaces": [
+        "future 0aid attestation-plan"
+      ],
+      "chain_surfaces": [
+        "x/attest types",
+        "x/attest keeper",
+        "x/attest message server"
+      ]
+    },
+    {
+      "phase": 4,
+      "name": "governance-and-validator-hooks",
+      "depends_on": ["attestation-mvp"],
+      "deliverables": [
+        "governance linkage rules",
+        "validator rollout gate projections",
+        "freeze and appeal integration tests"
+      ],
+      "cmd_surfaces": [
+        "0aid module-plan",
+        "future 0aid rollout-gate"
+      ],
+      "chain_surfaces": [
+        "x/gov hook bindings",
+        "x/validatorops gate evaluator"
+      ]
+    }
+  ]
+}

--- a/docs/module-milestone-1.md
+++ b/docs/module-milestone-1.md
@@ -1,0 +1,97 @@
+# Module Milestone 1
+
+The first implementable chain milestone is intentionally narrow:
+
+- permissioned operator identity
+- governed service registry
+- release safety attestations
+- governance and validator rollout hooks only where required to make those flows enforceable
+
+This milestone is not a full public protocol surface. It is the smallest chain
+scope that lets the permissioned testnet prove:
+
+- governed services can be registered
+- release candidates can be attested
+- validator rollout can be blocked on missing or disputed attestations
+- governance can freeze or escalate release actions when safety requires it
+
+## Source Of Truth
+
+The machine-readable source of truth is
+[config/modules/milestone-1.json](../config/modules/milestone-1.json).
+
+`0aid module-plan --root .` renders that config together with the current chain
+context:
+
+- chain id
+- network mode
+- governance houses
+- validator count
+- implementation sequence
+
+## MVP Modules
+
+### `registry`
+
+- state:
+  - service records
+  - release channels
+  - registry action log
+- key transactions:
+  - `register_service`
+  - `propose_release`
+  - `retire_service`
+- operator roles:
+  - `registry_operator`
+  - `registry_reviewer`
+
+### `attestation`
+
+- state:
+  - attestation records
+  - reviewer bonds
+  - appeal windows
+- key transactions:
+  - `submit_attestation`
+  - `finalize_attestation`
+  - `appeal_attestation`
+- operator roles:
+  - `auditor_operator`
+  - `attestation_reviewer`
+
+## Dependency Surfaces
+
+These are included only to support the MVP modules:
+
+- `identity_core`
+- `governance_hooks`
+- `validator_ops_hooks`
+
+They should stay narrow and serve the registry/attestation flow rather than
+expanding into general-purpose modules during the first milestone.
+
+## Rollout Order
+
+1. `identity-foundation`
+2. `registry-mvp`
+3. `attestation-mvp`
+4. `governance-and-validator-hooks`
+
+That order is deliberate:
+
+- registry and attestation cannot exist without actor and role bindings
+- attestation depends on registry release proposals
+- governance and validator gating should attach after the core records and
+  attestation lifecycle exist
+
+## Validator Interaction Rule
+
+Validators must not activate a governed release unless:
+
+- the service is visible in the registry
+- the release proposal exists
+- the attestation is finalized and not under appeal
+- governance has not frozen the rollout path
+
+That is the operational bridge between safety review and validator behavior for
+the first permissioned testnet.

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -12,6 +12,7 @@ type Bundle struct {
 	Topology TopologyConfig
 	Genesis  GenesisConfig
 	Policy   PolicyConfig
+	Modules  ModulePlanConfig
 }
 
 type TopologyConfig struct {
@@ -46,8 +47,8 @@ type ValidatorNode struct {
 }
 
 type GovernanceTopology struct {
-	Houses                      []string `json:"houses"`
-	CriticalActionsRequireDual  bool     `json:"critical_actions_require_dual_approval"`
+	Houses                     []string `json:"houses"`
+	CriticalActionsRequireDual bool     `json:"critical_actions_require_dual_approval"`
 }
 
 type GenesisConfig struct {
@@ -68,9 +69,9 @@ type GenesisDenoms struct {
 }
 
 type GenesisStaking struct {
-	MinimumSelfBond    string `json:"minimum_self_bond"`
-	UnbondingTimeSec   int    `json:"unbonding_time_seconds"`
-	MaxValidators      int    `json:"max_validators"`
+	MinimumSelfBond  string `json:"minimum_self_bond"`
+	UnbondingTimeSec int    `json:"unbonding_time_seconds"`
+	MaxValidators    int    `json:"max_validators"`
 }
 
 type GenesisGov struct {
@@ -96,16 +97,63 @@ type GenesisTreasury struct {
 }
 
 type PolicyConfig struct {
-	Version                  string            `json:"version"`
-	RequiredBeforePublic     []string          `json:"required_before_public_launch"`
-	ProhibitedShortcuts      []string          `json:"prohibited_shortcuts"`
-	SafeModeDefaults         SafeModeDefaults  `json:"safe_mode_defaults"`
+	Version              string           `json:"version"`
+	RequiredBeforePublic []string         `json:"required_before_public_launch"`
+	ProhibitedShortcuts  []string         `json:"prohibited_shortcuts"`
+	SafeModeDefaults     SafeModeDefaults `json:"safe_mode_defaults"`
 }
 
 type SafeModeDefaults struct {
-	PermissionedTestnet             bool `json:"permissioned_testnet"`
-	PublicTransferability           bool `json:"public_transferability"`
+	PermissionedTestnet              bool `json:"permissioned_testnet"`
+	PublicTransferability            bool `json:"public_transferability"`
 	EmergencyPauseRequiresPostmortem bool `json:"emergency_pause_requires_postmortem"`
+}
+
+type ModulePlanConfig struct {
+	Version            string           `json:"version"`
+	Milestone          string           `json:"milestone"`
+	Scope              string           `json:"scope"`
+	MVPModules         []ModuleBoundary `json:"mvp_modules"`
+	DependencySurfaces []ModuleBoundary `json:"dependency_surfaces"`
+	Rollout            []ModuleRollout  `json:"rollout"`
+}
+
+type ModuleBoundary struct {
+	Name                   string               `json:"name"`
+	Purpose                string               `json:"purpose"`
+	State                  []ModuleState        `json:"state"`
+	Transactions           []ModuleTransaction  `json:"transactions"`
+	OperatorPermissions    []OperatorPermission `json:"operator_permissions"`
+	GovernanceDependencies []string             `json:"governance_dependencies"`
+	ValidatorInteractions  []string             `json:"validator_interactions"`
+}
+
+type ModuleState struct {
+	Key         string `json:"key"`
+	Type        string `json:"type"`
+	Description string `json:"description"`
+}
+
+type ModuleTransaction struct {
+	Name                string   `json:"name"`
+	ActorRoles          []string `json:"actor_roles"`
+	Description         string   `json:"description"`
+	RequiresGovernance  bool     `json:"requires_governance"`
+	RequiresAttestation bool     `json:"requires_attestation"`
+}
+
+type OperatorPermission struct {
+	Role         string   `json:"role"`
+	Capabilities []string `json:"capabilities"`
+}
+
+type ModuleRollout struct {
+	Phase         int      `json:"phase"`
+	Name          string   `json:"name"`
+	DependsOn     []string `json:"depends_on"`
+	Deliverables  []string `json:"deliverables"`
+	CmdSurfaces   []string `json:"cmd_surfaces"`
+	ChainSurfaces []string `json:"chain_surfaces"`
 }
 
 func LoadBundle(root string) (Bundle, error) {
@@ -129,11 +177,17 @@ func LoadBundle(root string) (Bundle, error) {
 		return Bundle{}, err
 	}
 
+	var modules ModulePlanConfig
+	if err := loadJSON(filepath.Join(resolvedRoot, "config", "modules", "milestone-1.json"), &modules); err != nil {
+		return Bundle{}, err
+	}
+
 	return Bundle{
 		Root:     resolvedRoot,
 		Topology: topology,
 		Genesis:  genesis,
 		Policy:   policy,
+		Modules:  modules,
 	}, nil
 }
 

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -20,4 +20,10 @@ func TestLoadBundle(t *testing.T) {
 	if !bundle.Policy.SafeModeDefaults.PermissionedTestnet {
 		t.Fatal("expected permissioned_testnet safe mode")
 	}
+	if bundle.Modules.Milestone != "permissioned-testnet-registry-attestation" {
+		t.Fatalf("unexpected module milestone: %s", bundle.Modules.Milestone)
+	}
+	if len(bundle.Modules.MVPModules) != 2 {
+		t.Fatalf("expected 2 mvp modules, got %d", len(bundle.Modules.MVPModules))
+	}
 }

--- a/internal/project/modules.go
+++ b/internal/project/modules.go
@@ -1,0 +1,36 @@
+package project
+
+type ModulePlanOutput struct {
+	Version                string           `json:"version"`
+	Milestone              string           `json:"milestone"`
+	Scope                  string           `json:"scope"`
+	ChainID                string           `json:"chain_id"`
+	NetworkMode            string           `json:"network_mode"`
+	GovernanceHouses       []string         `json:"governance_houses"`
+	ValidatorCount         int              `json:"validator_count"`
+	MVPModules             []ModuleBoundary `json:"mvp_modules"`
+	DependencySurfaces     []ModuleBoundary `json:"dependency_surfaces"`
+	Rollout                []ModuleRollout  `json:"rollout"`
+	ImplementationSequence []string         `json:"implementation_sequence"`
+}
+
+func MilestoneModulePlan(bundle Bundle) ModulePlanOutput {
+	sequence := make([]string, 0, len(bundle.Modules.Rollout))
+	for _, phase := range bundle.Modules.Rollout {
+		sequence = append(sequence, phase.Name)
+	}
+
+	return ModulePlanOutput{
+		Version:                bundle.Modules.Version,
+		Milestone:              bundle.Modules.Milestone,
+		Scope:                  bundle.Modules.Scope,
+		ChainID:                bundle.Topology.ChainID,
+		NetworkMode:            bundle.Topology.Mode,
+		GovernanceHouses:       bundle.Topology.Governance.Houses,
+		ValidatorCount:         len(bundle.Topology.Validators),
+		MVPModules:             bundle.Modules.MVPModules,
+		DependencySurfaces:     bundle.Modules.DependencySurfaces,
+		Rollout:                bundle.Modules.Rollout,
+		ImplementationSequence: sequence,
+	}
+}

--- a/internal/project/modules_test.go
+++ b/internal/project/modules_test.go
@@ -1,0 +1,36 @@
+package project
+
+import "testing"
+
+func TestMilestoneModulePlan(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	plan := MilestoneModulePlan(bundle)
+	if plan.Milestone != "permissioned-testnet-registry-attestation" {
+		t.Fatalf("unexpected milestone: %s", plan.Milestone)
+	}
+	if plan.ChainID != "0ai-assurance-1" {
+		t.Fatalf("unexpected chain id: %s", plan.ChainID)
+	}
+	if plan.NetworkMode != "permissioned_testnet" {
+		t.Fatalf("unexpected network mode: %s", plan.NetworkMode)
+	}
+	if len(plan.MVPModules) != 2 {
+		t.Fatalf("expected 2 mvp modules, got %d", len(plan.MVPModules))
+	}
+	if len(plan.DependencySurfaces) != 3 {
+		t.Fatalf("expected 3 dependency surfaces, got %d", len(plan.DependencySurfaces))
+	}
+	if len(plan.Rollout) != 4 {
+		t.Fatalf("expected 4 rollout phases, got %d", len(plan.Rollout))
+	}
+	if plan.ImplementationSequence[0] != "identity-foundation" {
+		t.Fatalf("unexpected first rollout phase: %s", plan.ImplementationSequence[0])
+	}
+	if plan.ImplementationSequence[len(plan.ImplementationSequence)-1] != "governance-and-validator-hooks" {
+		t.Fatalf("unexpected final rollout phase: %s", plan.ImplementationSequence[len(plan.ImplementationSequence)-1])
+	}
+}

--- a/src/assurancectl/config.py
+++ b/src/assurancectl/config.py
@@ -21,6 +21,7 @@ class LoadedConfig:
     genesis: dict[str, Any]
     policy: dict[str, Any]
     checkpoint_signers: dict[str, Any]
+    module_plan: dict[str, Any]
 
 
 def root_dir(explicit_root: str | Path | None = None) -> Path:
@@ -43,6 +44,7 @@ def load_config(explicit_root: str | Path | None = None) -> LoadedConfig:
         genesis=_load_json(config / "genesis" / "base-genesis.json"),
         policy=_load_json(config / "policy" / "release-guards.json"),
         checkpoint_signers=_load_json(config / "governance" / "checkpoint-signers.json"),
+        module_plan=_load_json(config / "modules" / "milestone-1.json"),
     )
 
 
@@ -158,8 +160,59 @@ def validate_checkpoint_signers(checkpoint_signers: dict[str, Any]) -> None:
         key_ids.add(key_id)
 
 
+def validate_module_plan(module_plan: dict[str, Any]) -> None:
+    _assert(module_plan["version"] != "", "module plan version must be set")
+    _assert(module_plan["milestone"] != "", "module plan milestone must be set")
+    _assert(module_plan["scope"] != "", "module plan scope must be set")
+
+    module_names: set[str] = set()
+    for collection_name in ("mvp_modules", "dependency_surfaces"):
+        collection = list(module_plan[collection_name])
+        _assert(collection, f"module plan {collection_name} must not be empty")
+        for module in collection:
+            name = str(module["name"])
+            _assert(name not in module_names, f"duplicate module name: {name}")
+            module_names.add(name)
+            _assert(module["purpose"] != "", f"module {name} must declare a purpose")
+            _assert(module["state"], f"module {name} must declare state")
+            _assert(module["transactions"], f"module {name} must declare transactions")
+            _assert(module["operator_permissions"], f"module {name} must declare operator permissions")
+            for state in module["state"]:
+                _assert(state["key"] != "", f"module {name} has state entry with empty key")
+                _assert(state["type"] != "", f"module {name} state {state['key']} must declare a type")
+            transaction_names: set[str] = set()
+            for tx in module["transactions"]:
+                tx_name = str(tx["name"])
+                _assert(tx_name not in transaction_names, f"module {name} has duplicate transaction {tx_name}")
+                _assert(tx["actor_roles"], f"module {name} transaction {tx_name} must declare actor roles")
+                transaction_names.add(tx_name)
+
+    rollout = list(module_plan["rollout"])
+    _assert(rollout, "module plan rollout must not be empty")
+    phase_numbers: list[int] = []
+    phase_names: set[str] = set()
+    for phase in rollout:
+        phase_number = int(phase["phase"])
+        phase_name = str(phase["name"])
+        _assert(phase_name not in phase_names, f"duplicate rollout phase name: {phase_name}")
+        _assert(phase["deliverables"], f"rollout phase {phase_name} must declare deliverables")
+        phase_numbers.append(phase_number)
+        phase_names.add(phase_name)
+    _assert(phase_numbers == list(range(1, len(phase_numbers) + 1)), "rollout phases must be sequential starting at 1")
+    seen_phase_names: set[str] = set()
+    for phase in rollout:
+        phase_name = str(phase["name"])
+        for dependency in phase["depends_on"]:
+            _assert(
+                dependency in seen_phase_names,
+                f"rollout phase {phase_name} depends on unknown or future phase {dependency}",
+            )
+        seen_phase_names.add(phase_name)
+
+
 def validate_all(config: LoadedConfig) -> None:
     validate_topology(config.topology)
     validate_genesis(config.genesis, config.topology)
     validate_policy(config.policy)
     validate_checkpoint_signers(config.checkpoint_signers)
+    validate_module_plan(config.module_plan)

--- a/tests/test_assurancectl.py
+++ b/tests/test_assurancectl.py
@@ -168,6 +168,7 @@ class AssuranceCtlTests(unittest.TestCase):
                 ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
                 ("config/policy/release-guards.json", "config/policy/release-guards.json"),
                 ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
+                ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
             ):
                 target_path = root / target
                 target_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add a loadable milestone-1 module plan for registry, attestation, and their supporting dependency surfaces
- expose the milestone through 0aid module-plan and wire validation through both the Go bundle loader and assurancectl config checks
- document the first permissioned-testnet implementation sequence for state, transactions, permissions, governance hooks, and validator rollout interactions

Closes #5.

## Verification
- python -m py_compile src/assurancectl/config.py
- python -m unittest discover -s tests -v
- make validate
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go test ./...
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go build ./cmd/0aid
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go run ./cmd/0aid module-plan --root .
- make module-plan OUT=/tmp/oai-assurance-module-plan-make.json