### PR TITLE
Add identity foundation bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -22,6 +22,7 @@ help:
 	@echo "  go-build         Build the 0aid binary"
 	@echo "  go-test          Run Go unit tests"
 	@echo "  module-plan      Render the first registry/attestation milestone plan"
+	@echo "  identity-plan    Render the permissioned actor and role bootstrap plan"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -73,6 +74,9 @@ go-test:
 
 module-plan:
 	./0aid module-plan --root . $(if $(OUT),--out $(OUT),)
+
+identity-plan:
+	./0aid identity-plan --root . $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ projects/0ai-assurance-network/
 ├── config/
 │   ├── genesis/base-genesis.json
 │   ├── governance/inference-policy.json
+│   ├── identity/bootstrap.json
 │   ├── modules/milestone-1.json
 │   ├── network-topology.json
 │   └── policy/release-guards.json
@@ -72,6 +73,7 @@ make -C projects/0ai-assurance-network governance-drift PROPOSAL=examples/propos
 make -C projects/0ai-assurance-network go-build
 make -C projects/0ai-assurance-network go-test
 make -C projects/0ai-assurance-network module-plan
+make -C projects/0ai-assurance-network identity-plan
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -174,6 +176,7 @@ currently supports:
 - `version`
 - `module-map`
 - `module-plan`
+- `identity-plan`
 - `show-plan`
 - `init-genesis`
 - `render-validator`
@@ -188,6 +191,7 @@ Bootstrap examples:
 ```bash
 ./0aid render-identity --root . --id val-3
 ./0aid module-plan --root . --out ./build/module-plan.json
+./0aid identity-plan --root . --out ./build/identity-plan.json
 ./0aid init-node --root . --id val-3 --out ./build/nodes/validator-3
 ./0aid collect-validator --bundle ./build/nodes/validator-3 --out ./build/collection/validator-3.json
 ./0aid assemble-genesis --root . --collection ./build/collection --out ./build/assembled/genesis-plan.json
@@ -237,6 +241,12 @@ captured in [config/modules/milestone-1.json](config/modules/milestone-1.json)
 and documented in [docs/module-milestone-1.md](docs/module-milestone-1.md).
 `0aid module-plan` renders that milestone with the current chain and validator
 context so the next chain-code step has a bounded implementation sequence.
+
+The permissioned actor and role bootstrap for that milestone is versioned in
+[config/identity/bootstrap.json](config/identity/bootstrap.json). `0aid
+identity-plan` renders the active actor set, required roles, role coverage, and
+missing-role check so registry, attestation, governance, and validator rollout
+hooks all depend on the same operator identity surface.
 
 ## Current Design
 

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -47,6 +47,25 @@ func run(args []string) error {
 			return printJSON(plan)
 		}
 		return project.WriteJSON(filepath.Clean(*out), plan)
+	case "identity-plan":
+		fs := flag.NewFlagSet("identity-plan", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		plan, err := project.IdentityFoundationPlan(bundle)
+		if err != nil {
+			return err
+		}
+		if *out == "" {
+			return printJSON(plan)
+		}
+		return project.WriteJSON(filepath.Clean(*out), plan)
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -215,7 +234,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 

--- a/config/identity/bootstrap.json
+++ b/config/identity/bootstrap.json
@@ -1,0 +1,138 @@
+{
+  "version": "1.0.0",
+  "chain_id": "0ai-assurance-1",
+  "actors": [
+    {
+      "actor_id": "org-0ai-core",
+      "actor_type": "organization",
+      "display_name": "0AI Core",
+      "status": "active"
+    },
+    {
+      "actor_id": "org-assurance-audit",
+      "actor_type": "organization",
+      "display_name": "0AI Assurance Audit",
+      "status": "active"
+    },
+    {
+      "actor_id": "org-safety-council",
+      "actor_type": "council",
+      "display_name": "0AI Safety Council",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-network-admin-1",
+      "actor_type": "operator",
+      "display_name": "Network Admin 1",
+      "organization_id": "org-0ai-core",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-registry-1",
+      "actor_type": "operator",
+      "display_name": "Registry Operator 1",
+      "organization_id": "org-0ai-core",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-registry-review-1",
+      "actor_type": "operator",
+      "display_name": "Registry Reviewer 1",
+      "organization_id": "org-0ai-core",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-auditor-1",
+      "actor_type": "operator",
+      "display_name": "Auditor Operator 1",
+      "organization_id": "org-assurance-audit",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-attestation-review-1",
+      "actor_type": "operator",
+      "display_name": "Attestation Reviewer 1",
+      "organization_id": "org-assurance-audit",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-governance-admin-1",
+      "actor_type": "operator",
+      "display_name": "Governance Admin 1",
+      "organization_id": "org-0ai-core",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-validator-ops-1",
+      "actor_type": "operator",
+      "display_name": "Validator Ops Lead 1",
+      "organization_id": "org-0ai-core",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-safety-council-1",
+      "actor_type": "operator",
+      "display_name": "Safety Council Delegate 1",
+      "organization_id": "org-safety-council",
+      "status": "active"
+    }
+  ],
+  "role_bindings": [
+    {
+      "actor_id": "op-network-admin-1",
+      "role": "network_admin",
+      "scope": "network",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-registry-1",
+      "role": "registry_operator",
+      "scope": "registry",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-registry-review-1",
+      "role": "registry_reviewer",
+      "scope": "registry",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-auditor-1",
+      "role": "auditor_operator",
+      "scope": "attestation",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-attestation-review-1",
+      "role": "attestation_reviewer",
+      "scope": "attestation",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-governance-admin-1",
+      "role": "governance_admin",
+      "scope": "governance",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-validator-ops-1",
+      "role": "validator_ops_lead",
+      "scope": "validator_rollout",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-safety-council-1",
+      "role": "safety_council_delegate",
+      "scope": "governance",
+      "granted_by": "genesis",
+      "status": "active"
+    }
+  ]
+}

--- a/docs/identity-foundation.md
+++ b/docs/identity-foundation.md
@@ -1,0 +1,73 @@
+# Identity Foundation
+
+The first executable dependency surface for the permissioned testnet is the
+identity bootstrap in [config/identity/bootstrap.json](../config/identity/bootstrap.json).
+
+It exists to answer one narrow question for the initial network:
+
+Who is allowed to perform registry, attestation, governance-hook, and validator
+rollout actions before the full chain modules are implemented?
+
+## Bootstrap Scope
+
+The bootstrap currently models:
+
+- organizations and councils
+- operator identities
+- bounded role bindings
+
+It does not try to implement general-purpose on-chain identity yet. It is the
+minimal operator surface required by the module milestone plan.
+
+## Current Roles
+
+The bootstrap covers the required roles derived from
+[config/modules/milestone-1.json](../config/modules/milestone-1.json):
+
+- `network_admin`
+- `registry_operator`
+- `registry_reviewer`
+- `auditor_operator`
+- `attestation_reviewer`
+- `governance_admin`
+- `validator_ops_lead`
+- `safety_council_delegate`
+
+Validation fails if any required role is missing an active binding or if a role
+binding is duplicated.
+
+## Operator Command
+
+Render the current identity plan:
+
+```bash
+./0aid identity-plan --root .
+```
+
+Or via make:
+
+```bash
+make identity-plan
+```
+
+The plan reports:
+
+- actor count
+- active actor count
+- required roles
+- bound roles
+- missing roles
+- per-role actor bindings and module references
+
+## Dependency Relationship
+
+The identity bootstrap feeds the first chain milestone directly:
+
+- registry uses it to authorize service and release operations
+- attestation uses it to authorize auditors and reviewers
+- governance hooks use it to authorize bounded admin and safety roles
+- validator rollout uses it to verify that only approved operators can project
+  release eligibility into validator activation gates
+
+This keeps the initial permissioned testnet narrow and auditable while still
+giving later chain code a concrete identity target to implement.

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -13,6 +13,7 @@ type Bundle struct {
 	Genesis  GenesisConfig
 	Policy   PolicyConfig
 	Modules  ModulePlanConfig
+	Identity IdentityBootstrapConfig
 }
 
 type TopologyConfig struct {
@@ -156,6 +157,29 @@ type ModuleRollout struct {
 	ChainSurfaces []string `json:"chain_surfaces"`
 }
 
+type IdentityBootstrapConfig struct {
+	Version      string                `json:"version"`
+	ChainID      string                `json:"chain_id"`
+	Actors       []IdentityActor       `json:"actors"`
+	RoleBindings []IdentityRoleBinding `json:"role_bindings"`
+}
+
+type IdentityActor struct {
+	ActorID        string `json:"actor_id"`
+	ActorType      string `json:"actor_type"`
+	DisplayName    string `json:"display_name"`
+	OrganizationID string `json:"organization_id,omitempty"`
+	Status         string `json:"status"`
+}
+
+type IdentityRoleBinding struct {
+	ActorID   string `json:"actor_id"`
+	Role      string `json:"role"`
+	Scope     string `json:"scope"`
+	GrantedBy string `json:"granted_by"`
+	Status    string `json:"status"`
+}
+
 func LoadBundle(root string) (Bundle, error) {
 	resolvedRoot, err := filepath.Abs(root)
 	if err != nil {
@@ -182,12 +206,18 @@ func LoadBundle(root string) (Bundle, error) {
 		return Bundle{}, err
 	}
 
+	var identity IdentityBootstrapConfig
+	if err := loadJSON(filepath.Join(resolvedRoot, "config", "identity", "bootstrap.json"), &identity); err != nil {
+		return Bundle{}, err
+	}
+
 	return Bundle{
 		Root:     resolvedRoot,
 		Topology: topology,
 		Genesis:  genesis,
 		Policy:   policy,
 		Modules:  modules,
+		Identity: identity,
 	}, nil
 }
 

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -26,4 +26,10 @@ func TestLoadBundle(t *testing.T) {
 	if len(bundle.Modules.MVPModules) != 2 {
 		t.Fatalf("expected 2 mvp modules, got %d", len(bundle.Modules.MVPModules))
 	}
+	if bundle.Identity.Version != "1.0.0" {
+		t.Fatalf("unexpected identity bootstrap version: %s", bundle.Identity.Version)
+	}
+	if len(bundle.Identity.RoleBindings) != 8 {
+		t.Fatalf("expected 8 identity role bindings, got %d", len(bundle.Identity.RoleBindings))
+	}
 }

--- a/internal/project/identity.go
+++ b/internal/project/identity.go
@@ -1,0 +1,243 @@
+package project
+
+import (
+	"fmt"
+	"sort"
+)
+
+type IdentityRolePlan struct {
+	Role         string   `json:"role"`
+	BoundActors  []string `json:"bound_actors"`
+	ReferencedBy []string `json:"referenced_by"`
+}
+
+type IdentityFoundationPlanOutput struct {
+	Version          string                `json:"version"`
+	ChainID          string                `json:"chain_id"`
+	Milestone        string                `json:"milestone"`
+	ActorCount       int                   `json:"actor_count"`
+	ActiveActorCount int                   `json:"active_actor_count"`
+	RequiredRoles    []string              `json:"required_roles"`
+	BoundRoles       []string              `json:"bound_roles"`
+	MissingRoles     []string              `json:"missing_roles"`
+	Actors           []IdentityActor       `json:"actors"`
+	RoleBindings     []IdentityRoleBinding `json:"role_bindings"`
+	RolePlan         []IdentityRolePlan    `json:"role_plan"`
+}
+
+func requiredIdentityRoles(modulePlan ModulePlanConfig) (map[string][]string, []string) {
+	roleUsage := make(map[string][]string)
+	appendUsage := func(role string, source string) {
+		for _, existing := range roleUsage[role] {
+			if existing == source {
+				return
+			}
+		}
+		roleUsage[role] = append(roleUsage[role], source)
+		sort.Strings(roleUsage[role])
+	}
+
+	recordBoundary := func(prefix string, boundary ModuleBoundary) {
+		source := prefix + ":" + boundary.Name
+		for _, tx := range boundary.Transactions {
+			for _, role := range tx.ActorRoles {
+				appendUsage(role, source)
+			}
+		}
+		for _, permission := range boundary.OperatorPermissions {
+			appendUsage(permission.Role, source)
+		}
+	}
+
+	for _, boundary := range modulePlan.MVPModules {
+		recordBoundary("mvp", boundary)
+	}
+	for _, boundary := range modulePlan.DependencySurfaces {
+		recordBoundary("dependency", boundary)
+	}
+
+	roles := make([]string, 0, len(roleUsage))
+	for role := range roleUsage {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	return roleUsage, roles
+}
+
+func ValidateIdentityBootstrap(bundle Bundle) error {
+	if bundle.Identity.Version == "" {
+		return fmt.Errorf("identity bootstrap version must be set")
+	}
+	if bundle.Identity.ChainID != bundle.Topology.ChainID {
+		return fmt.Errorf(
+			"identity bootstrap chain id %s does not match topology chain id %s",
+			bundle.Identity.ChainID,
+			bundle.Topology.ChainID,
+		)
+	}
+	if len(bundle.Identity.Actors) == 0 {
+		return fmt.Errorf("identity bootstrap must declare actors")
+	}
+	if len(bundle.Identity.RoleBindings) == 0 {
+		return fmt.Errorf("identity bootstrap must declare role bindings")
+	}
+
+	allowedActorTypes := map[string]struct{}{
+		"organization":    {},
+		"operator":        {},
+		"council":         {},
+		"service_account": {},
+	}
+	allowedStatus := map[string]struct{}{
+		"active":   {},
+		"inactive": {},
+	}
+
+	actors := make(map[string]IdentityActor, len(bundle.Identity.Actors))
+	for _, actor := range bundle.Identity.Actors {
+		if actor.ActorID == "" {
+			return fmt.Errorf("identity actor id must not be empty")
+		}
+		if _, exists := actors[actor.ActorID]; exists {
+			return fmt.Errorf("duplicate identity actor id: %s", actor.ActorID)
+		}
+		if _, ok := allowedActorTypes[actor.ActorType]; !ok {
+			return fmt.Errorf("identity actor %s has invalid actor type %s", actor.ActorID, actor.ActorType)
+		}
+		if _, ok := allowedStatus[actor.Status]; !ok {
+			return fmt.Errorf("identity actor %s has invalid status %s", actor.ActorID, actor.Status)
+		}
+		if actor.DisplayName == "" {
+			return fmt.Errorf("identity actor %s must declare a display name", actor.ActorID)
+		}
+		actors[actor.ActorID] = actor
+	}
+	for _, actor := range bundle.Identity.Actors {
+		if actor.OrganizationID == "" {
+			continue
+		}
+		organization, exists := actors[actor.OrganizationID]
+		if !exists {
+			return fmt.Errorf(
+				"identity actor %s references unknown organization %s",
+				actor.ActorID,
+				actor.OrganizationID,
+			)
+		}
+		if organization.ActorType != "organization" && organization.ActorType != "council" {
+			return fmt.Errorf(
+				"identity actor %s organization %s must be organization or council",
+				actor.ActorID,
+				actor.OrganizationID,
+			)
+		}
+	}
+
+	roleUsage, requiredRoles := requiredIdentityRoles(bundle.Modules)
+	boundRoles := make(map[string]struct{})
+	seenBindings := make(map[string]struct{}, len(bundle.Identity.RoleBindings))
+	for _, binding := range bundle.Identity.RoleBindings {
+		if binding.ActorID == "" || binding.Role == "" || binding.Scope == "" || binding.GrantedBy == "" {
+			return fmt.Errorf("identity role binding must declare actor_id, role, scope, and granted_by")
+		}
+		if _, exists := actors[binding.ActorID]; !exists {
+			return fmt.Errorf("identity role binding references unknown actor %s", binding.ActorID)
+		}
+		if _, ok := allowedStatus[binding.Status]; !ok {
+			return fmt.Errorf(
+				"identity role binding %s/%s has invalid status %s",
+				binding.ActorID,
+				binding.Role,
+				binding.Status,
+			)
+		}
+		if _, ok := roleUsage[binding.Role]; !ok {
+			return fmt.Errorf("identity role binding uses undeclared role %s", binding.Role)
+		}
+		bindingKey := binding.ActorID + "|" + binding.Role + "|" + binding.Scope
+		if _, exists := seenBindings[bindingKey]; exists {
+			return fmt.Errorf("duplicate identity role binding: %s", bindingKey)
+		}
+		seenBindings[bindingKey] = struct{}{}
+		if binding.Status == "active" {
+			boundRoles[binding.Role] = struct{}{}
+		}
+	}
+	for _, role := range requiredRoles {
+		if _, exists := boundRoles[role]; !exists {
+			return fmt.Errorf("identity bootstrap missing active binding for required role %s", role)
+		}
+	}
+	return nil
+}
+
+func IdentityFoundationPlan(bundle Bundle) (IdentityFoundationPlanOutput, error) {
+	if err := ValidateIdentityBootstrap(bundle); err != nil {
+		return IdentityFoundationPlanOutput{}, err
+	}
+
+	roleUsage, requiredRoles := requiredIdentityRoles(bundle.Modules)
+	activeActors := 0
+	for _, actor := range bundle.Identity.Actors {
+		if actor.Status == "active" {
+			activeActors++
+		}
+	}
+
+	roleBindings := append([]IdentityRoleBinding(nil), bundle.Identity.RoleBindings...)
+	sort.Slice(roleBindings, func(i, j int) bool {
+		if roleBindings[i].Role == roleBindings[j].Role {
+			if roleBindings[i].ActorID == roleBindings[j].ActorID {
+				return roleBindings[i].Scope < roleBindings[j].Scope
+			}
+			return roleBindings[i].ActorID < roleBindings[j].ActorID
+		}
+		return roleBindings[i].Role < roleBindings[j].Role
+	})
+
+	actors := append([]IdentityActor(nil), bundle.Identity.Actors...)
+	sort.Slice(actors, func(i, j int) bool {
+		return actors[i].ActorID < actors[j].ActorID
+	})
+
+	boundRolesSet := make(map[string][]string)
+	for _, binding := range roleBindings {
+		if binding.Status != "active" {
+			continue
+		}
+		boundRolesSet[binding.Role] = append(boundRolesSet[binding.Role], binding.ActorID)
+	}
+
+	boundRoles := make([]string, 0, len(boundRolesSet))
+	rolePlan := make([]IdentityRolePlan, 0, len(requiredRoles))
+	missingRoles := make([]string, 0)
+	for _, role := range requiredRoles {
+		actorsForRole := boundRolesSet[role]
+		sort.Strings(actorsForRole)
+		if len(actorsForRole) == 0 {
+			missingRoles = append(missingRoles, role)
+		} else {
+			boundRoles = append(boundRoles, role)
+		}
+		rolePlan = append(rolePlan, IdentityRolePlan{
+			Role:         role,
+			BoundActors:  actorsForRole,
+			ReferencedBy: roleUsage[role],
+		})
+	}
+	sort.Strings(boundRoles)
+
+	return IdentityFoundationPlanOutput{
+		Version:          bundle.Identity.Version,
+		ChainID:          bundle.Identity.ChainID,
+		Milestone:        bundle.Modules.Milestone,
+		ActorCount:       len(actors),
+		ActiveActorCount: activeActors,
+		RequiredRoles:    requiredRoles,
+		BoundRoles:       boundRoles,
+		MissingRoles:     missingRoles,
+		Actors:           actors,
+		RoleBindings:     roleBindings,
+		RolePlan:         rolePlan,
+	}, nil
+}

--- a/internal/project/identity_test.go
+++ b/internal/project/identity_test.go
@@ -1,0 +1,46 @@
+package project
+
+import "testing"
+
+func TestIdentityFoundationPlan(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	plan, err := IdentityFoundationPlan(bundle)
+	if err != nil {
+		t.Fatalf("IdentityFoundationPlan failed: %v", err)
+	}
+
+	if plan.Milestone != "permissioned-testnet-registry-attestation" {
+		t.Fatalf("unexpected milestone: %s", plan.Milestone)
+	}
+	if plan.ChainID != "0ai-assurance-1" {
+		t.Fatalf("unexpected chain id: %s", plan.ChainID)
+	}
+	if plan.ActorCount != 11 {
+		t.Fatalf("expected 11 actors, got %d", plan.ActorCount)
+	}
+	if plan.ActiveActorCount != 11 {
+		t.Fatalf("expected 11 active actors, got %d", plan.ActiveActorCount)
+	}
+	if len(plan.RequiredRoles) != 8 {
+		t.Fatalf("expected 8 required roles, got %d", len(plan.RequiredRoles))
+	}
+	if len(plan.MissingRoles) != 0 {
+		t.Fatalf("expected no missing roles, got %v", plan.MissingRoles)
+	}
+	foundNetworkAdmin := false
+	for _, role := range plan.RolePlan {
+		if role.Role == "network_admin" {
+			foundNetworkAdmin = true
+			if len(role.BoundActors) != 1 || role.BoundActors[0] != "op-network-admin-1" {
+				t.Fatalf("unexpected network_admin binding: %+v", role)
+			}
+		}
+	}
+	if !foundNetworkAdmin {
+		t.Fatal("expected network_admin role plan entry")
+	}
+}

--- a/src/assurancectl/config.py
+++ b/src/assurancectl/config.py
@@ -22,6 +22,7 @@ class LoadedConfig:
     policy: dict[str, Any]
     checkpoint_signers: dict[str, Any]
     module_plan: dict[str, Any]
+    identity_bootstrap: dict[str, Any]
 
 
 def root_dir(explicit_root: str | Path | None = None) -> Path:
@@ -45,6 +46,7 @@ def load_config(explicit_root: str | Path | None = None) -> LoadedConfig:
         policy=_load_json(config / "policy" / "release-guards.json"),
         checkpoint_signers=_load_json(config / "governance" / "checkpoint-signers.json"),
         module_plan=_load_json(config / "modules" / "milestone-1.json"),
+        identity_bootstrap=_load_json(config / "identity" / "bootstrap.json"),
     )
 
 
@@ -210,9 +212,76 @@ def validate_module_plan(module_plan: dict[str, Any]) -> None:
         seen_phase_names.add(phase_name)
 
 
+def _required_identity_roles(module_plan: dict[str, Any]) -> set[str]:
+    required: set[str] = set()
+    for collection_name in ("mvp_modules", "dependency_surfaces"):
+        for module in module_plan[collection_name]:
+            for tx in module["transactions"]:
+                required.update(str(role) for role in tx["actor_roles"])
+            for permission in module["operator_permissions"]:
+                required.add(str(permission["role"]))
+    return required
+
+
+def validate_identity_bootstrap(identity_bootstrap: dict[str, Any], module_plan: dict[str, Any], topology: dict[str, Any]) -> None:
+    _assert(identity_bootstrap["version"] != "", "identity bootstrap version must be set")
+    _assert(identity_bootstrap["chain_id"] == topology["chain_id"], "identity bootstrap chain id must match topology")
+
+    actors = list(identity_bootstrap["actors"])
+    role_bindings = list(identity_bootstrap["role_bindings"])
+    _assert(actors, "identity bootstrap actors must not be empty")
+    _assert(role_bindings, "identity bootstrap role bindings must not be empty")
+
+    allowed_actor_types = {"organization", "operator", "council", "service_account"}
+    allowed_status = {"active", "inactive"}
+    actors_by_id: dict[str, dict[str, Any]] = {}
+    for actor in actors:
+        actor_id = str(actor["actor_id"])
+        _assert(actor_id not in actors_by_id, f"duplicate identity actor id: {actor_id}")
+        _assert(actor["actor_type"] in allowed_actor_types, f"identity actor {actor_id} has invalid actor_type")
+        _assert(actor["status"] in allowed_status, f"identity actor {actor_id} has invalid status")
+        _assert(str(actor["display_name"]) != "", f"identity actor {actor_id} must declare a display_name")
+        actors_by_id[actor_id] = actor
+
+    for actor in actors:
+        organization_id = str(actor.get("organization_id", "") or "")
+        if not organization_id:
+            continue
+        _assert(organization_id in actors_by_id, f"identity actor {actor['actor_id']} references unknown organization")
+        organization = actors_by_id[organization_id]
+        _assert(
+            organization["actor_type"] in {"organization", "council"},
+            f"identity actor {actor['actor_id']} organization must be organization or council",
+        )
+
+    required_roles = _required_identity_roles(module_plan)
+    seen_bindings: set[str] = set()
+    active_roles: set[str] = set()
+    for binding in role_bindings:
+        actor_id = str(binding["actor_id"])
+        role = str(binding["role"])
+        scope = str(binding["scope"])
+        granted_by = str(binding["granted_by"])
+        status = str(binding["status"])
+        _assert(actor_id in actors_by_id, f"identity role binding references unknown actor {actor_id}")
+        _assert(role in required_roles, f"identity role binding uses undeclared role {role}")
+        _assert(scope != "", f"identity role binding {actor_id}/{role} must declare a scope")
+        _assert(granted_by != "", f"identity role binding {actor_id}/{role} must declare granted_by")
+        _assert(status in allowed_status, f"identity role binding {actor_id}/{role} has invalid status")
+        binding_key = f"{actor_id}|{role}|{scope}"
+        _assert(binding_key not in seen_bindings, f"duplicate identity role binding: {binding_key}")
+        seen_bindings.add(binding_key)
+        if status == "active":
+            active_roles.add(role)
+
+    missing_roles = sorted(required_roles - active_roles)
+    _assert(not missing_roles, f"identity bootstrap missing active bindings for roles: {', '.join(missing_roles)}")
+
+
 def validate_all(config: LoadedConfig) -> None:
     validate_topology(config.topology)
     validate_genesis(config.genesis, config.topology)
     validate_policy(config.policy)
     validate_checkpoint_signers(config.checkpoint_signers)
     validate_module_plan(config.module_plan)
+    validate_identity_bootstrap(config.identity_bootstrap, config.module_plan, config.topology)

--- a/tests/test_assurancectl.py
+++ b/tests/test_assurancectl.py
@@ -169,6 +169,7 @@ class AssuranceCtlTests(unittest.TestCase):
                 ("config/policy/release-guards.json", "config/policy/release-guards.json"),
                 ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
                 ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
+                ("config/identity/bootstrap.json", "config/identity/bootstrap.json"),
             ):
                 target_path = root / target
                 target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -187,6 +188,76 @@ class AssuranceCtlTests(unittest.TestCase):
             payload = json.loads(result.stdout)
             self.assertEqual(payload["status"], "not_ready")
             self.assertTrue(any("missing threat model" == item for item in payload["blockers"]))
+
+    def test_validate_fails_when_identity_binding_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for source, target in (
+                ("config/network-topology.json", "config/network-topology.json"),
+                ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
+                ("config/policy/release-guards.json", "config/policy/release-guards.json"),
+                ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
+                ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
+                ("config/identity/bootstrap.json", "config/identity/bootstrap.json"),
+            ):
+                target_path = root / target
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                target_path.write_text((PROJECT_ROOT / source).read_text(encoding="utf-8"), encoding="utf-8")
+
+            identity_path = root / "config" / "identity" / "bootstrap.json"
+            identity_payload = json.loads(identity_path.read_text(encoding="utf-8"))
+            identity_payload["role_bindings"] = [
+                binding
+                for binding in identity_payload["role_bindings"]
+                if binding["role"] != "network_admin"
+            ]
+            identity_path.write_text(json.dumps(identity_payload), encoding="utf-8")
+
+            env = {"PYTHONPATH": PYTHONPATH}
+            result = subprocess.run(
+                [sys.executable, "-m", "assurancectl.cli", "--root", str(root), "validate"],
+                cwd=PROJECT_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("identity bootstrap missing active bindings", result.stderr)
+
+    def test_validate_fails_when_identity_binding_is_duplicated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for source, target in (
+                ("config/network-topology.json", "config/network-topology.json"),
+                ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
+                ("config/policy/release-guards.json", "config/policy/release-guards.json"),
+                ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
+                ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
+                ("config/identity/bootstrap.json", "config/identity/bootstrap.json"),
+            ):
+                target_path = root / target
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                target_path.write_text((PROJECT_ROOT / source).read_text(encoding="utf-8"), encoding="utf-8")
+
+            identity_path = root / "config" / "identity" / "bootstrap.json"
+            identity_payload = json.loads(identity_path.read_text(encoding="utf-8"))
+            identity_payload["role_bindings"].append(identity_payload["role_bindings"][0])
+            identity_path.write_text(json.dumps(identity_payload), encoding="utf-8")
+
+            env = {"PYTHONPATH": PYTHONPATH}
+            result = subprocess.run(
+                [sys.executable, "-m", "assurancectl.cli", "--root", str(root), "validate"],
+                cwd=PROJECT_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("duplicate identity role binding", result.stderr)
 
     def test_governance_sim_treasury_grant(self) -> None:
         result = self.run_cli(


### PR DESCRIPTION
## Summary
- add a versioned permissioned actor and role bootstrap for the initial network operators
- validate identity bootstrap coverage in both the Go and Python config paths
- add `0aid identity-plan` plus docs for how identity state feeds registry, attestation, governance, and validator rollout hooks

Closes #12.

## Verification
- python -m py_compile src/assurancectl/config.py
- python -m unittest discover -s tests -v
- make validate
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go test ./...
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go build -o ./0aid ./cmd/0aid
- ./0aid identity-plan --root .
- make identity-plan OUT=/tmp/oai-assurance-identity-plan-make.json