### PR TITLE
Bind governance actors to identity bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ projects/0ai-assurance-network/
 ├── cmd/0aid/
 ├── config/
 │   ├── genesis/base-genesis.json
+│   ├── governance/checkpoint-signers.json
 │   ├── governance/inference-policy.json
 │   ├── identity/bootstrap.json
 │   ├── modules/milestone-1.json
@@ -116,9 +117,10 @@ its normal cadence.
 `governance-remediation` turns those trend clusters into structured mitigation
 bundles with severity, release blockers, immediate actions, approval
 guardrails, monitoring steps, and machine-readable checkpoints with explicit
-owner roles, completion criteria, dependency ordering between phases, and
-status-aware rollups for current execution readiness. That keeps the governance
-path operationally useful once the engine detects an unstable cluster.
+owner roles, eligible bootstrap actors, assigned actor context, completion
+criteria, dependency ordering between phases, and status-aware rollups for
+current execution readiness. That keeps the governance path operationally
+useful once the engine detects an unstable cluster.
 
 Each governance command also supports `--artifact-out <path>` so external
 automation can consume a stable, versioned orchestration artifact without
@@ -128,9 +130,9 @@ scraping CLI text. The artifact contract is documented in
 `governance-replay` reconstructs deterministic current checkpoint state from an
 append-only event log or a derived snapshot. Event logs are stricter than
 snapshots: each event must include `checkpoint_id`, `previous_status`,
-`new_status`, `updated_at`, `recorded_by`, and `rationale`, and replay rejects
-duplicate, contradictory, illegal, or out-of-order history. Signed event logs
-must also include a `signature` object with:
+`new_status`, `updated_at`, `recorded_by`, `actor_id`, and `rationale`, and
+replay rejects duplicate, contradictory, illegal, or out-of-order history.
+Signed event logs must also include a `signature` object with:
 
 - `format`
 - `signer_id`
@@ -143,15 +145,20 @@ must also include a `signature` object with:
 Signer-to-role policy lives in
 `config/governance/checkpoint-signers.json`. The current repository ships
 development-only HMAC signers so the pre-launch testnet can exercise
-authenticated updates without pretending to solve production custody.
+authenticated updates without pretending to solve production custody. Each
+signer is bound to an `actor_id`, and replay only accepts signed updates when
+that actor is active in `config/identity/bootstrap.json` and actively bound to
+the claimed role.
 
 Status inputs are transition-aware. Each non-pending checkpoint update should
-include `previous_status`, `updated_at`, and `recorded_by`, and the engine only
-accepts lifecycle moves that stay inside the deterministic path
+include `previous_status`, `updated_at`, `recorded_by`, and `actor_id`, and the
+engine only accepts lifecycle moves that stay inside the deterministic path
 `pending -> in_progress -> completed`. It also validates dependency timestamp
 ordering so downstream checkpoints cannot appear to complete before the latest
 completed prerequisite. Remediation accepts either a derived checkpoint snapshot
-or a replayable append-only event log via `--status`.
+or a replayable append-only event log via `--status`, and surfaces resolved
+actor/org context in the machine-readable payload so operators can audit who is
+actually assigned to each governance checkpoint.
 
 For event logs, non-pending updates are only accepted when the signature is
 valid, the signer is authorized for the `recorded_by` role, and the update falls

--- a/config/governance/checkpoint-signers.json
+++ b/config/governance/checkpoint-signers.json
@@ -5,60 +5,98 @@
   "maximum_signature_validity_seconds": 86400,
   "signers": [
     {
+      "actor_id": "op-governance-chair-1",
+      "signer_id": "governance-chair-bot",
+      "key_id": "governance-chair-dev-v1",
+      "roles": ["governance-chair"],
+      "shared_secret": "dev-secret-governance-chair-v1"
+    },
+    {
+      "actor_id": "op-governance-ops-1",
+      "signer_id": "governance-ops-bot",
+      "key_id": "governance-ops-dev-v1",
+      "roles": ["governance-ops"],
+      "shared_secret": "dev-secret-governance-ops-v1"
+    },
+    {
+      "actor_id": "op-token-house-secretariat-1",
+      "signer_id": "token-house-secretariat-bot",
+      "key_id": "token-house-secretariat-dev-v1",
+      "roles": ["token-house-secretariat"],
+      "shared_secret": "dev-secret-token-house-secretariat-v1"
+    },
+    {
+      "actor_id": "op-telemetry-ops-1",
+      "signer_id": "telemetry-ops-bot",
+      "key_id": "telemetry-ops-dev-v1",
+      "roles": ["telemetry-ops"],
+      "shared_secret": "dev-secret-telemetry-ops-v1"
+    },
+    {
+      "actor_id": "op-treasury-program-manager-1",
       "signer_id": "treasury-program-manager-bot",
       "key_id": "treasury-program-manager-dev-v1",
       "roles": ["treasury-program-manager"],
       "shared_secret": "dev-secret-treasury-program-manager-v1"
     },
     {
+      "actor_id": "op-treasury-review-chair-1",
       "signer_id": "treasury-review-chair-bot",
       "key_id": "treasury-review-chair-dev-v1",
       "roles": ["treasury-review-chair"],
       "shared_secret": "dev-secret-treasury-review-chair-v1"
     },
     {
+      "actor_id": "op-finance-telemetry-lead-1",
       "signer_id": "finance-telemetry-lead-bot",
       "key_id": "finance-telemetry-lead-dev-v1",
       "roles": ["finance-telemetry-lead"],
       "shared_secret": "dev-secret-finance-telemetry-lead-v1"
     },
     {
+      "actor_id": "op-validator-ops-1",
       "signer_id": "validator-ops-lead-bot",
       "key_id": "validator-ops-lead-dev-v1",
       "roles": ["validator-ops-lead"],
       "shared_secret": "dev-secret-validator-ops-lead-v1"
     },
     {
+      "actor_id": "op-staking-governance-reviewer-1",
       "signer_id": "staking-governance-reviewer-bot",
       "key_id": "staking-governance-reviewer-dev-v1",
       "roles": ["staking-governance-reviewer"],
       "shared_secret": "dev-secret-staking-governance-reviewer-v1"
     },
     {
+      "actor_id": "op-network-reliability-lead-1",
       "signer_id": "network-reliability-lead-bot",
       "key_id": "network-reliability-lead-dev-v1",
       "roles": ["network-reliability-lead"],
       "shared_secret": "dev-secret-network-reliability-lead-v1"
     },
     {
+      "actor_id": "op-safety-council-chair-1",
       "signer_id": "safety-council-chair-bot",
       "key_id": "safety-council-chair-dev-v1",
       "roles": ["safety-council-chair"],
       "shared_secret": "dev-secret-safety-council-chair-v1"
     },
     {
+      "actor_id": "op-incident-commander-1",
       "signer_id": "incident-commander-bot",
       "key_id": "incident-commander-dev-v1",
       "roles": ["incident-commander"],
       "shared_secret": "dev-secret-incident-commander-v1"
     },
     {
+      "actor_id": "op-safety-council-secretariat-1",
       "signer_id": "safety-council-secretariat-bot",
       "key_id": "safety-council-secretariat-dev-v1",
       "roles": ["safety-council-secretariat"],
       "shared_secret": "dev-secret-safety-council-secretariat-v1"
     },
     {
+      "actor_id": "op-security-telemetry-lead-1",
       "signer_id": "security-telemetry-lead-bot",
       "key_id": "security-telemetry-lead-dev-v1",
       "roles": ["security-telemetry-lead"],

--- a/config/identity/bootstrap.json
+++ b/config/identity/bootstrap.json
@@ -75,6 +75,97 @@
       "display_name": "Safety Council Delegate 1",
       "organization_id": "org-safety-council",
       "status": "active"
+    },
+    {
+      "actor_id": "op-governance-chair-1",
+      "actor_type": "operator",
+      "display_name": "Governance Chair 1",
+      "organization_id": "org-0ai-core",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-governance-ops-1",
+      "actor_type": "operator",
+      "display_name": "Governance Ops 1",
+      "organization_id": "org-0ai-core",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-token-house-secretariat-1",
+      "actor_type": "operator",
+      "display_name": "Token House Secretariat 1",
+      "organization_id": "org-0ai-core",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-telemetry-ops-1",
+      "actor_type": "operator",
+      "display_name": "Telemetry Ops 1",
+      "organization_id": "org-assurance-audit",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-treasury-program-manager-1",
+      "actor_type": "operator",
+      "display_name": "Treasury Program Manager 1",
+      "organization_id": "org-0ai-core",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-treasury-review-chair-1",
+      "actor_type": "operator",
+      "display_name": "Treasury Review Chair 1",
+      "organization_id": "org-assurance-audit",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-finance-telemetry-lead-1",
+      "actor_type": "operator",
+      "display_name": "Finance Telemetry Lead 1",
+      "organization_id": "org-assurance-audit",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-staking-governance-reviewer-1",
+      "actor_type": "operator",
+      "display_name": "Staking Governance Reviewer 1",
+      "organization_id": "org-assurance-audit",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-network-reliability-lead-1",
+      "actor_type": "operator",
+      "display_name": "Network Reliability Lead 1",
+      "organization_id": "org-0ai-core",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-safety-council-chair-1",
+      "actor_type": "operator",
+      "display_name": "Safety Council Chair 1",
+      "organization_id": "org-safety-council",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-incident-commander-1",
+      "actor_type": "operator",
+      "display_name": "Incident Commander 1",
+      "organization_id": "org-safety-council",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-safety-council-secretariat-1",
+      "actor_type": "operator",
+      "display_name": "Safety Council Secretariat 1",
+      "organization_id": "org-safety-council",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-security-telemetry-lead-1",
+      "actor_type": "operator",
+      "display_name": "Security Telemetry Lead 1",
+      "organization_id": "org-assurance-audit",
+      "status": "active"
     }
   ],
   "role_bindings": [
@@ -131,6 +222,104 @@
       "actor_id": "op-safety-council-1",
       "role": "safety_council_delegate",
       "scope": "governance",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-governance-chair-1",
+      "role": "governance-chair",
+      "scope": "governance",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-governance-ops-1",
+      "role": "governance-ops",
+      "scope": "governance",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-token-house-secretariat-1",
+      "role": "token-house-secretariat",
+      "scope": "governance",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-telemetry-ops-1",
+      "role": "telemetry-ops",
+      "scope": "monitoring",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-treasury-program-manager-1",
+      "role": "treasury-program-manager",
+      "scope": "treasury",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-treasury-review-chair-1",
+      "role": "treasury-review-chair",
+      "scope": "treasury",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-finance-telemetry-lead-1",
+      "role": "finance-telemetry-lead",
+      "scope": "treasury",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-validator-ops-1",
+      "role": "validator-ops-lead",
+      "scope": "governance",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-staking-governance-reviewer-1",
+      "role": "staking-governance-reviewer",
+      "scope": "governance",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-network-reliability-lead-1",
+      "role": "network-reliability-lead",
+      "scope": "monitoring",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-safety-council-chair-1",
+      "role": "safety-council-chair",
+      "scope": "governance",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-incident-commander-1",
+      "role": "incident-commander",
+      "scope": "emergency",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-safety-council-secretariat-1",
+      "role": "safety-council-secretariat",
+      "scope": "governance",
+      "granted_by": "genesis",
+      "status": "active"
+    },
+    {
+      "actor_id": "op-security-telemetry-lead-1",
+      "role": "security-telemetry-lead",
+      "scope": "monitoring",
       "granted_by": "genesis",
       "status": "active"
     }

--- a/docs/governance-inference.md
+++ b/docs/governance-inference.md
@@ -162,6 +162,7 @@ Each event must include:
 - `new_status`
 - `updated_at`
 - `recorded_by`
+- `actor_id`
 - `rationale`
 - `signature.format`
 - `signature.signer_id`
@@ -175,12 +176,14 @@ Signer-role bindings are defined in
 `config/governance/checkpoint-signers.json`. The current implementation uses a
 development-only HMAC verifier so the permissioned testnet can exercise actor
 verification and replay protection without pretending to be a production key
-management system.
+management system. Each signer entry is now bound to an identity bootstrap
+actor, so replay rejects any signed update where the signer, actor, and role do
+not line up with `config/identity/bootstrap.json`.
 
 The status file is not treated as an arbitrary snapshot. For non-pending
-updates, operators should provide `previous_status`, `updated_at`, and
-`recorded_by`, and the engine validates the transition against the policy
-lifecycle:
+updates, operators should provide `previous_status`, `updated_at`,
+`recorded_by`, and `actor_id`, and the engine validates the transition against
+the policy lifecycle:
 
 - `pending -> in_progress`
 - `in_progress -> completed`
@@ -190,14 +193,25 @@ Illegal moves are surfaced as transition alerts and force the current plan
 readiness to `invalid`.
 
 Audit gaps are treated the same way. The remediation engine rejects non-pending
-updates without actor attribution or timestamps, and it rejects checkpoint
+updates without actor attribution or timestamps, rejects actor/role pairs that
+are not actively bound in the identity bootstrap, and rejects checkpoint
 updates whose `updated_at` value predates the latest completed dependency.
 
 Event logs add another deterministic guarantee: replay rejects duplicate,
 contradictory, illegal, or out-of-order history. Signed event logs go further:
-replay rejects invalid signatures, wrong-role signers, expired signatures, and
-reused `signature_id` values. That means remediation can consume an event log
-directly without trusting a mutable current-state file as the source of truth.
+replay rejects invalid signatures, wrong-role signers, signer/actor mismatch,
+expired signatures, and reused `signature_id` values. That means remediation
+can consume an event log directly without trusting a mutable current-state file
+as the source of truth.
+
+When remediation plans are rendered, each checkpoint now includes:
+
+- eligible bootstrap actors for the owner role
+- the assigned actor when a checkpoint status or event log resolves one
+- organization context for the resolved actor
+
+That makes the machine-readable output usable as both a control artifact and an
+operator accountability view.
 
 Operationally, rejected or expired signatures should not be patched in place.
 They should be superseded by a new signed update or event log segment. The CLI

--- a/docs/identity-foundation.md
+++ b/docs/identity-foundation.md
@@ -15,6 +15,7 @@ The bootstrap currently models:
 - organizations and councils
 - operator identities
 - bounded role bindings
+- governance execution actors used by remediation checkpoints and signer policy
 
 It does not try to implement general-purpose on-chain identity yet. It is the
 minimal operator surface required by the module milestone plan.
@@ -22,7 +23,10 @@ minimal operator surface required by the module milestone plan.
 ## Current Roles
 
 The bootstrap covers the required roles derived from
-[config/modules/milestone-1.json](../config/modules/milestone-1.json):
+[config/modules/milestone-1.json](../config/modules/milestone-1.json), plus the
+governance execution roles referenced by
+[config/governance/inference-policy.json](../config/governance/inference-policy.json)
+and [config/governance/checkpoint-signers.json](../config/governance/checkpoint-signers.json):
 
 - `network_admin`
 - `registry_operator`
@@ -32,9 +36,24 @@ The bootstrap covers the required roles derived from
 - `governance_admin`
 - `validator_ops_lead`
 - `safety_council_delegate`
+- `governance-chair`
+- `governance-ops`
+- `token-house-secretariat`
+- `telemetry-ops`
+- `treasury-program-manager`
+- `treasury-review-chair`
+- `finance-telemetry-lead`
+- `validator-ops-lead`
+- `staking-governance-reviewer`
+- `network-reliability-lead`
+- `safety-council-chair`
+- `incident-commander`
+- `safety-council-secretariat`
+- `security-telemetry-lead`
 
 Validation fails if any required role is missing an active binding or if a role
-binding is duplicated.
+binding is duplicated. It also fails if a configured checkpoint signer is not
+bound to an active bootstrap actor for the role it claims to sign.
 
 ## Operator Command
 
@@ -66,6 +85,8 @@ The identity bootstrap feeds the first chain milestone directly:
 - registry uses it to authorize service and release operations
 - attestation uses it to authorize auditors and reviewers
 - governance hooks use it to authorize bounded admin and safety roles
+- governance replay uses it to bind signed checkpoint events to active actors
+- governance remediation uses it to resolve eligible owner actors per checkpoint
 - validator rollout uses it to verify that only approved operators can project
   release eligibility into validator activation gates
 

--- a/examples/proposals/checkpoint-events.json
+++ b/examples/proposals/checkpoint-events.json
@@ -7,6 +7,7 @@
       "new_status": "in_progress",
       "updated_at": "2026-04-16T11:51:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "rationale": "Started milestone release planning.",
       "signature": {
         "format": "0ai-hmac-sha256-v1",
@@ -15,7 +16,7 @@
         "signature_id": "example-immediate-action-1-start",
         "signed_at": "2026-04-16T10:00:00Z",
         "expires_at": "2026-04-17T10:00:00Z",
-        "value": "adce4ccf51ef95c7f284a77877af8346c2d40ca0aba2958c3eb322ec8a684ebf"
+        "value": "929e71acef10c322cd794472b0f4dcd3d9690b637dceee594e424602adb5e229"
       }
     },
     {
@@ -24,6 +25,7 @@
       "new_status": "completed",
       "updated_at": "2026-04-16T12:01:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "rationale": "Milestone release plan approved.",
       "signature": {
         "format": "0ai-hmac-sha256-v1",
@@ -32,7 +34,7 @@
         "signature_id": "example-immediate-action-1-complete",
         "signed_at": "2026-04-16T10:00:00Z",
         "expires_at": "2026-04-17T10:00:00Z",
-        "value": "0d796900e2f95ab5c76048422ab0f4c679fec4cc20bf0182b1724a938fd8472d"
+        "value": "335b7c45cc9c18ce0f06e384f839c45796fa6943230649918d6675bfe661024a"
       }
     },
     {
@@ -41,6 +43,7 @@
       "new_status": "in_progress",
       "updated_at": "2026-04-16T11:52:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "rationale": "Started staged release split.",
       "signature": {
         "format": "0ai-hmac-sha256-v1",
@@ -49,7 +52,7 @@
         "signature_id": "example-immediate-action-2-start",
         "signed_at": "2026-04-16T10:00:00Z",
         "expires_at": "2026-04-17T10:00:00Z",
-        "value": "8f5cde42bbd8593a297dd2f24225aa0a62eaf9aa62ed5a8161758d3de7aada78"
+        "value": "38c54c328f8ecc2cb5998b9dee0cdbf3f1e022a27f69ea11c70a6a8d6454fbb8"
       }
     },
     {
@@ -58,6 +61,7 @@
       "new_status": "completed",
       "updated_at": "2026-04-16T12:02:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "rationale": "Funding was broken into staged releases.",
       "signature": {
         "format": "0ai-hmac-sha256-v1",
@@ -66,7 +70,7 @@
         "signature_id": "example-immediate-action-2-complete",
         "signed_at": "2026-04-16T10:00:00Z",
         "expires_at": "2026-04-17T10:00:00Z",
-        "value": "6e0772a2fdb427a4d6717052376a0400c6fe19a62ccfb280a140ac7da49b4e31"
+        "value": "12ab033625ca27de2c7ed3c2f5b9307e99973ba19ec537d502753959a2f6663d"
       }
     }
   ]

--- a/examples/proposals/checkpoint-status.json
+++ b/examples/proposals/checkpoint-status.json
@@ -6,6 +6,7 @@
       "previous_status": "in_progress",
       "updated_at": "2026-04-16T12:01:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "status": "completed"
     },
     {
@@ -13,6 +14,7 @@
       "previous_status": "in_progress",
       "updated_at": "2026-04-16T12:02:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "status": "completed"
     },
     {
@@ -20,6 +22,7 @@
       "previous_status": "in_progress",
       "updated_at": "2026-04-16T12:03:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "status": "completed"
     },
     {
@@ -27,6 +30,7 @@
       "previous_status": "in_progress",
       "updated_at": "2026-04-16T12:04:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "status": "completed"
     },
     {
@@ -34,6 +38,7 @@
       "previous_status": "in_progress",
       "updated_at": "2026-04-16T12:05:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "status": "completed"
     },
     {
@@ -41,6 +46,7 @@
       "previous_status": "in_progress",
       "updated_at": "2026-04-16T12:06:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "status": "completed"
     },
     {
@@ -48,6 +54,7 @@
       "previous_status": "in_progress",
       "updated_at": "2026-04-16T12:07:00Z",
       "recorded_by": "treasury-program-manager",
+      "actor_id": "op-treasury-program-manager-1",
       "status": "completed"
     },
     {
@@ -55,6 +62,7 @@
       "previous_status": "in_progress",
       "updated_at": "2026-04-16T12:08:00Z",
       "recorded_by": "treasury-review-chair",
+      "actor_id": "op-treasury-review-chair-1",
       "status": "completed"
     },
     {
@@ -62,6 +70,7 @@
       "previous_status": "in_progress",
       "updated_at": "2026-04-16T12:09:00Z",
       "recorded_by": "treasury-review-chair",
+      "actor_id": "op-treasury-review-chair-1",
       "status": "completed"
     },
     {
@@ -69,6 +78,7 @@
       "previous_status": "in_progress",
       "updated_at": "2026-04-16T12:10:00Z",
       "recorded_by": "treasury-review-chair",
+      "actor_id": "op-treasury-review-chair-1",
       "status": "completed"
     },
     {
@@ -76,6 +86,7 @@
       "previous_status": "pending",
       "updated_at": "2026-04-16T13:00:00Z",
       "recorded_by": "finance-telemetry-lead",
+      "actor_id": "op-finance-telemetry-lead-1",
       "status": "in_progress"
     }
   ]

--- a/internal/project/config.go
+++ b/internal/project/config.go
@@ -8,12 +8,14 @@ import (
 )
 
 type Bundle struct {
-	Root     string
-	Topology TopologyConfig
-	Genesis  GenesisConfig
-	Policy   PolicyConfig
-	Modules  ModulePlanConfig
-	Identity IdentityBootstrapConfig
+	Root              string
+	Topology          TopologyConfig
+	Genesis           GenesisConfig
+	Policy            PolicyConfig
+	Modules           ModulePlanConfig
+	Identity          IdentityBootstrapConfig
+	InferencePolicy   map[string]any
+	CheckpointSigners map[string]any
 }
 
 type TopologyConfig struct {
@@ -210,14 +212,24 @@ func LoadBundle(root string) (Bundle, error) {
 	if err := loadJSON(filepath.Join(resolvedRoot, "config", "identity", "bootstrap.json"), &identity); err != nil {
 		return Bundle{}, err
 	}
+	var inferencePolicy map[string]any
+	if err := loadJSON(filepath.Join(resolvedRoot, "config", "governance", "inference-policy.json"), &inferencePolicy); err != nil {
+		return Bundle{}, err
+	}
+	var checkpointSigners map[string]any
+	if err := loadJSON(filepath.Join(resolvedRoot, "config", "governance", "checkpoint-signers.json"), &checkpointSigners); err != nil {
+		return Bundle{}, err
+	}
 
 	return Bundle{
-		Root:     resolvedRoot,
-		Topology: topology,
-		Genesis:  genesis,
-		Policy:   policy,
-		Modules:  modules,
-		Identity: identity,
+		Root:              resolvedRoot,
+		Topology:          topology,
+		Genesis:           genesis,
+		Policy:            policy,
+		Modules:           modules,
+		Identity:          identity,
+		InferencePolicy:   inferencePolicy,
+		CheckpointSigners: checkpointSigners,
 	}, nil
 }
 

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -29,7 +29,13 @@ func TestLoadBundle(t *testing.T) {
 	if bundle.Identity.Version != "1.0.0" {
 		t.Fatalf("unexpected identity bootstrap version: %s", bundle.Identity.Version)
 	}
-	if len(bundle.Identity.RoleBindings) != 8 {
-		t.Fatalf("expected 8 identity role bindings, got %d", len(bundle.Identity.RoleBindings))
+	if len(bundle.Identity.RoleBindings) != 22 {
+		t.Fatalf("expected 22 identity role bindings, got %d", len(bundle.Identity.RoleBindings))
+	}
+	if len(bundle.CheckpointSigners) == 0 {
+		t.Fatal("expected checkpoint signer policy to be loaded")
+	}
+	if len(bundle.InferencePolicy) == 0 {
+		t.Fatal("expected inference policy to be loaded")
 	}
 }

--- a/internal/project/identity.go
+++ b/internal/project/identity.go
@@ -25,35 +25,79 @@ type IdentityFoundationPlanOutput struct {
 	RolePlan         []IdentityRolePlan    `json:"role_plan"`
 }
 
-func requiredIdentityRoles(modulePlan ModulePlanConfig) (map[string][]string, []string) {
-	roleUsage := make(map[string][]string)
-	appendUsage := func(role string, source string) {
-		for _, existing := range roleUsage[role] {
-			if existing == source {
-				return
-			}
-		}
-		roleUsage[role] = append(roleUsage[role], source)
-		sort.Strings(roleUsage[role])
+func stringMap(value any) map[string]any {
+	if typed, ok := value.(map[string]any); ok {
+		return typed
 	}
+	return map[string]any{}
+}
+
+func stringSlice(value any) []string {
+	raw, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	items := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		text := fmt.Sprint(entry)
+		if text != "" {
+			items = append(items, text)
+		}
+	}
+	return items
+}
+
+func appendIdentityRoleUsage(roleUsage map[string][]string, role string, source string) {
+	if role == "" {
+		return
+	}
+	for _, existing := range roleUsage[role] {
+		if existing == source {
+			return
+		}
+	}
+	roleUsage[role] = append(roleUsage[role], source)
+	sort.Strings(roleUsage[role])
+}
+
+func requiredIdentityRoles(bundle Bundle) (map[string][]string, []string) {
+	roleUsage := make(map[string][]string)
 
 	recordBoundary := func(prefix string, boundary ModuleBoundary) {
 		source := prefix + ":" + boundary.Name
 		for _, tx := range boundary.Transactions {
 			for _, role := range tx.ActorRoles {
-				appendUsage(role, source)
+				appendIdentityRoleUsage(roleUsage, role, source)
 			}
 		}
 		for _, permission := range boundary.OperatorPermissions {
-			appendUsage(permission.Role, source)
+			appendIdentityRoleUsage(roleUsage, permission.Role, source)
 		}
 	}
 
-	for _, boundary := range modulePlan.MVPModules {
+	for _, boundary := range bundle.Modules.MVPModules {
 		recordBoundary("mvp", boundary)
 	}
-	for _, boundary := range modulePlan.DependencySurfaces {
+	for _, boundary := range bundle.Modules.DependencySurfaces {
 		recordBoundary("dependency", boundary)
+	}
+	executionDefaults := stringMap(stringMap(stringMap(bundle.InferencePolicy["remediation"])["execution_defaults"]))
+	for phase, role := range stringMap(executionDefaults["phase_owners"]) {
+		appendIdentityRoleUsage(roleUsage, fmt.Sprint(role), "governance:phase_owner:"+phase)
+	}
+	for proposalKind, override := range stringMap(executionDefaults["owner_overrides"]) {
+		for phase, role := range stringMap(override) {
+			appendIdentityRoleUsage(roleUsage, fmt.Sprint(role), "governance:owner_override:"+proposalKind+":"+phase)
+		}
+	}
+	if rawSigners, ok := bundle.CheckpointSigners["signers"].([]any); ok {
+		for _, rawSigner := range rawSigners {
+			signer := stringMap(rawSigner)
+			signerID := fmt.Sprint(signer["signer_id"])
+			for _, role := range stringSlice(signer["roles"]) {
+				appendIdentityRoleUsage(roleUsage, role, "governance:signer:"+signerID)
+			}
+		}
 	}
 
 	roles := make([]string, 0, len(roleUsage))
@@ -133,8 +177,9 @@ func ValidateIdentityBootstrap(bundle Bundle) error {
 		}
 	}
 
-	roleUsage, requiredRoles := requiredIdentityRoles(bundle.Modules)
+	roleUsage, requiredRoles := requiredIdentityRoles(bundle)
 	boundRoles := make(map[string]struct{})
+	activeActorRoleBindings := make(map[string]struct{})
 	seenBindings := make(map[string]struct{}, len(bundle.Identity.RoleBindings))
 	for _, binding := range bundle.Identity.RoleBindings {
 		if binding.ActorID == "" || binding.Role == "" || binding.Scope == "" || binding.GrantedBy == "" {
@@ -161,11 +206,38 @@ func ValidateIdentityBootstrap(bundle Bundle) error {
 		seenBindings[bindingKey] = struct{}{}
 		if binding.Status == "active" {
 			boundRoles[binding.Role] = struct{}{}
+			activeActorRoleBindings[binding.ActorID+"|"+binding.Role] = struct{}{}
 		}
 	}
 	for _, role := range requiredRoles {
 		if _, exists := boundRoles[role]; !exists {
 			return fmt.Errorf("identity bootstrap missing active binding for required role %s", role)
+		}
+	}
+	if rawSigners, ok := bundle.CheckpointSigners["signers"].([]any); ok {
+		for _, rawSigner := range rawSigners {
+			signer := stringMap(rawSigner)
+			signerID := fmt.Sprint(signer["signer_id"])
+			actorID := fmt.Sprint(signer["actor_id"])
+			if actorID == "" {
+				return fmt.Errorf("checkpoint signer %s must declare actor_id", signerID)
+			}
+			actor, exists := actors[actorID]
+			if !exists {
+				return fmt.Errorf("checkpoint signer %s references unknown actor %s", signerID, actorID)
+			}
+			if actor.Status != "active" {
+				return fmt.Errorf("checkpoint signer %s references inactive actor %s", signerID, actorID)
+			}
+			for _, role := range stringSlice(signer["roles"]) {
+				if _, exists := activeActorRoleBindings[actorID+"|"+role]; !exists {
+					return fmt.Errorf(
+						"checkpoint signer %s role %s is not backed by an active identity binding",
+						signerID,
+						role,
+					)
+				}
+			}
 		}
 	}
 	return nil
@@ -176,7 +248,7 @@ func IdentityFoundationPlan(bundle Bundle) (IdentityFoundationPlanOutput, error)
 		return IdentityFoundationPlanOutput{}, err
 	}
 
-	roleUsage, requiredRoles := requiredIdentityRoles(bundle.Modules)
+	roleUsage, requiredRoles := requiredIdentityRoles(bundle)
 	activeActors := 0
 	for _, actor := range bundle.Identity.Actors {
 		if actor.Status == "active" {

--- a/internal/project/identity_test.go
+++ b/internal/project/identity_test.go
@@ -19,19 +19,20 @@ func TestIdentityFoundationPlan(t *testing.T) {
 	if plan.ChainID != "0ai-assurance-1" {
 		t.Fatalf("unexpected chain id: %s", plan.ChainID)
 	}
-	if plan.ActorCount != 11 {
-		t.Fatalf("expected 11 actors, got %d", plan.ActorCount)
+	if plan.ActorCount != 24 {
+		t.Fatalf("expected 24 actors, got %d", plan.ActorCount)
 	}
-	if plan.ActiveActorCount != 11 {
-		t.Fatalf("expected 11 active actors, got %d", plan.ActiveActorCount)
+	if plan.ActiveActorCount != 24 {
+		t.Fatalf("expected 24 active actors, got %d", plan.ActiveActorCount)
 	}
-	if len(plan.RequiredRoles) != 8 {
-		t.Fatalf("expected 8 required roles, got %d", len(plan.RequiredRoles))
+	if len(plan.RequiredRoles) != 22 {
+		t.Fatalf("expected 22 required roles, got %d", len(plan.RequiredRoles))
 	}
 	if len(plan.MissingRoles) != 0 {
 		t.Fatalf("expected no missing roles, got %v", plan.MissingRoles)
 	}
 	foundNetworkAdmin := false
+	foundTreasuryProgramManager := false
 	for _, role := range plan.RolePlan {
 		if role.Role == "network_admin" {
 			foundNetworkAdmin = true
@@ -39,8 +40,17 @@ func TestIdentityFoundationPlan(t *testing.T) {
 				t.Fatalf("unexpected network_admin binding: %+v", role)
 			}
 		}
+		if role.Role == "treasury-program-manager" {
+			foundTreasuryProgramManager = true
+			if len(role.BoundActors) != 1 || role.BoundActors[0] != "op-treasury-program-manager-1" {
+				t.Fatalf("unexpected treasury-program-manager binding: %+v", role)
+			}
+		}
 	}
 	if !foundNetworkAdmin {
 		t.Fatal("expected network_admin role plan entry")
+	}
+	if !foundTreasuryProgramManager {
+		t.Fatal("expected treasury-program-manager role plan entry")
 	}
 }

--- a/src/assurancectl/cli.py
+++ b/src/assurancectl/cli.py
@@ -21,6 +21,7 @@ from .inference import (
     load_proposal,
     load_registry,
     replay_checkpoint_state,
+    resolve_identity_actor_ref,
 )
 
 
@@ -210,7 +211,21 @@ def _governance_trends_payload(trends) -> list[dict[str, object]]:
     ]
 
 
-def _governance_replay_payload(replay) -> dict[str, object]:
+def _actor_ref_payload(actor) -> dict[str, object] | None:
+    if actor is None:
+        return None
+    return {
+        "actor_id": actor.actor_id,
+        "display_name": actor.display_name,
+        "actor_type": actor.actor_type,
+        "organization_id": actor.organization_id,
+        "organization_display_name": actor.organization_display_name,
+        "role": actor.role,
+        "scopes": actor.scopes,
+    }
+
+
+def _governance_replay_payload(replay, identity_bootstrap) -> dict[str, object]:
     return {
         "source_kind": replay.source_kind,
         "replay_event_count": replay.replay_event_count,
@@ -222,6 +237,14 @@ def _governance_replay_payload(replay) -> dict[str, object]:
                 "previous_status": checkpoint_state.get("previous_status"),
                 "updated_at": checkpoint_state.get("updated_at"),
                 "recorded_by": checkpoint_state.get("recorded_by"),
+                "actor_id": checkpoint_state.get("actor_id"),
+                "actor": _actor_ref_payload(
+                    resolve_identity_actor_ref(
+                        identity_bootstrap,
+                        checkpoint_state.get("actor_id"),
+                        checkpoint_state.get("recorded_by"),
+                    )
+                ),
                 "status": checkpoint_state.get("status"),
             }
             for checkpoint_id, checkpoint_state in sorted(replay.checkpoints.items())
@@ -260,11 +283,14 @@ def _governance_remediation_payload(plans) -> list[dict[str, object]]:
                     "phase": checkpoint.phase,
                     "phase_order": checkpoint.phase_order,
                     "owner_role": checkpoint.owner_role,
+                    "eligible_actors": [_actor_ref_payload(actor) for actor in checkpoint.eligible_actors],
                     "title": checkpoint.title,
                     "blocking": checkpoint.blocking,
                     "previous_status": checkpoint.previous_status,
                     "updated_at": checkpoint.updated_at,
                     "recorded_by": checkpoint.recorded_by,
+                    "actor_id": checkpoint.actor_id,
+                    "assigned_actor": _actor_ref_payload(checkpoint.assigned_actor),
                     "status": checkpoint.status,
                     "transition_valid": checkpoint.transition_valid,
                     "transition_note": checkpoint.transition_note,
@@ -413,8 +439,8 @@ def _print_governance_trends(trends, emit_json: bool) -> None:
         print(f"   summary: {trend.summary}")
 
 
-def _print_governance_replay(replay, emit_json: bool) -> None:
-    payload = _governance_replay_payload(replay)
+def _print_governance_replay(replay, identity_bootstrap, emit_json: bool) -> None:
+    payload = _governance_replay_payload(replay, identity_bootstrap)
     if emit_json:
         print(json.dumps(payload, indent=2))
         return
@@ -627,6 +653,7 @@ def main(argv: list[str] | None = None) -> int:
             policy=policy,
             checkpoint_statuses=checkpoint_statuses,
             signature_policy=signer_policy,
+            identity_bootstrap=config.identity_bootstrap,
         )
         sources = {"registry": args.registry, "history": args.history}
         if args.status:
@@ -648,15 +675,19 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "governance-replay":
         checkpoint_statuses = load_checkpoint_statuses(args.status)
         signer_policy = load_checkpoint_signer_policy(config)
-        replay = replay_checkpoint_state(checkpoint_statuses, signature_policy=signer_policy)
+        replay = replay_checkpoint_state(
+            checkpoint_statuses,
+            signature_policy=signer_policy,
+            identity_bootstrap=config.identity_bootstrap,
+        )
         _maybe_write_artifact(
             path=args.artifact_out,
             artifact_type="governance_replay",
             command=args.command,
-            payload=_governance_replay_payload(replay),
+            payload=_governance_replay_payload(replay, config.identity_bootstrap),
             sources={"status": args.status},
         )
-        _print_governance_replay(replay, emit_json=args.json)
+        _print_governance_replay(replay, config.identity_bootstrap, emit_json=args.json)
         return 0 if replay.invalid_event_count == 0 else 2
 
     if args.command == "governance-drift":

--- a/src/assurancectl/config.py
+++ b/src/assurancectl/config.py
@@ -20,6 +20,7 @@ class LoadedConfig:
     topology: dict[str, Any]
     genesis: dict[str, Any]
     policy: dict[str, Any]
+    inference_policy: dict[str, Any]
     checkpoint_signers: dict[str, Any]
     module_plan: dict[str, Any]
     identity_bootstrap: dict[str, Any]
@@ -44,6 +45,7 @@ def load_config(explicit_root: str | Path | None = None) -> LoadedConfig:
         topology=_load_json(config / "network-topology.json"),
         genesis=_load_json(config / "genesis" / "base-genesis.json"),
         policy=_load_json(config / "policy" / "release-guards.json"),
+        inference_policy=_load_json(config / "governance" / "inference-policy.json"),
         checkpoint_signers=_load_json(config / "governance" / "checkpoint-signers.json"),
         module_plan=_load_json(config / "modules" / "milestone-1.json"),
         identity_bootstrap=_load_json(config / "identity" / "bootstrap.json"),
@@ -146,10 +148,12 @@ def validate_checkpoint_signers(checkpoint_signers: dict[str, Any]) -> None:
     key_ids: set[str] = set()
     role_bindings: set[str] = set()
     for signer in signers:
+        actor_id = str(signer.get("actor_id", ""))
         signer_id = str(signer["signer_id"])
         key_id = str(signer["key_id"])
         shared_secret = str(signer["shared_secret"])
         roles = [str(role) for role in signer["roles"]]
+        _assert(actor_id != "", f"checkpoint signer {signer_id} must declare an actor_id")
         _assert(signer_id not in signer_ids, f"duplicate checkpoint signer_id: {signer_id}")
         _assert(key_id not in key_ids, f"duplicate checkpoint key_id: {key_id}")
         _assert(shared_secret != "", f"checkpoint signer {signer_id} must declare a shared_secret")
@@ -223,7 +227,41 @@ def _required_identity_roles(module_plan: dict[str, Any]) -> set[str]:
     return required
 
 
-def validate_identity_bootstrap(identity_bootstrap: dict[str, Any], module_plan: dict[str, Any], topology: dict[str, Any]) -> None:
+def _required_governance_identity_roles(
+    inference_policy: dict[str, Any],
+    checkpoint_signers: dict[str, Any],
+) -> set[str]:
+    required: set[str] = set()
+    execution_defaults = (
+        inference_policy.get("remediation", {})
+        .get("execution_defaults", {})
+    )
+    required.update(str(role) for role in execution_defaults.get("phase_owners", {}).values())
+    for override in execution_defaults.get("owner_overrides", {}).values():
+        required.update(str(role) for role in override.values())
+    for signer in checkpoint_signers.get("signers", []):
+        required.update(str(role) for role in signer.get("roles", []))
+    return {role for role in required if role}
+
+
+def _allowed_identity_roles(
+    module_plan: dict[str, Any],
+    inference_policy: dict[str, Any],
+    checkpoint_signers: dict[str, Any],
+) -> set[str]:
+    return (
+        _required_identity_roles(module_plan)
+        | _required_governance_identity_roles(inference_policy, checkpoint_signers)
+    )
+
+
+def validate_identity_bootstrap(
+    identity_bootstrap: dict[str, Any],
+    module_plan: dict[str, Any],
+    topology: dict[str, Any],
+    inference_policy: dict[str, Any],
+    checkpoint_signers: dict[str, Any],
+) -> None:
     _assert(identity_bootstrap["version"] != "", "identity bootstrap version must be set")
     _assert(identity_bootstrap["chain_id"] == topology["chain_id"], "identity bootstrap chain id must match topology")
 
@@ -254,9 +292,10 @@ def validate_identity_bootstrap(identity_bootstrap: dict[str, Any], module_plan:
             f"identity actor {actor['actor_id']} organization must be organization or council",
         )
 
-    required_roles = _required_identity_roles(module_plan)
+    required_roles = _allowed_identity_roles(module_plan, inference_policy, checkpoint_signers)
     seen_bindings: set[str] = set()
     active_roles: set[str] = set()
+    active_actor_role_bindings: set[str] = set()
     for binding in role_bindings:
         actor_id = str(binding["actor_id"])
         role = str(binding["role"])
@@ -273,9 +312,22 @@ def validate_identity_bootstrap(identity_bootstrap: dict[str, Any], module_plan:
         seen_bindings.add(binding_key)
         if status == "active":
             active_roles.add(role)
+            active_actor_role_bindings.add(f"{actor_id}|{role}")
 
     missing_roles = sorted(required_roles - active_roles)
     _assert(not missing_roles, f"identity bootstrap missing active bindings for roles: {', '.join(missing_roles)}")
+    for signer in checkpoint_signers["signers"]:
+        actor_id = str(signer["actor_id"])
+        signer_id = str(signer["signer_id"])
+        _assert(actor_id in actors_by_id, f"checkpoint signer {signer_id} references unknown actor {actor_id}")
+        actor = actors_by_id[actor_id]
+        _assert(actor["status"] == "active", f"checkpoint signer {signer_id} references inactive actor {actor_id}")
+        for role in signer["roles"]:
+            binding_key = f"{actor_id}|{role}"
+            _assert(
+                binding_key in active_actor_role_bindings,
+                f"checkpoint signer {signer_id} role {role} is not backed by an active identity binding",
+            )
 
 
 def validate_all(config: LoadedConfig) -> None:
@@ -284,4 +336,10 @@ def validate_all(config: LoadedConfig) -> None:
     validate_policy(config.policy)
     validate_checkpoint_signers(config.checkpoint_signers)
     validate_module_plan(config.module_plan)
-    validate_identity_bootstrap(config.identity_bootstrap, config.module_plan, config.topology)
+    validate_identity_bootstrap(
+        config.identity_bootstrap,
+        config.module_plan,
+        config.topology,
+        config.inference_policy,
+        config.checkpoint_signers,
+    )

--- a/src/assurancectl/inference.py
+++ b/src/assurancectl/inference.py
@@ -121,11 +121,14 @@ class GovernanceRemediationCheckpoint:
     phase: str
     phase_order: int
     owner_role: str
+    eligible_actors: list[GovernanceIdentityActorRef]
     title: str
     blocking: bool
     previous_status: str | None
     updated_at: str | None
     recorded_by: str | None
+    actor_id: str | None
+    assigned_actor: GovernanceIdentityActorRef | None
     status: str
     transition_valid: bool
     transition_note: str | None
@@ -143,6 +146,17 @@ class GovernanceCheckpointReplay:
     invalid_event_count: int
     event_alerts: list[str]
     checkpoints: dict[str, dict[str, str | None]]
+
+
+@dataclass(frozen=True)
+class GovernanceIdentityActorRef:
+    actor_id: str
+    display_name: str
+    actor_type: str
+    organization_id: str | None
+    organization_display_name: str | None
+    role: str
+    scopes: list[str]
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -172,6 +186,116 @@ def load_history(path: str | Path) -> dict[str, Any]:
 
 def load_checkpoint_statuses(path: str | Path) -> dict[str, Any]:
     return _load_json(Path(path))
+
+
+def _identity_actor_indexes(
+    identity_bootstrap: dict[str, Any] | None,
+) -> tuple[dict[str, dict[str, Any]], dict[tuple[str, str], list[str]]]:
+    actors_by_id: dict[str, dict[str, Any]] = {}
+    actor_role_scopes: dict[tuple[str, str], list[str]] = {}
+    if not identity_bootstrap:
+        return actors_by_id, actor_role_scopes
+    for actor in identity_bootstrap.get("actors", []):
+        actor_id = str(actor.get("actor_id", "")).strip()
+        if actor_id:
+            actors_by_id[actor_id] = dict(actor)
+    for binding in identity_bootstrap.get("role_bindings", []):
+        if str(binding.get("status", "")).strip() != "active":
+            continue
+        actor_id = str(binding.get("actor_id", "")).strip()
+        role = str(binding.get("role", "")).strip()
+        scope = str(binding.get("scope", "")).strip()
+        if not actor_id or not role or not scope:
+            continue
+        actor_role_scopes.setdefault((actor_id, role), [])
+        if scope not in actor_role_scopes[(actor_id, role)]:
+            actor_role_scopes[(actor_id, role)].append(scope)
+    for scopes in actor_role_scopes.values():
+        scopes.sort()
+    return actors_by_id, actor_role_scopes
+
+
+def resolve_identity_actor_ref(
+    identity_bootstrap: dict[str, Any] | None,
+    actor_id: str | None,
+    role: str | None,
+) -> GovernanceIdentityActorRef | None:
+    if not identity_bootstrap or not actor_id or not role:
+        return None
+    actors_by_id, actor_role_scopes = _identity_actor_indexes(identity_bootstrap)
+    actor = actors_by_id.get(actor_id)
+    if actor is None or str(actor.get("status", "")).strip() != "active":
+        return None
+    scopes = actor_role_scopes.get((actor_id, role), [])
+    if not scopes:
+        return None
+    organization_id = str(actor.get("organization_id", "")).strip() or None
+    organization_display_name = None
+    if organization_id:
+        organization = actors_by_id.get(organization_id)
+        if organization is not None:
+            organization_display_name = str(organization.get("display_name", "")).strip() or None
+    return GovernanceIdentityActorRef(
+        actor_id=actor_id,
+        display_name=str(actor.get("display_name", "")).strip(),
+        actor_type=str(actor.get("actor_type", "")).strip(),
+        organization_id=organization_id,
+        organization_display_name=organization_display_name,
+        role=role,
+        scopes=list(scopes),
+    )
+
+
+def resolve_role_actor_refs(
+    identity_bootstrap: dict[str, Any] | None,
+    role: str,
+) -> list[GovernanceIdentityActorRef]:
+    actors_by_id, actor_role_scopes = _identity_actor_indexes(identity_bootstrap)
+    refs: list[GovernanceIdentityActorRef] = []
+    for (actor_id, bound_role), scopes in sorted(actor_role_scopes.items()):
+        if bound_role != role:
+            continue
+        actor = actors_by_id.get(actor_id)
+        if actor is None or str(actor.get("status", "")).strip() != "active":
+            continue
+        organization_id = str(actor.get("organization_id", "")).strip() or None
+        organization_display_name = None
+        if organization_id:
+            organization = actors_by_id.get(organization_id)
+            if organization is not None:
+                organization_display_name = str(organization.get("display_name", "")).strip() or None
+        refs.append(
+            GovernanceIdentityActorRef(
+                actor_id=actor_id,
+                display_name=str(actor.get("display_name", "")).strip(),
+                actor_type=str(actor.get("actor_type", "")).strip(),
+                organization_id=organization_id,
+                organization_display_name=organization_display_name,
+                role=role,
+                scopes=list(scopes),
+            )
+        )
+    return refs
+
+
+def validate_identity_actor_role_assignment(
+    *,
+    identity_bootstrap: dict[str, Any] | None,
+    actor_id: str | None,
+    role: str | None,
+    context: str,
+) -> str | None:
+    if not identity_bootstrap or not actor_id or not role:
+        return None
+    actors_by_id, actor_role_scopes = _identity_actor_indexes(identity_bootstrap)
+    actor = actors_by_id.get(actor_id)
+    if actor is None:
+        return f"{context}: unknown actor_id {actor_id}."
+    if str(actor.get("status", "")).strip() != "active":
+        return f"{context}: actor {actor_id} is not active."
+    if (actor_id, role) not in actor_role_scopes:
+        return f"{context}: actor {actor_id} is not actively bound to role {role}."
+    return None
 
 
 def _contains_any(text: str, keywords: list[str]) -> bool:
@@ -211,6 +335,7 @@ def replay_checkpoint_state(
     statuses: dict[str, Any] | None,
     *,
     signature_policy: dict[str, Any] | None = None,
+    identity_bootstrap: dict[str, Any] | None = None,
 ) -> GovernanceCheckpointReplay:
     if not statuses:
         return GovernanceCheckpointReplay(
@@ -225,7 +350,11 @@ def replay_checkpoint_state(
     raw_events = statuses.get("events")
     if has_events_key:
         if isinstance(raw_events, list):
-            return _replay_checkpoint_events(raw_events, signature_policy=signature_policy)
+            return _replay_checkpoint_events(
+                raw_events,
+                signature_policy=signature_policy,
+                identity_bootstrap=identity_bootstrap,
+            )
         return GovernanceCheckpointReplay(
             source_kind="event_log",
             replay_event_count=0,
@@ -244,6 +373,7 @@ def replay_checkpoint_state(
                 "previous_status": None,
                 "updated_at": None,
                 "recorded_by": None,
+                "actor_id": None,
                 "status": status_name if status_name in allowed_statuses else "pending",
             }
         return GovernanceCheckpointReplay(
@@ -275,6 +405,11 @@ def replay_checkpoint_state(
                     if entry.get("recorded_by") is not None and str(entry.get("recorded_by")).strip()
                     else None
                 ),
+                "actor_id": (
+                    str(entry.get("actor_id")).strip()
+                    if entry.get("actor_id") is not None and str(entry.get("actor_id")).strip()
+                    else None
+                ),
                 "status": status if status in allowed_statuses else "pending",
             }
     return GovernanceCheckpointReplay(
@@ -293,6 +428,7 @@ def _build_checkpoint_signature_message(
     new_status: str,
     updated_at: str,
     recorded_by: str,
+    actor_id: str,
     rationale: str,
     signature_meta: dict[str, str],
 ) -> str:
@@ -302,6 +438,7 @@ def _build_checkpoint_signature_message(
         "new_status": new_status,
         "updated_at": updated_at,
         "recorded_by": recorded_by,
+        "actor_id": actor_id,
         "rationale": rationale,
         "signature": signature_meta,
     }
@@ -316,9 +453,11 @@ def _validate_signed_checkpoint_event(
     new_status: str,
     updated_at: str,
     recorded_by: str,
+    actor_id: str,
     rationale: str,
     raw_signature: Any,
     signature_policy: dict[str, Any] | None,
+    identity_bootstrap: dict[str, Any] | None,
     seen_signature_ids: set[str],
 ) -> str | None:
     if not signature_policy or not signature_policy.get("require_signatures_for_event_logs", False):
@@ -372,12 +511,28 @@ def _validate_signed_checkpoint_event(
     )
     if signer_entry is None:
         return f"Event {event_index} ({checkpoint_id}): unknown signer_id/key_id pair."
+    signer_actor_id = str(signer_entry.get("actor_id", "")).strip()
+    if not signer_actor_id:
+        return f"Event {event_index} ({checkpoint_id}): signer {signer_id} is missing actor_id."
+    if signer_actor_id != actor_id:
+        return (
+            f"Event {event_index} ({checkpoint_id}): signer {signer_id} actor {signer_actor_id} "
+            f"does not match event actor_id {actor_id}."
+        )
 
     signer_roles = [str(role).strip() for role in signer_entry.get("roles", [])]
     if recorded_by not in signer_roles:
         return (
             f"Event {event_index} ({checkpoint_id}): signer {signer_id} is not authorized for role {recorded_by}."
         )
+    identity_error = validate_identity_actor_role_assignment(
+        identity_bootstrap=identity_bootstrap,
+        actor_id=actor_id,
+        role=recorded_by,
+        context=f"Event {event_index} ({checkpoint_id})",
+    )
+    if identity_error:
+        return identity_error
 
     signature_meta = {
         "format": signature_format,
@@ -393,6 +548,7 @@ def _validate_signed_checkpoint_event(
         new_status=new_status,
         updated_at=updated_at,
         recorded_by=recorded_by,
+        actor_id=actor_id,
         rationale=rationale,
         signature_meta=signature_meta,
     )
@@ -409,6 +565,7 @@ def _replay_checkpoint_events(
     events: list[Any],
     *,
     signature_policy: dict[str, Any] | None = None,
+    identity_bootstrap: dict[str, Any] | None = None,
 ) -> GovernanceCheckpointReplay:
     allowed_statuses = {"pending", "in_progress", "completed"}
     allowed_transitions = {
@@ -438,6 +595,7 @@ def _replay_checkpoint_events(
         new_name = str(new_status).strip().lower() if new_status is not None else ""
         updated_at = str(raw_event.get("updated_at")).strip() if raw_event.get("updated_at") is not None else None
         recorded_by = str(raw_event.get("recorded_by")).strip() if raw_event.get("recorded_by") is not None else None
+        actor_id = str(raw_event.get("actor_id")).strip() if raw_event.get("actor_id") is not None else None
         rationale = str(raw_event.get("rationale")).strip() if raw_event.get("rationale") is not None else None
 
         if previous_name not in allowed_statuses:
@@ -468,6 +626,9 @@ def _replay_checkpoint_events(
         if not recorded_by:
             event_alerts.append(f"Event {index} ({checkpoint_id}): missing recorded_by.")
             continue
+        if not actor_id:
+            event_alerts.append(f"Event {index} ({checkpoint_id}): missing actor_id.")
+            continue
         if not rationale:
             event_alerts.append(f"Event {index} ({checkpoint_id}): missing rationale.")
             continue
@@ -478,9 +639,11 @@ def _replay_checkpoint_events(
             new_status=new_name,
             updated_at=updated_at,
             recorded_by=recorded_by,
+            actor_id=actor_id,
             rationale=rationale,
             raw_signature=raw_event.get("signature"),
             signature_policy=signature_policy,
+            identity_bootstrap=identity_bootstrap,
             seen_signature_ids=seen_signature_ids,
         )
         if signature_error:
@@ -507,6 +670,7 @@ def _replay_checkpoint_events(
             "previous_status": previous_name,
             "updated_at": updated_at,
             "recorded_by": recorded_by,
+            "actor_id": actor_id,
             "status": new_name,
         }
         replayed_timestamps[checkpoint_id] = parsed_timestamp
@@ -541,17 +705,23 @@ def _validate_checkpoint_audit(
     status: str,
     updated_at: str | None,
     recorded_by: str | None,
+    actor_id: str | None,
     expected_owner_role: str,
     require_actor_for_non_pending: bool,
     require_timestamp_for_non_pending: bool,
+    identity_bootstrap: dict[str, Any] | None,
 ) -> tuple[bool, str | None, datetime | None]:
     parsed_timestamp = _parse_timestamp(updated_at)
     if updated_at is not None and parsed_timestamp is None:
         return False, f"Invalid checkpoint updated_at timestamp: {updated_at}", None
 
     if status != "pending":
-        if require_actor_for_non_pending and not recorded_by:
-            return False, "Non-pending checkpoint updates must include recorded_by for audit attribution.", parsed_timestamp
+        if require_actor_for_non_pending and (not recorded_by or not actor_id):
+            return (
+                False,
+                "Non-pending checkpoint updates must include recorded_by and actor_id for audit attribution.",
+                parsed_timestamp,
+            )
         if require_timestamp_for_non_pending and not updated_at:
             return False, "Non-pending checkpoint updates must include updated_at for audit ordering.", parsed_timestamp
         if recorded_by and recorded_by != expected_owner_role:
@@ -560,6 +730,14 @@ def _validate_checkpoint_audit(
                 f"Checkpoint actor role mismatch: expected {expected_owner_role}, received {recorded_by}.",
                 parsed_timestamp,
             )
+        identity_error = validate_identity_actor_role_assignment(
+            identity_bootstrap=identity_bootstrap,
+            actor_id=actor_id,
+            role=recorded_by,
+            context="Checkpoint audit",
+        )
+        if identity_error:
+            return False, identity_error, parsed_timestamp
 
     return True, None, parsed_timestamp
 
@@ -1163,6 +1341,7 @@ def infer_governance_remediation_plans(
     policy: dict[str, Any] | None = None,
     checkpoint_statuses: dict[str, Any] | None = None,
     signature_policy: dict[str, Any] | None = None,
+    identity_bootstrap: dict[str, Any] | None = None,
 ) -> list[GovernanceRemediationPlan]:
     remediation_policy = (policy or {}).get("remediation", {})
     severity_actions = remediation_policy.get("severity_actions", {})
@@ -1180,7 +1359,11 @@ def infer_governance_remediation_plans(
     require_actor_for_non_pending = bool(audit_requirements.get("require_actor_for_non_pending", True))
     require_timestamp_for_non_pending = bool(audit_requirements.get("require_timestamp_for_non_pending", True))
     enforce_dependency_timestamp_order = bool(audit_requirements.get("enforce_dependency_timestamp_order", True))
-    checkpoint_replay = replay_checkpoint_state(checkpoint_statuses, signature_policy=signature_policy)
+    checkpoint_replay = replay_checkpoint_state(
+        checkpoint_statuses,
+        signature_policy=signature_policy,
+        identity_bootstrap=identity_bootstrap,
+    )
     normalized_statuses = checkpoint_replay.checkpoints
 
     cluster_entries: dict[str, list[GovernanceQueueEntry]] = {}
@@ -1310,7 +1493,13 @@ def infer_governance_remediation_plans(
             checkpoint_id = str(raw_checkpoint["checkpoint_id"])
             checkpoint_state = normalized_statuses.get(
                 checkpoint_id,
-                {"previous_status": None, "updated_at": None, "recorded_by": None, "status": "pending"},
+                {
+                    "previous_status": None,
+                    "updated_at": None,
+                    "recorded_by": None,
+                    "actor_id": None,
+                    "status": "pending",
+                },
             )
             previous_status = (
                 str(checkpoint_state.get("previous_status"))
@@ -1327,7 +1516,14 @@ def infer_governance_remediation_plans(
                 if checkpoint_state.get("recorded_by") is not None
                 else None
             )
+            actor_id = (
+                str(checkpoint_state.get("actor_id"))
+                if checkpoint_state.get("actor_id") is not None
+                else None
+            )
             status = str(checkpoint_state.get("status", "pending"))
+            eligible_actors = resolve_role_actor_refs(identity_bootstrap, str(raw_checkpoint["owner_role"]))
+            assigned_actor = resolve_identity_actor_ref(identity_bootstrap, actor_id, recorded_by)
             transition_valid, transition_note = _validate_checkpoint_transition(
                 previous_status,
                 status,
@@ -1339,9 +1535,11 @@ def infer_governance_remediation_plans(
                 status=status,
                 updated_at=updated_at,
                 recorded_by=recorded_by,
+                actor_id=actor_id,
                 expected_owner_role=str(raw_checkpoint["owner_role"]),
                 require_actor_for_non_pending=require_actor_for_non_pending,
                 require_timestamp_for_non_pending=require_timestamp_for_non_pending,
+                identity_bootstrap=identity_bootstrap,
             )
             if not audit_valid and audit_note and audit_note not in audit_alerts:
                 audit_alerts.append(audit_note)
@@ -1356,11 +1554,14 @@ def infer_governance_remediation_plans(
                     phase=str(raw_checkpoint["phase"]),
                     phase_order=int(raw_checkpoint["phase_order"]),
                     owner_role=str(raw_checkpoint["owner_role"]),
+                    eligible_actors=eligible_actors,
                     title=str(raw_checkpoint["title"]),
                     blocking=bool(raw_checkpoint["blocking"]),
                     previous_status=previous_status,
                     updated_at=updated_at,
                     recorded_by=recorded_by,
+                    actor_id=actor_id,
+                    assigned_actor=assigned_actor,
                     status=status,
                     transition_valid=transition_valid,
                     transition_note=transition_note,

--- a/tests/test_assurancectl.py
+++ b/tests/test_assurancectl.py
@@ -42,6 +42,7 @@ class AssuranceCtlTests(unittest.TestCase):
         rationale: str,
         signature_id: str,
         signer_id: str | None = None,
+        actor_id: str | None = None,
     ) -> dict[str, object]:
         signer_policy = self.load_checkpoint_signer_policy()
         signers = signer_policy["signers"]
@@ -57,6 +58,7 @@ class AssuranceCtlTests(unittest.TestCase):
             "signed_at": "2026-04-16T10:00:00Z",
             "expires_at": "2026-04-17T10:00:00Z",
         }
+        resolved_actor_id = actor_id or str(signer_entry["actor_id"])
         message = json.dumps(
             {
                 "checkpoint_id": checkpoint_id,
@@ -64,6 +66,7 @@ class AssuranceCtlTests(unittest.TestCase):
                 "new_status": new_status,
                 "updated_at": updated_at,
                 "recorded_by": recorded_by,
+                "actor_id": resolved_actor_id,
                 "rationale": rationale,
                 "signature": signature_meta,
             },
@@ -81,6 +84,7 @@ class AssuranceCtlTests(unittest.TestCase):
             "new_status": new_status,
             "updated_at": updated_at,
             "recorded_by": recorded_by,
+            "actor_id": resolved_actor_id,
             "rationale": rationale,
             "signature": {
                 **signature_meta,
@@ -167,6 +171,7 @@ class AssuranceCtlTests(unittest.TestCase):
                 ("config/network-topology.json", "config/network-topology.json"),
                 ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
                 ("config/policy/release-guards.json", "config/policy/release-guards.json"),
+                ("config/governance/inference-policy.json", "config/governance/inference-policy.json"),
                 ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
                 ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
                 ("config/identity/bootstrap.json", "config/identity/bootstrap.json"),
@@ -196,6 +201,7 @@ class AssuranceCtlTests(unittest.TestCase):
                 ("config/network-topology.json", "config/network-topology.json"),
                 ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
                 ("config/policy/release-guards.json", "config/policy/release-guards.json"),
+                ("config/governance/inference-policy.json", "config/governance/inference-policy.json"),
                 ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
                 ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
                 ("config/identity/bootstrap.json", "config/identity/bootstrap.json"),
@@ -233,6 +239,7 @@ class AssuranceCtlTests(unittest.TestCase):
                 ("config/network-topology.json", "config/network-topology.json"),
                 ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
                 ("config/policy/release-guards.json", "config/policy/release-guards.json"),
+                ("config/governance/inference-policy.json", "config/governance/inference-policy.json"),
                 ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
                 ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
                 ("config/identity/bootstrap.json", "config/identity/bootstrap.json"),
@@ -258,6 +265,44 @@ class AssuranceCtlTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
             self.assertIn("duplicate identity role binding", result.stderr)
+
+    def test_validate_fails_when_checkpoint_signer_actor_binding_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for source, target in (
+                ("config/network-topology.json", "config/network-topology.json"),
+                ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
+                ("config/policy/release-guards.json", "config/policy/release-guards.json"),
+                ("config/governance/inference-policy.json", "config/governance/inference-policy.json"),
+                ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
+                ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
+                ("config/identity/bootstrap.json", "config/identity/bootstrap.json"),
+            ):
+                target_path = root / target
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                target_path.write_text((PROJECT_ROOT / source).read_text(encoding="utf-8"), encoding="utf-8")
+
+            identity_path = root / "config" / "identity" / "bootstrap.json"
+            identity_payload = json.loads(identity_path.read_text(encoding="utf-8"))
+            identity_payload["role_bindings"] = [
+                binding
+                for binding in identity_payload["role_bindings"]
+                if binding["role"] != "treasury-program-manager"
+            ]
+            identity_path.write_text(json.dumps(identity_payload), encoding="utf-8")
+
+            env = {"PYTHONPATH": PYTHONPATH}
+            result = subprocess.run(
+                [sys.executable, "-m", "assurancectl.cli", "--root", str(root), "validate"],
+                cwd=PROJECT_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("identity bootstrap missing active bindings for roles: treasury-program-manager", result.stderr)
 
     def test_governance_sim_treasury_grant(self) -> None:
         result = self.run_cli(
@@ -633,6 +678,19 @@ class AssuranceCtlTests(unittest.TestCase):
                             )
                         )
                     ),
+                    "actor_id": (
+                        "op-treasury-program-manager-1"
+                        if checkpoint["phase"] == "immediate_action"
+                        else (
+                            "op-treasury-review-chair-1"
+                            if checkpoint["phase"] == "approval_guardrail"
+                            else (
+                                "op-finance-telemetry-lead-1"
+                                if checkpoint["phase"] == "monitoring" and index == len(treasury["checkpoints"]) - 1
+                                else None
+                            )
+                        )
+                    ),
                     "status": (
                         "completed"
                         if checkpoint["phase"] in {"immediate_action", "approval_guardrail"}
@@ -667,6 +725,20 @@ class AssuranceCtlTests(unittest.TestCase):
         self.assertEqual(treasury_updated["checkpoint_status_counts"]["pending"], 1)
         self.assertEqual(treasury_updated["invalid_transition_count"], 0)
         self.assertEqual(treasury_updated["invalid_audit_count"], 0)
+        immediate_action = next(
+            checkpoint
+            for checkpoint in treasury_updated["checkpoints"]
+            if checkpoint["phase"] == "immediate_action"
+        )
+        self.assertTrue(immediate_action["eligible_actors"])
+        self.assertEqual(immediate_action["eligible_actors"][0]["actor_id"], "op-treasury-program-manager-1")
+        monitoring_checkpoint = next(
+            checkpoint
+            for checkpoint in treasury_updated["checkpoints"]
+            if checkpoint["checkpoint_id"] == "treasury-grant-0ai-core-monitoring-1"
+        )
+        self.assertEqual(monitoring_checkpoint["actor_id"], "op-finance-telemetry-lead-1")
+        self.assertEqual(monitoring_checkpoint["assigned_actor"]["display_name"], "Finance Telemetry Lead 1")
         self.assertTrue(
             all(
                 checkpoint["ready_to_start"]
@@ -706,6 +778,8 @@ class AssuranceCtlTests(unittest.TestCase):
         )
         self.assertEqual(monitoring["status"], "in_progress")
         self.assertEqual(monitoring["recorded_by"], "finance-telemetry-lead")
+        self.assertEqual(monitoring["actor_id"], "op-finance-telemetry-lead-1")
+        self.assertEqual(monitoring["actor"]["display_name"], "Finance Telemetry Lead 1")
 
     def test_governance_replay_rejects_duplicate_events(self) -> None:
         duplicate_payload = {
@@ -827,6 +901,33 @@ class AssuranceCtlTests(unittest.TestCase):
         self.assertEqual(payload["source_kind"], "event_log")
         self.assertEqual(payload["invalid_event_count"], 1)
         self.assertIn("is not authorized for role treasury-program-manager", payload["event_alerts"][0])
+
+    def test_governance_replay_rejects_signer_actor_mismatch(self) -> None:
+        mismatched_actor_payload = {
+            "version": "checkpoint-event-log-actor-mismatch-test",
+            "events": [
+                self.build_signed_event(
+                    checkpoint_id="treasury-grant-0ai-core-immediate_action-1",
+                    previous_status="pending",
+                    new_status="in_progress",
+                    updated_at="2026-04-16T11:01:00Z",
+                    recorded_by="treasury-program-manager",
+                    actor_id="op-treasury-review-chair-1",
+                    rationale="Actor mismatch should be rejected.",
+                    signature_id="actor-mismatch-1",
+                )
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            event_path = Path(tmpdir) / "events-actor-mismatch.json"
+            event_path.write_text(json.dumps(mismatched_actor_payload), encoding="utf-8")
+            result = self.run_cli("governance-replay", "--status", str(event_path), "--json")
+
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["invalid_event_count"], 1)
+        self.assertIn("does not match event actor_id", payload["event_alerts"][0])
 
     def test_governance_replay_rejects_signature_replay_attempt(self) -> None:
         replayed_signature_payload = {
@@ -978,6 +1079,7 @@ class AssuranceCtlTests(unittest.TestCase):
                     "previous_status": "pending",
                     "updated_at": "2026-04-16T12:00:00Z",
                     "recorded_by": "treasury-program-manager",
+                    "actor_id": "op-treasury-program-manager-1",
                     "status": "completed",
                 }
             ],
@@ -1034,6 +1136,7 @@ class AssuranceCtlTests(unittest.TestCase):
                         "previous_status": "in_progress",
                         "updated_at": f"2026-04-16T12:{index:02d}:00Z",
                         "recorded_by": "treasury-program-manager",
+                        "actor_id": "op-treasury-program-manager-1",
                         "status": "completed",
                     }
                 )
@@ -1045,6 +1148,7 @@ class AssuranceCtlTests(unittest.TestCase):
                         "previous_status": "in_progress",
                         "updated_at": "2026-04-16T12:01:00Z",
                         "recorded_by": "treasury-review-chair",
+                        "actor_id": "op-treasury-review-chair-1",
                         "status": "completed",
                     }
                 )


### PR DESCRIPTION
## Summary
- extend the identity bootstrap and signer policy to cover governance execution actors and signer ownership
- enforce identity-backed actor validation in governance replay and remediation outputs
- expose eligible and assigned actor context in machine-readable governance artifacts and operator docs

Closes #14.

## Verification
- python -m py_compile src/assurancectl/inference.py src/assurancectl/cli.py src/assurancectl/config.py
- python -m unittest discover -s tests -v
- make validate
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go test ./...
- GOCACHE=/tmp/oai-go-cache GOMODCACHE=/tmp/oai-go-modcache go build -o ./0aid ./cmd/0aid
- ./0aid identity-plan --root .
- PYTHONPATH=src python -m assurancectl.cli governance-replay --status examples/proposals/checkpoint-events.json --json
- PYTHONPATH=src python -m assurancectl.cli governance-remediation --registry examples/proposals/registry.json --history examples/proposals/history.json --status examples/proposals/checkpoint-status.json --json