### PR TITLE
Render signer manifest and rotation plan from bootstrap state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/localnet/
 build/nodes/
+build/*.json
 .cache/
 /0aid
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -23,6 +23,7 @@ help:
 	@echo "  go-test          Run Go unit tests"
 	@echo "  module-plan      Render the first registry/attestation milestone plan"
 	@echo "  identity-plan    Render the permissioned actor and role bootstrap plan"
+	@echo "  signer-manifest  Render checkpoint signer ownership and rotation plan"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -77,6 +78,9 @@ module-plan:
 
 identity-plan:
 	./0aid identity-plan --root . $(if $(OUT),--out $(OUT),)
+
+signer-manifest:
+	./0aid signer-manifest --root . $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ make -C projects/0ai-assurance-network go-build
 make -C projects/0ai-assurance-network go-test
 make -C projects/0ai-assurance-network module-plan
 make -C projects/0ai-assurance-network identity-plan
+make -C projects/0ai-assurance-network signer-manifest
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -173,6 +174,12 @@ is replaced with a new signed record.
 `go-build` and `go-test` operate on the `0aid` binary skeleton and the internal
 Go project package.
 
+`signer-manifest` renders the active checkpoint signer ownership map and
+rotation plan from the signer policy and identity bootstrap. It fails closed if
+rotation metadata is stale, if two active signers claim the same actor
+ownership, or if a governance execution role has no active signer coverage. The
+rotation contract is described in [docs/signer-manifests.md](docs/signer-manifests.md).
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -184,6 +191,7 @@ currently supports:
 - `module-map`
 - `module-plan`
 - `identity-plan`
+- `signer-manifest`
 - `show-plan`
 - `init-genesis`
 - `render-validator`
@@ -199,6 +207,7 @@ Bootstrap examples:
 ./0aid render-identity --root . --id val-3
 ./0aid module-plan --root . --out ./build/module-plan.json
 ./0aid identity-plan --root . --out ./build/identity-plan.json
+./0aid signer-manifest --root . --out ./build/signer-manifest.json
 ./0aid init-node --root . --id val-3 --out ./build/nodes/validator-3
 ./0aid collect-validator --bundle ./build/nodes/validator-3 --out ./build/collection/validator-3.json
 ./0aid assemble-genesis --root . --collection ./build/collection --out ./build/assembled/genesis-plan.json

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -66,6 +66,25 @@ func run(args []string) error {
 			return printJSON(plan)
 		}
 		return project.WriteJSON(filepath.Clean(*out), plan)
+	case "signer-manifest":
+		fs := flag.NewFlagSet("signer-manifest", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		manifest, err := project.SignerManifest(bundle)
+		if err != nil {
+			return err
+		}
+		if *out == "" {
+			return printJSON(manifest)
+		}
+		return project.WriteJSON(filepath.Clean(*out), manifest)
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -234,7 +253,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 

--- a/config/governance/checkpoint-signers.json
+++ b/config/governance/checkpoint-signers.json
@@ -3,11 +3,18 @@
   "signature_format": "0ai-hmac-sha256-v1",
   "require_signatures_for_event_logs": true,
   "maximum_signature_validity_seconds": 86400,
+  "rotation_policy": {
+    "reference_time": "2026-04-17T00:00:00Z",
+    "warning_window_days": 14
+  },
   "signers": [
     {
       "actor_id": "op-governance-chair-1",
       "signer_id": "governance-chair-bot",
       "key_id": "governance-chair-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-02-01T00:00:00Z",
+      "rotate_by": "2026-04-28T00:00:00Z",
       "roles": ["governance-chair"],
       "shared_secret": "dev-secret-governance-chair-v1"
     },
@@ -15,6 +22,9 @@
       "actor_id": "op-governance-ops-1",
       "signer_id": "governance-ops-bot",
       "key_id": "governance-ops-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-02-04T00:00:00Z",
+      "rotate_by": "2026-05-20T00:00:00Z",
       "roles": ["governance-ops"],
       "shared_secret": "dev-secret-governance-ops-v1"
     },
@@ -22,6 +32,9 @@
       "actor_id": "op-token-house-secretariat-1",
       "signer_id": "token-house-secretariat-bot",
       "key_id": "token-house-secretariat-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-02-08T00:00:00Z",
+      "rotate_by": "2026-05-24T00:00:00Z",
       "roles": ["token-house-secretariat"],
       "shared_secret": "dev-secret-token-house-secretariat-v1"
     },
@@ -29,6 +42,9 @@
       "actor_id": "op-telemetry-ops-1",
       "signer_id": "telemetry-ops-bot",
       "key_id": "telemetry-ops-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-02-12T00:00:00Z",
+      "rotate_by": "2026-06-01T00:00:00Z",
       "roles": ["telemetry-ops"],
       "shared_secret": "dev-secret-telemetry-ops-v1"
     },
@@ -36,6 +52,9 @@
       "actor_id": "op-treasury-program-manager-1",
       "signer_id": "treasury-program-manager-bot",
       "key_id": "treasury-program-manager-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-02-15T00:00:00Z",
+      "rotate_by": "2026-05-18T00:00:00Z",
       "roles": ["treasury-program-manager"],
       "shared_secret": "dev-secret-treasury-program-manager-v1"
     },
@@ -43,6 +62,9 @@
       "actor_id": "op-treasury-review-chair-1",
       "signer_id": "treasury-review-chair-bot",
       "key_id": "treasury-review-chair-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-02-18T00:00:00Z",
+      "rotate_by": "2026-06-04T00:00:00Z",
       "roles": ["treasury-review-chair"],
       "shared_secret": "dev-secret-treasury-review-chair-v1"
     },
@@ -50,6 +72,9 @@
       "actor_id": "op-finance-telemetry-lead-1",
       "signer_id": "finance-telemetry-lead-bot",
       "key_id": "finance-telemetry-lead-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-02-20T00:00:00Z",
+      "rotate_by": "2026-06-06T00:00:00Z",
       "roles": ["finance-telemetry-lead"],
       "shared_secret": "dev-secret-finance-telemetry-lead-v1"
     },
@@ -57,6 +82,9 @@
       "actor_id": "op-validator-ops-1",
       "signer_id": "validator-ops-lead-bot",
       "key_id": "validator-ops-lead-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-02-23T00:00:00Z",
+      "rotate_by": "2026-05-29T00:00:00Z",
       "roles": ["validator-ops-lead"],
       "shared_secret": "dev-secret-validator-ops-lead-v1"
     },
@@ -64,6 +92,9 @@
       "actor_id": "op-staking-governance-reviewer-1",
       "signer_id": "staking-governance-reviewer-bot",
       "key_id": "staking-governance-reviewer-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-02-25T00:00:00Z",
+      "rotate_by": "2026-05-31T00:00:00Z",
       "roles": ["staking-governance-reviewer"],
       "shared_secret": "dev-secret-staking-governance-reviewer-v1"
     },
@@ -71,6 +102,9 @@
       "actor_id": "op-network-reliability-lead-1",
       "signer_id": "network-reliability-lead-bot",
       "key_id": "network-reliability-lead-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-02-27T00:00:00Z",
+      "rotate_by": "2026-06-08T00:00:00Z",
       "roles": ["network-reliability-lead"],
       "shared_secret": "dev-secret-network-reliability-lead-v1"
     },
@@ -78,6 +112,9 @@
       "actor_id": "op-safety-council-chair-1",
       "signer_id": "safety-council-chair-bot",
       "key_id": "safety-council-chair-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-03-01T00:00:00Z",
+      "rotate_by": "2026-05-14T00:00:00Z",
       "roles": ["safety-council-chair"],
       "shared_secret": "dev-secret-safety-council-chair-v1"
     },
@@ -85,6 +122,9 @@
       "actor_id": "op-incident-commander-1",
       "signer_id": "incident-commander-bot",
       "key_id": "incident-commander-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-03-03T00:00:00Z",
+      "rotate_by": "2026-05-16T00:00:00Z",
       "roles": ["incident-commander"],
       "shared_secret": "dev-secret-incident-commander-v1"
     },
@@ -92,6 +132,9 @@
       "actor_id": "op-safety-council-secretariat-1",
       "signer_id": "safety-council-secretariat-bot",
       "key_id": "safety-council-secretariat-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-03-06T00:00:00Z",
+      "rotate_by": "2026-05-22T00:00:00Z",
       "roles": ["safety-council-secretariat"],
       "shared_secret": "dev-secret-safety-council-secretariat-v1"
     },
@@ -99,6 +142,9 @@
       "actor_id": "op-security-telemetry-lead-1",
       "signer_id": "security-telemetry-lead-bot",
       "key_id": "security-telemetry-lead-dev-v1",
+      "status": "active",
+      "provisioned_at": "2026-03-09T00:00:00Z",
+      "rotate_by": "2026-05-26T00:00:00Z",
       "roles": ["security-telemetry-lead"],
       "shared_secret": "dev-secret-security-telemetry-lead-v1"
     }

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -1,0 +1,65 @@
+# Signer Manifests
+
+`0aid signer-manifest` joins the checkpoint signer policy in
+`config/governance/checkpoint-signers.json` with the active identity bootstrap
+in `config/identity/bootstrap.json`.
+
+The rendered manifest is meant to be the operator-facing source of truth for:
+
+- which actor owns each active signer
+- which governance execution roles each signer covers
+- which governance phases depend on that role coverage
+- when each signer must be rotated
+- which signer rotations are current vs expiring
+
+## Required signer metadata
+
+Each signer entry must declare:
+
+- `actor_id`
+- `signer_id`
+- `key_id`
+- `status`
+- `provisioned_at`
+- `rotate_by`
+- `roles`
+- `shared_secret`
+
+The current repository uses development-only HMAC signers for authenticated
+pre-launch governance replay. This is intentionally not a production custody
+design.
+
+## Rotation policy
+
+`rotation_policy.reference_time` is the deterministic point-in-time used for
+validation and manifest rendering.
+
+`rotation_policy.warning_window_days` controls when a signer is marked
+`expiring`.
+
+Active signers are rejected when:
+
+- `rotate_by` is not after `provisioned_at`
+- `rotate_by` is not after `rotation_policy.reference_time`
+- two active signers claim the same `actor_id`
+- two active signers cover the same governance execution role
+- a required governance execution role has no active signer coverage
+
+## Output shape
+
+The manifest contains:
+
+- signer ownership and organization context
+- per-role governance references such as `governance:phase_owner:*`
+- rotation status (`current`, `expiring`, `inactive`)
+- `rotation_plan`, sorted by earliest `rotate_by`
+
+Example:
+
+```bash
+./0aid signer-manifest --root . --out ./build/signer-manifest.json
+```
+
+This command should be treated as a release-gating check for governance
+bootstrap changes. If it fails, the signer policy is no longer operationally
+sound enough to exercise checkpoint replay or remediation signing.

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -35,6 +35,13 @@ func TestLoadBundle(t *testing.T) {
 	if len(bundle.CheckpointSigners) == 0 {
 		t.Fatal("expected checkpoint signer policy to be loaded")
 	}
+	if len(bundle.CheckpointSigners["signers"].([]any)) != 14 {
+		t.Fatalf("expected 14 checkpoint signers, got %d", len(bundle.CheckpointSigners["signers"].([]any)))
+	}
+	rotationPolicy := bundle.CheckpointSigners["rotation_policy"].(map[string]any)
+	if rotationPolicy["reference_time"] != "2026-04-17T00:00:00Z" {
+		t.Fatalf("unexpected signer rotation reference time: %v", rotationPolicy["reference_time"])
+	}
 	if len(bundle.InferencePolicy) == 0 {
 		t.Fatal("expected inference policy to be loaded")
 	}

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -1,0 +1,433 @@
+package project
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+)
+
+type SignerRoleCoverage struct {
+	Role         string   `json:"role"`
+	ReferencedBy []string `json:"referenced_by"`
+}
+
+type SignerManifestEntry struct {
+	ActorID           string               `json:"actor_id"`
+	ActorDisplayName  string               `json:"actor_display_name"`
+	ActorStatus       string               `json:"actor_status"`
+	OrganizationID    string               `json:"organization_id,omitempty"`
+	OrganizationName  string               `json:"organization_name,omitempty"`
+	SignerID          string               `json:"signer_id"`
+	KeyID             string               `json:"key_id"`
+	SignerStatus      string               `json:"signer_status"`
+	Roles             []string             `json:"roles"`
+	RoleCoverage      []SignerRoleCoverage `json:"role_coverage"`
+	ProvisionedAt     string               `json:"provisioned_at"`
+	RotateBy          string               `json:"rotate_by"`
+	RotationStatus    string               `json:"rotation_status"`
+	DaysUntilRotation int                  `json:"days_until_rotation"`
+}
+
+type SignerRotationPlanEntry struct {
+	Order             int      `json:"order"`
+	SignerID          string   `json:"signer_id"`
+	ActorID           string   `json:"actor_id"`
+	Roles             []string `json:"roles"`
+	RotateBy          string   `json:"rotate_by"`
+	RotationStatus    string   `json:"rotation_status"`
+	DaysUntilRotation int      `json:"days_until_rotation"`
+	RecommendedAction string   `json:"recommended_action"`
+}
+
+type SignerManifestOutput struct {
+	Version             string                    `json:"version"`
+	ChainID             string                    `json:"chain_id"`
+	PolicyVersion       string                    `json:"policy_version"`
+	IdentityVersion     string                    `json:"identity_version"`
+	ReferenceTime       string                    `json:"reference_time"`
+	WarningWindowDays   int                       `json:"warning_window_days"`
+	SignerCount         int                       `json:"signer_count"`
+	ActiveSignerCount   int                       `json:"active_signer_count"`
+	MissingRoleCoverage []string                  `json:"missing_role_coverage"`
+	ExpiringSignerIDs   []string                  `json:"expiring_signer_ids"`
+	RotationPlan        []SignerRotationPlanEntry `json:"rotation_plan"`
+	Signers             []SignerManifestEntry     `json:"signers"`
+}
+
+type parsedSignerEntry struct {
+	ActorID           string
+	SignerID          string
+	KeyID             string
+	Status            string
+	Roles             []string
+	ProvisionedAt     time.Time
+	RotateBy          time.Time
+	RotationStatus    string
+	DaysUntilRotation int
+}
+
+func governanceExecutionRoleUsage(bundle Bundle) map[string][]string {
+	roleUsage := make(map[string][]string)
+	executionDefaults := stringMap(stringMap(stringMap(bundle.InferencePolicy["remediation"])["execution_defaults"]))
+	for phase, role := range stringMap(executionDefaults["phase_owners"]) {
+		appendIdentityRoleUsage(roleUsage, fmt.Sprint(role), "governance:phase_owner:"+phase)
+	}
+	for proposalKind, override := range stringMap(executionDefaults["owner_overrides"]) {
+		for phase, role := range stringMap(override) {
+			appendIdentityRoleUsage(roleUsage, fmt.Sprint(role), "governance:owner_override:"+proposalKind+":"+phase)
+		}
+	}
+	return roleUsage
+}
+
+func parseRFC3339(value any, field string) (time.Time, error) {
+	text := fmt.Sprint(value)
+	if text == "" {
+		return time.Time{}, fmt.Errorf("%s must be set", field)
+	}
+	parsed, err := time.Parse(time.RFC3339, text)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%s must be RFC3339 timestamp: %w", field, err)
+	}
+	return parsed.UTC(), nil
+}
+
+func intValue(value any) (int, error) {
+	switch typed := value.(type) {
+	case int:
+		return typed, nil
+	case int64:
+		return int(typed), nil
+	case float64:
+		return int(typed), nil
+	case string:
+		return strconv.Atoi(typed)
+	default:
+		return 0, fmt.Errorf("unsupported integer type %T", value)
+	}
+}
+
+func signerRotationStatus(referenceTime time.Time, warningWindowDays int, signerStatus string, rotateBy time.Time) string {
+	if signerStatus != "active" {
+		return "inactive"
+	}
+	if !rotateBy.After(referenceTime) {
+		return "stale"
+	}
+	if rotateBy.Sub(referenceTime) <= (time.Duration(warningWindowDays) * 24 * time.Hour) {
+		return "expiring"
+	}
+	return "current"
+}
+
+func ValidateSignerManifestInputs(bundle Bundle) error {
+	if err := ValidateIdentityBootstrap(bundle); err != nil {
+		return err
+	}
+
+	if fmt.Sprint(bundle.CheckpointSigners["signature_format"]) != "0ai-hmac-sha256-v1" {
+		return fmt.Errorf("checkpoint signer signature_format must be 0ai-hmac-sha256-v1")
+	}
+	if fmt.Sprint(bundle.CheckpointSigners["require_signatures_for_event_logs"]) != "true" {
+		return fmt.Errorf("checkpoint signer policy must require signatures for event logs")
+	}
+	maxValidity, err := intValue(bundle.CheckpointSigners["maximum_signature_validity_seconds"])
+	if err != nil || maxValidity <= 0 {
+		return fmt.Errorf("checkpoint signer validity window must be positive")
+	}
+	rotationPolicy := stringMap(bundle.CheckpointSigners["rotation_policy"])
+	referenceTime, err := parseRFC3339(rotationPolicy["reference_time"], "checkpoint signer rotation_policy.reference_time")
+	if err != nil {
+		return err
+	}
+	warningWindowDays, err := intValue(rotationPolicy["warning_window_days"])
+	if err != nil || warningWindowDays <= 0 {
+		return fmt.Errorf("checkpoint signer rotation_policy.warning_window_days must be positive")
+	}
+
+	roleUsage := governanceExecutionRoleUsage(bundle)
+	actors := make(map[string]IdentityActor, len(bundle.Identity.Actors))
+	activeRoleBindings := make(map[string]struct{}, len(bundle.Identity.RoleBindings))
+	for _, actor := range bundle.Identity.Actors {
+		actors[actor.ActorID] = actor
+	}
+	for _, binding := range bundle.Identity.RoleBindings {
+		if binding.Status == "active" {
+			activeRoleBindings[binding.ActorID+"|"+binding.Role] = struct{}{}
+		}
+	}
+
+	rawSigners, ok := bundle.CheckpointSigners["signers"].([]any)
+	if !ok || len(rawSigners) == 0 {
+		return fmt.Errorf("at least one checkpoint signer must be configured")
+	}
+
+	signerIDs := make(map[string]struct{}, len(rawSigners))
+	keyIDs := make(map[string]struct{}, len(rawSigners))
+	activeActorIDs := make(map[string]struct{}, len(rawSigners))
+	activeRoleCoverage := make(map[string]string)
+
+	for _, rawSigner := range rawSigners {
+		signer := stringMap(rawSigner)
+		actorID := fmt.Sprint(signer["actor_id"])
+		signerID := fmt.Sprint(signer["signer_id"])
+		keyID := fmt.Sprint(signer["key_id"])
+		sharedSecret := fmt.Sprint(signer["shared_secret"])
+		status := fmt.Sprint(signer["status"])
+		roles := stringSlice(signer["roles"])
+
+		if actorID == "" {
+			return fmt.Errorf("checkpoint signer %s must declare actor_id", signerID)
+		}
+		if signerID == "" {
+			return fmt.Errorf("checkpoint signer signer_id must not be empty")
+		}
+		if _, exists := signerIDs[signerID]; exists {
+			return fmt.Errorf("duplicate checkpoint signer_id: %s", signerID)
+		}
+		if _, exists := keyIDs[keyID]; exists {
+			return fmt.Errorf("duplicate checkpoint key_id: %s", keyID)
+		}
+		if sharedSecret == "" {
+			return fmt.Errorf("checkpoint signer %s must declare a shared_secret", signerID)
+		}
+		if status != "active" && status != "inactive" {
+			return fmt.Errorf("checkpoint signer %s has invalid status", signerID)
+		}
+		if len(roles) == 0 {
+			return fmt.Errorf("checkpoint signer %s must declare at least one role", signerID)
+		}
+		provisionedAt, err := parseRFC3339(signer["provisioned_at"], "checkpoint signer "+signerID+" provisioned_at")
+		if err != nil {
+			return err
+		}
+		rotateBy, err := parseRFC3339(signer["rotate_by"], "checkpoint signer "+signerID+" rotate_by")
+		if err != nil {
+			return err
+		}
+		if !rotateBy.After(provisionedAt) {
+			return fmt.Errorf("checkpoint signer %s rotate_by must be after provisioned_at", signerID)
+		}
+
+		actor, exists := actors[actorID]
+		if !exists {
+			return fmt.Errorf("checkpoint signer %s references unknown actor %s", signerID, actorID)
+		}
+		if actor.Status != "active" {
+			return fmt.Errorf("checkpoint signer %s references inactive actor %s", signerID, actorID)
+		}
+
+		for _, role := range roles {
+			if _, exists := activeRoleBindings[actorID+"|"+role]; !exists {
+				return fmt.Errorf(
+					"checkpoint signer %s role %s is not backed by an active identity binding",
+					signerID,
+					role,
+				)
+			}
+		}
+
+		if status == "active" {
+			if _, exists := activeActorIDs[actorID]; exists {
+				return fmt.Errorf("duplicate checkpoint signer actor ownership: %s", actorID)
+			}
+			activeActorIDs[actorID] = struct{}{}
+			if !rotateBy.After(referenceTime) {
+				return fmt.Errorf("checkpoint signer %s has stale rotation metadata", signerID)
+			}
+			for _, role := range roles {
+				if owner, exists := activeRoleCoverage[role]; exists {
+					return fmt.Errorf("duplicate checkpoint signer role coverage: %s (%s, %s)", role, owner, signerID)
+				}
+				activeRoleCoverage[role] = signerID
+			}
+			if signerRotationStatus(referenceTime, warningWindowDays, status, rotateBy) == "stale" {
+				return fmt.Errorf("checkpoint signer %s has stale rotation metadata", signerID)
+			}
+		}
+
+		signerIDs[signerID] = struct{}{}
+		keyIDs[keyID] = struct{}{}
+	}
+
+	missingRoles := make([]string, 0)
+	for role := range roleUsage {
+		if _, exists := activeRoleCoverage[role]; !exists {
+			missingRoles = append(missingRoles, role)
+		}
+	}
+	sort.Strings(missingRoles)
+	if len(missingRoles) > 0 {
+		return fmt.Errorf("checkpoint signer coverage missing roles: %s", commaList(missingRoles))
+	}
+
+	return nil
+}
+
+func SignerManifest(bundle Bundle) (SignerManifestOutput, error) {
+	if err := ValidateSignerManifestInputs(bundle); err != nil {
+		return SignerManifestOutput{}, err
+	}
+
+	rotationPolicy := stringMap(bundle.CheckpointSigners["rotation_policy"])
+	referenceTime, _ := parseRFC3339(rotationPolicy["reference_time"], "checkpoint signer rotation_policy.reference_time")
+	warningWindowDays, _ := intValue(rotationPolicy["warning_window_days"])
+	roleUsage := governanceExecutionRoleUsage(bundle)
+
+	actors := make(map[string]IdentityActor, len(bundle.Identity.Actors))
+	for _, actor := range bundle.Identity.Actors {
+		actors[actor.ActorID] = actor
+	}
+
+	entries := make([]SignerManifestEntry, 0)
+	expiring := make([]string, 0)
+	rotationPlan := make([]SignerRotationPlanEntry, 0)
+
+	rawSigners := bundle.CheckpointSigners["signers"].([]any)
+	parsedSigners := make([]parsedSignerEntry, 0, len(rawSigners))
+	for _, rawSigner := range rawSigners {
+		signer := stringMap(rawSigner)
+		provisionedAt, _ := parseRFC3339(signer["provisioned_at"], "checkpoint signer provisioned_at")
+		rotateBy, _ := parseRFC3339(signer["rotate_by"], "checkpoint signer rotate_by")
+		status := fmt.Sprint(signer["status"])
+		daysUntilRotation := int(rotateBy.Sub(referenceTime).Hours() / 24)
+		parsedSigners = append(parsedSigners, parsedSignerEntry{
+			ActorID:           fmt.Sprint(signer["actor_id"]),
+			SignerID:          fmt.Sprint(signer["signer_id"]),
+			KeyID:             fmt.Sprint(signer["key_id"]),
+			Status:            status,
+			Roles:             stringSlice(signer["roles"]),
+			ProvisionedAt:     provisionedAt,
+			RotateBy:          rotateBy,
+			RotationStatus:    signerRotationStatus(referenceTime, warningWindowDays, status, rotateBy),
+			DaysUntilRotation: daysUntilRotation,
+		})
+	}
+
+	sort.Slice(parsedSigners, func(i, j int) bool {
+		if parsedSigners[i].RotateBy.Equal(parsedSigners[j].RotateBy) {
+			return parsedSigners[i].SignerID < parsedSigners[j].SignerID
+		}
+		return parsedSigners[i].RotateBy.Before(parsedSigners[j].RotateBy)
+	})
+
+	activeCount := 0
+	for _, signer := range parsedSigners {
+		actor := actors[signer.ActorID]
+		roleCoverage := make([]SignerRoleCoverage, 0, len(signer.Roles))
+		for _, role := range signer.Roles {
+			referencedBy := append([]string(nil), roleUsage[role]...)
+			sort.Strings(referencedBy)
+			roleCoverage = append(roleCoverage, SignerRoleCoverage{
+				Role:         role,
+				ReferencedBy: referencedBy,
+			})
+		}
+		sort.Slice(roleCoverage, func(i, j int) bool {
+			return roleCoverage[i].Role < roleCoverage[j].Role
+		})
+
+		organizationName := ""
+		if actor.OrganizationID != "" {
+			if organization, exists := actors[actor.OrganizationID]; exists {
+				organizationName = organization.DisplayName
+			}
+		}
+
+		entry := SignerManifestEntry{
+			ActorID:           signer.ActorID,
+			ActorDisplayName:  actor.DisplayName,
+			ActorStatus:       actor.Status,
+			OrganizationID:    actor.OrganizationID,
+			OrganizationName:  organizationName,
+			SignerID:          signer.SignerID,
+			KeyID:             signer.KeyID,
+			SignerStatus:      signer.Status,
+			Roles:             append([]string(nil), signer.Roles...),
+			RoleCoverage:      roleCoverage,
+			ProvisionedAt:     signer.ProvisionedAt.Format(time.RFC3339),
+			RotateBy:          signer.RotateBy.Format(time.RFC3339),
+			RotationStatus:    signer.RotationStatus,
+			DaysUntilRotation: signer.DaysUntilRotation,
+		}
+		entries = append(entries, entry)
+
+		if signer.Status == "active" {
+			activeCount++
+			rotationPlan = append(rotationPlan, SignerRotationPlanEntry{
+				SignerID:          signer.SignerID,
+				ActorID:           signer.ActorID,
+				Roles:             append([]string(nil), signer.Roles...),
+				RotateBy:          signer.RotateBy.Format(time.RFC3339),
+				RotationStatus:    signer.RotationStatus,
+				DaysUntilRotation: signer.DaysUntilRotation,
+				RecommendedAction: recommendedRotationAction(signer.RotationStatus),
+			})
+			if signer.RotationStatus == "expiring" {
+				expiring = append(expiring, signer.SignerID)
+			}
+		}
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].SignerID < entries[j].SignerID
+	})
+	sort.Strings(expiring)
+	for idx := range rotationPlan {
+		rotationPlan[idx].Order = idx + 1
+	}
+
+	return SignerManifestOutput{
+		Version:             "1.0.0",
+		ChainID:             bundle.Topology.ChainID,
+		PolicyVersion:       fmt.Sprint(bundle.CheckpointSigners["version"]),
+		IdentityVersion:     bundle.Identity.Version,
+		ReferenceTime:       referenceTime.Format(time.RFC3339),
+		WarningWindowDays:   warningWindowDays,
+		SignerCount:         len(entries),
+		ActiveSignerCount:   activeCount,
+		MissingRoleCoverage: []string{},
+		ExpiringSignerIDs:   expiring,
+		RotationPlan:        rotationPlan,
+		Signers:             entries,
+	}, nil
+}
+
+func recommendedRotationAction(rotationStatus string) string {
+	switch rotationStatus {
+	case "expiring":
+		return "rotate signer key before the current rotate_by deadline and publish the replacement manifest"
+	case "inactive":
+		return "retain retired signer metadata for audit history only"
+	default:
+		return "maintain signer custody and validate the next scheduled rotation checkpoint"
+	}
+}
+
+func commaList(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s", sortAndJoin(values))
+}
+
+func sortAndJoin(values []string) string {
+	sorted := append([]string(nil), values...)
+	sort.Strings(sorted)
+	return joinStrings(sorted, ", ")
+}
+
+func joinStrings(values []string, separator string) string {
+	switch len(values) {
+	case 0:
+		return ""
+	case 1:
+		return values[0]
+	}
+	output := values[0]
+	for _, value := range values[1:] {
+		output += separator + value
+	}
+	return output
+}

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -1,0 +1,135 @@
+package project
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func cloneSignerPolicy(t *testing.T, value map[string]any) map[string]any {
+	t.Helper()
+
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal signer policy: %v", err)
+	}
+	var cloned map[string]any
+	if err := json.Unmarshal(encoded, &cloned); err != nil {
+		t.Fatalf("unmarshal signer policy: %v", err)
+	}
+	return cloned
+}
+
+func TestSignerManifest(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	manifest, err := SignerManifest(bundle)
+	if err != nil {
+		t.Fatalf("SignerManifest failed: %v", err)
+	}
+
+	if manifest.ChainID != "0ai-assurance-1" {
+		t.Fatalf("unexpected chain id: %s", manifest.ChainID)
+	}
+	if manifest.SignerCount != 14 {
+		t.Fatalf("expected 14 signers, got %d", manifest.SignerCount)
+	}
+	if manifest.ActiveSignerCount != 14 {
+		t.Fatalf("expected 14 active signers, got %d", manifest.ActiveSignerCount)
+	}
+	if len(manifest.ExpiringSignerIDs) != 1 || manifest.ExpiringSignerIDs[0] != "governance-chair-bot" {
+		t.Fatalf("unexpected expiring signer set: %#v", manifest.ExpiringSignerIDs)
+	}
+	if len(manifest.RotationPlan) != 14 {
+		t.Fatalf("expected 14 rotation plan entries, got %d", len(manifest.RotationPlan))
+	}
+	if manifest.RotationPlan[0].SignerID != "governance-chair-bot" {
+		t.Fatalf("unexpected first rotation entry: %+v", manifest.RotationPlan[0])
+	}
+
+	foundGovernanceChair := false
+	for _, signer := range manifest.Signers {
+		if signer.SignerID != "governance-chair-bot" {
+			continue
+		}
+		foundGovernanceChair = true
+		if signer.ActorID != "op-governance-chair-1" {
+			t.Fatalf("unexpected governance chair actor id: %s", signer.ActorID)
+		}
+		if signer.RotationStatus != "expiring" {
+			t.Fatalf("expected governance chair signer to be expiring, got %s", signer.RotationStatus)
+		}
+		if len(signer.RoleCoverage) != 1 || len(signer.RoleCoverage[0].ReferencedBy) != 1 {
+			t.Fatalf("unexpected governance chair role coverage: %+v", signer.RoleCoverage)
+		}
+		if signer.RoleCoverage[0].ReferencedBy[0] != "governance:phase_owner:release_blocker" {
+			t.Fatalf("unexpected governance chair referenced_by: %+v", signer.RoleCoverage[0].ReferencedBy)
+		}
+	}
+	if !foundGovernanceChair {
+		t.Fatal("expected governance-chair-bot signer entry")
+	}
+}
+
+func TestSignerManifestFailsOnDuplicateActorOwnership(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	policy := cloneSignerPolicy(t, bundle.CheckpointSigners)
+	signers := policy["signers"].([]any)
+	second := signers[1].(map[string]any)
+	second["actor_id"] = "op-governance-chair-1"
+	second["roles"] = []any{"governance-chair"}
+	bundle.CheckpointSigners = policy
+
+	_, err = SignerManifest(bundle)
+	if err == nil || !strings.Contains(err.Error(), "duplicate checkpoint signer actor ownership") {
+		t.Fatalf("expected duplicate actor ownership error, got %v", err)
+	}
+}
+
+func TestSignerManifestFailsOnMissingRoleCoverage(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	policy := cloneSignerPolicy(t, bundle.CheckpointSigners)
+	filtered := make([]any, 0)
+	for _, rawSigner := range policy["signers"].([]any) {
+		signer := rawSigner.(map[string]any)
+		if signer["signer_id"] == "treasury-review-chair-bot" {
+			continue
+		}
+		filtered = append(filtered, signer)
+	}
+	policy["signers"] = filtered
+	bundle.CheckpointSigners = policy
+
+	_, err = SignerManifest(bundle)
+	if err == nil || !strings.Contains(err.Error(), "checkpoint signer coverage missing roles: treasury-review-chair") {
+		t.Fatalf("expected missing signer coverage error, got %v", err)
+	}
+}
+
+func TestSignerManifestFailsOnStaleRotationMetadata(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	policy := cloneSignerPolicy(t, bundle.CheckpointSigners)
+	first := policy["signers"].([]any)[0].(map[string]any)
+	first["rotate_by"] = "2026-04-01T00:00:00Z"
+	bundle.CheckpointSigners = policy
+
+	_, err = SignerManifest(bundle)
+	if err == nil || !strings.Contains(err.Error(), "stale rotation metadata") {
+		t.Fatalf("expected stale rotation error, got %v", err)
+	}
+}

--- a/src/assurancectl/config.py
+++ b/src/assurancectl/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -55,6 +56,18 @@ def load_config(explicit_root: str | Path | None = None) -> LoadedConfig:
 def _assert(condition: bool, message: str) -> None:
     if not condition:
         raise ValidationError(message)
+
+
+def _parse_utc_timestamp(value: Any, field_name: str) -> datetime:
+    text = str(value or "")
+    _assert(text != "", f"{field_name} must be set")
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValidationError(f"{field_name} must be RFC3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 def validate_topology(topology: dict[str, Any]) -> None:
@@ -128,7 +141,17 @@ def validate_policy(policy: dict[str, Any]) -> None:
     )
 
 
-def validate_checkpoint_signers(checkpoint_signers: dict[str, Any]) -> None:
+def _required_signer_roles(inference_policy: dict[str, Any]) -> set[str]:
+    remediation = inference_policy.get("remediation", {})
+    execution_defaults = remediation.get("execution_defaults", {})
+    required: set[str] = set()
+    required.update(str(role) for role in execution_defaults.get("phase_owners", {}).values())
+    for override in execution_defaults.get("owner_overrides", {}).values():
+        required.update(str(role) for role in override.values())
+    return {role for role in required if role}
+
+
+def validate_checkpoint_signers(checkpoint_signers: dict[str, Any], inference_policy: dict[str, Any]) -> None:
     _assert(
         checkpoint_signers["signature_format"] == "0ai-hmac-sha256-v1",
         "checkpoint signer signature_format must be 0ai-hmac-sha256-v1",
@@ -141,29 +164,79 @@ def validate_checkpoint_signers(checkpoint_signers: dict[str, Any]) -> None:
         int(checkpoint_signers["maximum_signature_validity_seconds"]) > 0,
         "checkpoint signer validity window must be positive",
     )
+    rotation_policy = dict(checkpoint_signers.get("rotation_policy", {}))
+    reference_time = _parse_utc_timestamp(
+        rotation_policy.get("reference_time"),
+        "checkpoint signer rotation_policy.reference_time",
+    )
+    warning_window_days = int(rotation_policy.get("warning_window_days", 0))
+    _assert(
+        warning_window_days > 0,
+        "checkpoint signer rotation_policy.warning_window_days must be positive",
+    )
     signers = list(checkpoint_signers["signers"])
     _assert(signers, "at least one checkpoint signer must be configured")
 
     signer_ids: set[str] = set()
     key_ids: set[str] = set()
     role_bindings: set[str] = set()
+    active_actor_ids: set[str] = set()
+    active_role_coverage: dict[str, str] = {}
+    required_roles = _required_signer_roles(inference_policy)
     for signer in signers:
         actor_id = str(signer.get("actor_id", ""))
         signer_id = str(signer["signer_id"])
         key_id = str(signer["key_id"])
         shared_secret = str(signer["shared_secret"])
+        status = str(signer.get("status", ""))
         roles = [str(role) for role in signer["roles"]]
+        provisioned_at = _parse_utc_timestamp(
+            signer.get("provisioned_at"),
+            f"checkpoint signer {signer_id} provisioned_at",
+        )
+        rotate_by = _parse_utc_timestamp(
+            signer.get("rotate_by"),
+            f"checkpoint signer {signer_id} rotate_by",
+        )
         _assert(actor_id != "", f"checkpoint signer {signer_id} must declare an actor_id")
         _assert(signer_id not in signer_ids, f"duplicate checkpoint signer_id: {signer_id}")
         _assert(key_id not in key_ids, f"duplicate checkpoint key_id: {key_id}")
         _assert(shared_secret != "", f"checkpoint signer {signer_id} must declare a shared_secret")
+        _assert(status in {"active", "inactive"}, f"checkpoint signer {signer_id} has invalid status")
+        _assert(
+            rotate_by > provisioned_at,
+            f"checkpoint signer {signer_id} rotate_by must be after provisioned_at",
+        )
         _assert(roles, f"checkpoint signer {signer_id} must declare at least one role")
         for role in roles:
             binding = f"{signer_id}:{role}"
             _assert(binding not in role_bindings, f"duplicate checkpoint signer role binding: {binding}")
             role_bindings.add(binding)
+        if status == "active":
+            _assert(
+                actor_id not in active_actor_ids,
+                f"duplicate checkpoint signer actor ownership: {actor_id}",
+            )
+            _assert(
+                rotate_by > reference_time,
+                f"checkpoint signer {signer_id} has stale rotation metadata",
+            )
+            for role in roles:
+                owner = active_role_coverage.get(role)
+                _assert(
+                    owner is None,
+                    f"duplicate checkpoint signer role coverage: {role}",
+                )
+                active_role_coverage[role] = signer_id
+            active_actor_ids.add(actor_id)
         signer_ids.add(signer_id)
         key_ids.add(key_id)
+
+    missing_roles = sorted(required_roles - set(active_role_coverage))
+    _assert(
+        not missing_roles,
+        f"checkpoint signer coverage missing roles: {', '.join(missing_roles)}",
+    )
 
 
 def validate_module_plan(module_plan: dict[str, Any]) -> None:
@@ -334,7 +407,7 @@ def validate_all(config: LoadedConfig) -> None:
     validate_topology(config.topology)
     validate_genesis(config.genesis, config.topology)
     validate_policy(config.policy)
-    validate_checkpoint_signers(config.checkpoint_signers)
+    validate_checkpoint_signers(config.checkpoint_signers, config.inference_policy)
     validate_module_plan(config.module_plan)
     validate_identity_bootstrap(
         config.identity_bootstrap,

--- a/tests/test_assurancectl.py
+++ b/tests/test_assurancectl.py
@@ -304,6 +304,112 @@ class AssuranceCtlTests(unittest.TestCase):
             self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
             self.assertIn("identity bootstrap missing active bindings for roles: treasury-program-manager", result.stderr)
 
+    def test_validate_fails_when_checkpoint_signer_actor_ownership_is_duplicated(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for source, target in (
+                ("config/network-topology.json", "config/network-topology.json"),
+                ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
+                ("config/policy/release-guards.json", "config/policy/release-guards.json"),
+                ("config/governance/inference-policy.json", "config/governance/inference-policy.json"),
+                ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
+                ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
+                ("config/identity/bootstrap.json", "config/identity/bootstrap.json"),
+            ):
+                target_path = root / target
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                target_path.write_text((PROJECT_ROOT / source).read_text(encoding="utf-8"), encoding="utf-8")
+
+            signer_path = root / "config" / "governance" / "checkpoint-signers.json"
+            signer_payload = json.loads(signer_path.read_text(encoding="utf-8"))
+            signer_payload["signers"][1]["actor_id"] = signer_payload["signers"][0]["actor_id"]
+            signer_path.write_text(json.dumps(signer_payload), encoding="utf-8")
+
+            env = {"PYTHONPATH": PYTHONPATH}
+            result = subprocess.run(
+                [sys.executable, "-m", "assurancectl.cli", "--root", str(root), "validate"],
+                cwd=PROJECT_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("duplicate checkpoint signer actor ownership", result.stderr)
+
+    def test_validate_fails_when_checkpoint_signer_rotation_is_stale(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for source, target in (
+                ("config/network-topology.json", "config/network-topology.json"),
+                ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
+                ("config/policy/release-guards.json", "config/policy/release-guards.json"),
+                ("config/governance/inference-policy.json", "config/governance/inference-policy.json"),
+                ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
+                ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
+                ("config/identity/bootstrap.json", "config/identity/bootstrap.json"),
+            ):
+                target_path = root / target
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                target_path.write_text((PROJECT_ROOT / source).read_text(encoding="utf-8"), encoding="utf-8")
+
+            signer_path = root / "config" / "governance" / "checkpoint-signers.json"
+            signer_payload = json.loads(signer_path.read_text(encoding="utf-8"))
+            signer_payload["signers"][0]["rotate_by"] = "2026-04-01T00:00:00Z"
+            signer_path.write_text(json.dumps(signer_payload), encoding="utf-8")
+
+            env = {"PYTHONPATH": PYTHONPATH}
+            result = subprocess.run(
+                [sys.executable, "-m", "assurancectl.cli", "--root", str(root), "validate"],
+                cwd=PROJECT_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("stale rotation metadata", result.stderr)
+
+    def test_validate_fails_when_checkpoint_signer_coverage_is_incomplete(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            for source, target in (
+                ("config/network-topology.json", "config/network-topology.json"),
+                ("config/genesis/base-genesis.json", "config/genesis/base-genesis.json"),
+                ("config/policy/release-guards.json", "config/policy/release-guards.json"),
+                ("config/governance/inference-policy.json", "config/governance/inference-policy.json"),
+                ("config/governance/checkpoint-signers.json", "config/governance/checkpoint-signers.json"),
+                ("config/modules/milestone-1.json", "config/modules/milestone-1.json"),
+                ("config/identity/bootstrap.json", "config/identity/bootstrap.json"),
+            ):
+                target_path = root / target
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                target_path.write_text((PROJECT_ROOT / source).read_text(encoding="utf-8"), encoding="utf-8")
+
+            signer_path = root / "config" / "governance" / "checkpoint-signers.json"
+            signer_payload = json.loads(signer_path.read_text(encoding="utf-8"))
+            signer_payload["signers"] = [
+                signer
+                for signer in signer_payload["signers"]
+                if signer["signer_id"] != "treasury-review-chair-bot"
+            ]
+            signer_path.write_text(json.dumps(signer_payload), encoding="utf-8")
+
+            env = {"PYTHONPATH": PYTHONPATH}
+            result = subprocess.run(
+                [sys.executable, "-m", "assurancectl.cli", "--root", str(root), "validate"],
+                cwd=PROJECT_ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("checkpoint signer coverage missing roles: treasury-review-chair", result.stderr)
+
     def test_governance_sim_treasury_grant(self) -> None:
         result = self.run_cli(
             "governance-sim",


### PR DESCRIPTION
## Summary
- add strict checkpoint signer rotation metadata and coverage validation
- render a deterministic signer manifest and ordered rotation plan from bootstrap state
- document the signer manifest contract and cover duplicate owner, missing coverage, and stale rotation failures

## Testing
- python -m unittest discover -s tests -v
- make validate
- make go-test
- make go-build
- ./0aid signer-manifest --root .
- make signer-manifest OUT=build/signer-manifest.json

Closes #16