### PR TITLE
Add signer rotation receipt stubs and preview manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/localnet/
 build/nodes/
+build/rotation/
 build/*.json
 .cache/
 /0aid

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -24,6 +24,7 @@ help:
 	@echo "  module-plan      Render the first registry/attestation milestone plan"
 	@echo "  identity-plan    Render the permissioned actor and role bootstrap plan"
 	@echo "  signer-manifest  Render checkpoint signer ownership and rotation plan"
+	@echo "  signer-rotation-receipt Render a replacement-ready signer manifest and rotation receipt stub"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -81,6 +82,13 @@ identity-plan:
 
 signer-manifest:
 	./0aid signer-manifest --root . $(if $(OUT),--out $(OUT),)
+
+signer-rotation-receipt:
+	@test -n "$(OUTGOING_SIGNER_ID)" || (echo "Usage: make signer-rotation-receipt OUTGOING_SIGNER_ID=governance-chair-bot INCOMING_SIGNER_ID=governance-chair-bot-v2 INCOMING_KEY_ID=governance-chair-dev-v2 EFFECTIVE_AT=2026-04-24T00:00:00Z" && exit 1)
+	@test -n "$(INCOMING_SIGNER_ID)" || (echo "Usage: make signer-rotation-receipt OUTGOING_SIGNER_ID=governance-chair-bot INCOMING_SIGNER_ID=governance-chair-bot-v2 INCOMING_KEY_ID=governance-chair-dev-v2 EFFECTIVE_AT=2026-04-24T00:00:00Z" && exit 1)
+	@test -n "$(INCOMING_KEY_ID)" || (echo "Usage: make signer-rotation-receipt OUTGOING_SIGNER_ID=governance-chair-bot INCOMING_SIGNER_ID=governance-chair-bot-v2 INCOMING_KEY_ID=governance-chair-dev-v2 EFFECTIVE_AT=2026-04-24T00:00:00Z" && exit 1)
+	@test -n "$(EFFECTIVE_AT)" || (echo "Usage: make signer-rotation-receipt OUTGOING_SIGNER_ID=governance-chair-bot INCOMING_SIGNER_ID=governance-chair-bot-v2 INCOMING_KEY_ID=governance-chair-dev-v2 EFFECTIVE_AT=2026-04-24T00:00:00Z" && exit 1)
+	./0aid signer-rotation-receipt --root . --outgoing-signer-id $(OUTGOING_SIGNER_ID) --incoming-signer-id $(INCOMING_SIGNER_ID) --incoming-key-id $(INCOMING_KEY_ID) --effective-at $(EFFECTIVE_AT) $(if $(INCOMING_ACTOR_ID),--incoming-actor-id $(INCOMING_ACTOR_ID),) $(if $(INCOMING_ROLES),--incoming-roles $(INCOMING_ROLES),) $(if $(INCOMING_PROVISIONED_AT),--incoming-provisioned-at $(INCOMING_PROVISIONED_AT),) $(if $(INCOMING_ROTATE_BY),--incoming-rotate-by $(INCOMING_ROTATE_BY),) $(if $(RECEIPT_ID),--receipt-id $(RECEIPT_ID),) $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ make -C projects/0ai-assurance-network go-test
 make -C projects/0ai-assurance-network module-plan
 make -C projects/0ai-assurance-network identity-plan
 make -C projects/0ai-assurance-network signer-manifest
+make -C projects/0ai-assurance-network signer-rotation-receipt OUTGOING_SIGNER_ID=governance-chair-bot INCOMING_SIGNER_ID=governance-chair-bot-v2 INCOMING_KEY_ID=governance-chair-dev-v2 EFFECTIVE_AT=2026-04-24T00:00:00Z
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -180,6 +181,14 @@ rotation metadata is stale, if two active signers claim the same actor
 ownership, or if a governance execution role has no active signer coverage. The
 rotation contract is described in [docs/signer-manifests.md](docs/signer-manifests.md).
 
+`signer-rotation-receipt` renders a machine-readable rotation receipt stub for
+one outgoing signer plus a replacement-ready signer manifest preview. The stub
+records the outgoing signer, the incoming signer/key, approval actors, the
+effective cutover time, and the manifest path the operator should publish with
+the receipt. Rotation receipts fail closed when the replacement would leave a
+required governance role uncovered, reuse another active actor owner, or use an
+invalid effective-at ordering.
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -192,6 +201,7 @@ currently supports:
 - `module-plan`
 - `identity-plan`
 - `signer-manifest`
+- `signer-rotation-receipt`
 - `show-plan`
 - `init-genesis`
 - `render-validator`
@@ -208,6 +218,12 @@ Bootstrap examples:
 ./0aid module-plan --root . --out ./build/module-plan.json
 ./0aid identity-plan --root . --out ./build/identity-plan.json
 ./0aid signer-manifest --root . --out ./build/signer-manifest.json
+./0aid signer-rotation-receipt --root . \
+  --outgoing-signer-id governance-chair-bot \
+  --incoming-signer-id governance-chair-bot-v2 \
+  --incoming-key-id governance-chair-dev-v2 \
+  --effective-at 2026-04-24T00:00:00Z \
+  --out ./build/rotation/governance-chair-receipt.json
 ./0aid init-node --root . --id val-3 --out ./build/nodes/validator-3
 ./0aid collect-validator --bundle ./build/nodes/validator-3 --out ./build/collection/validator-3.json
 ./0aid assemble-genesis --root . --collection ./build/collection --out ./build/assembled/genesis-plan.json

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/0ai-Cyberviser/0ai-assurance-network/internal/project"
 )
@@ -85,6 +86,64 @@ func run(args []string) error {
 			return printJSON(manifest)
 		}
 		return project.WriteJSON(filepath.Clean(*out), manifest)
+	case "signer-rotation-receipt":
+		fs := flag.NewFlagSet("signer-rotation-receipt", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		outgoingSignerID := fs.String("outgoing-signer-id", "", "outgoing signer id")
+		incomingSignerID := fs.String("incoming-signer-id", "", "incoming signer id")
+		incomingKeyID := fs.String("incoming-key-id", "", "incoming key id")
+		incomingActorID := fs.String("incoming-actor-id", "", "incoming actor id (defaults to outgoing actor)")
+		incomingRoles := fs.String("incoming-roles", "", "comma-separated incoming roles (defaults to outgoing roles)")
+		incomingProvisionedAt := fs.String("incoming-provisioned-at", "", "incoming signer provisioned_at timestamp")
+		incomingRotateBy := fs.String("incoming-rotate-by", "", "incoming signer rotate_by timestamp")
+		effectiveAt := fs.String("effective-at", "", "rotation effective_at timestamp")
+		receiptID := fs.String("receipt-id", "", "explicit receipt id")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *outgoingSignerID == "" {
+			return errors.New("signer-rotation-receipt requires --outgoing-signer-id")
+		}
+		if *incomingSignerID == "" {
+			return errors.New("signer-rotation-receipt requires --incoming-signer-id")
+		}
+		if *incomingKeyID == "" {
+			return errors.New("signer-rotation-receipt requires --incoming-key-id")
+		}
+		if *effectiveAt == "" {
+			return errors.New("signer-rotation-receipt requires --effective-at")
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		request := project.SignerRotationReceiptRequest{
+			OutgoingSignerID:      *outgoingSignerID,
+			IncomingSignerID:      *incomingSignerID,
+			IncomingKeyID:         *incomingKeyID,
+			IncomingActorID:       *incomingActorID,
+			IncomingProvisionedAt: *incomingProvisionedAt,
+			IncomingRotateBy:      *incomingRotateBy,
+			EffectiveAt:           *effectiveAt,
+			ReceiptID:             *receiptID,
+		}
+		if strings.TrimSpace(*incomingRoles) != "" {
+			for _, role := range strings.Split(*incomingRoles, ",") {
+				role = strings.TrimSpace(role)
+				if role != "" {
+					request.IncomingRoles = append(request.IncomingRoles, role)
+				}
+			}
+		}
+		receipt, err := project.SignerRotationReceipt(bundle, request)
+		if err != nil {
+			return err
+		}
+		if *out == "" {
+			return printJSON(receipt)
+		}
+		return project.WriteJSON(filepath.Clean(*out), receipt)
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -253,7 +312,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 

--- a/config/governance/checkpoint-signers.json
+++ b/config/governance/checkpoint-signers.json
@@ -5,7 +5,12 @@
   "maximum_signature_validity_seconds": 86400,
   "rotation_policy": {
     "reference_time": "2026-04-17T00:00:00Z",
-    "warning_window_days": 14
+    "warning_window_days": 14,
+    "approval_roles": [
+      "governance-ops",
+      "token-house-secretariat",
+      "telemetry-ops"
+    ]
   },
   "signers": [
     {

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -53,6 +53,8 @@ The manifest contains:
 - per-role governance references such as `governance:phase_owner:*`
 - rotation status (`current`, `expiring`, `inactive`)
 - `rotation_plan`, sorted by earliest `rotate_by`
+- deterministic `next_rotation_receipt_id` values
+- deterministic `replacement_manifest_ref` paths
 
 Example:
 
@@ -63,3 +65,47 @@ Example:
 This command should be treated as a release-gating check for governance
 bootstrap changes. If it fails, the signer policy is no longer operationally
 sound enough to exercise checkpoint replay or remediation signing.
+
+## Rotation receipts
+
+`0aid signer-rotation-receipt` creates a machine-readable receipt stub for a
+planned signer replacement.
+
+The receipt includes:
+
+- outgoing signer metadata
+- incoming signer metadata
+- approval actor requirements, resolved from `rotation_policy.approval_roles`
+- `effective_at`
+- a deterministic `replacement_manifest_ref`
+- a full replacement-ready signer manifest preview
+
+Example:
+
+```bash
+./0aid signer-rotation-receipt --root . \
+  --outgoing-signer-id governance-chair-bot \
+  --incoming-signer-id governance-chair-bot-v2 \
+  --incoming-key-id governance-chair-dev-v2 \
+  --effective-at 2026-04-24T00:00:00Z \
+  --out ./build/rotation/governance-chair-receipt.json
+```
+
+The replacement preview only renders when:
+
+- the incoming actor is active
+- the incoming actor is actively bound to every replacement role
+- the replacement does not reuse another active signer owner
+- the replacement preserves all required governance execution role coverage
+- `effective_at` is after the current reference time and on or before the
+  outgoing signer `rotate_by`
+
+## Operator workflow
+
+1. Render the current signer manifest and identify any `expiring` signers.
+2. Generate a signer rotation receipt stub for the outgoing signer.
+3. Review the approval actor set and replacement manifest preview.
+4. Collect governance approval against the receipt stub.
+5. Publish the approved receipt together with the replacement signer manifest.
+6. Update `config/governance/checkpoint-signers.json` only after the approved
+   replacement manifest is ready to become the new active state.

--- a/internal/project/config_test.go
+++ b/internal/project/config_test.go
@@ -42,6 +42,9 @@ func TestLoadBundle(t *testing.T) {
 	if rotationPolicy["reference_time"] != "2026-04-17T00:00:00Z" {
 		t.Fatalf("unexpected signer rotation reference time: %v", rotationPolicy["reference_time"])
 	}
+	if len(rotationPolicy["approval_roles"].([]any)) != 3 {
+		t.Fatalf("expected 3 signer rotation approval roles, got %d", len(rotationPolicy["approval_roles"].([]any)))
+	}
 	if len(bundle.InferencePolicy) == 0 {
 		t.Fatal("expected inference policy to be loaded")
 	}

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -13,31 +14,35 @@ type SignerRoleCoverage struct {
 }
 
 type SignerManifestEntry struct {
-	ActorID           string               `json:"actor_id"`
-	ActorDisplayName  string               `json:"actor_display_name"`
-	ActorStatus       string               `json:"actor_status"`
-	OrganizationID    string               `json:"organization_id,omitempty"`
-	OrganizationName  string               `json:"organization_name,omitempty"`
-	SignerID          string               `json:"signer_id"`
-	KeyID             string               `json:"key_id"`
-	SignerStatus      string               `json:"signer_status"`
-	Roles             []string             `json:"roles"`
-	RoleCoverage      []SignerRoleCoverage `json:"role_coverage"`
-	ProvisionedAt     string               `json:"provisioned_at"`
-	RotateBy          string               `json:"rotate_by"`
-	RotationStatus    string               `json:"rotation_status"`
-	DaysUntilRotation int                  `json:"days_until_rotation"`
+	ActorID                string               `json:"actor_id"`
+	ActorDisplayName       string               `json:"actor_display_name"`
+	ActorStatus            string               `json:"actor_status"`
+	OrganizationID         string               `json:"organization_id,omitempty"`
+	OrganizationName       string               `json:"organization_name,omitempty"`
+	SignerID               string               `json:"signer_id"`
+	KeyID                  string               `json:"key_id"`
+	SignerStatus           string               `json:"signer_status"`
+	Roles                  []string             `json:"roles"`
+	RoleCoverage           []SignerRoleCoverage `json:"role_coverage"`
+	ProvisionedAt          string               `json:"provisioned_at"`
+	RotateBy               string               `json:"rotate_by"`
+	RotationStatus         string               `json:"rotation_status"`
+	DaysUntilRotation      int                  `json:"days_until_rotation"`
+	NextRotationReceiptID  string               `json:"next_rotation_receipt_id"`
+	ReplacementManifestRef string               `json:"replacement_manifest_ref"`
 }
 
 type SignerRotationPlanEntry struct {
-	Order             int      `json:"order"`
-	SignerID          string   `json:"signer_id"`
-	ActorID           string   `json:"actor_id"`
-	Roles             []string `json:"roles"`
-	RotateBy          string   `json:"rotate_by"`
-	RotationStatus    string   `json:"rotation_status"`
-	DaysUntilRotation int      `json:"days_until_rotation"`
-	RecommendedAction string   `json:"recommended_action"`
+	Order                  int      `json:"order"`
+	SignerID               string   `json:"signer_id"`
+	ActorID                string   `json:"actor_id"`
+	Roles                  []string `json:"roles"`
+	RotateBy               string   `json:"rotate_by"`
+	RotationStatus         string   `json:"rotation_status"`
+	DaysUntilRotation      int      `json:"days_until_rotation"`
+	RecommendedAction      string   `json:"recommended_action"`
+	NextRotationReceiptID  string   `json:"next_rotation_receipt_id"`
+	ReplacementManifestRef string   `json:"replacement_manifest_ref"`
 }
 
 type SignerManifestOutput struct {
@@ -53,6 +58,62 @@ type SignerManifestOutput struct {
 	ExpiringSignerIDs   []string                  `json:"expiring_signer_ids"`
 	RotationPlan        []SignerRotationPlanEntry `json:"rotation_plan"`
 	Signers             []SignerManifestEntry     `json:"signers"`
+}
+
+type SignerRotationApprovalOption struct {
+	ActorID          string `json:"actor_id"`
+	ActorDisplayName string `json:"actor_display_name"`
+	OrganizationID   string `json:"organization_id,omitempty"`
+	OrganizationName string `json:"organization_name,omitempty"`
+	SignerID         string `json:"signer_id"`
+}
+
+type SignerRotationApprovalRequirement struct {
+	Role            string                         `json:"role"`
+	EligibleSigners []SignerRotationApprovalOption `json:"eligible_signers"`
+}
+
+type SignerRotationReplacement struct {
+	ActorID                string   `json:"actor_id"`
+	ActorDisplayName       string   `json:"actor_display_name"`
+	OrganizationID         string   `json:"organization_id,omitempty"`
+	OrganizationName       string   `json:"organization_name,omitempty"`
+	SignerID               string   `json:"signer_id"`
+	KeyID                  string   `json:"key_id"`
+	Roles                  []string `json:"roles"`
+	ProvisionedAt          string   `json:"provisioned_at"`
+	RotateBy               string   `json:"rotate_by"`
+	EffectiveAt            string   `json:"effective_at"`
+	RotationReceiptID      string   `json:"rotation_receipt_id"`
+	ReplacementManifestRef string   `json:"replacement_manifest_ref"`
+}
+
+type SignerRotationReceiptRequest struct {
+	OutgoingSignerID      string
+	IncomingSignerID      string
+	IncomingKeyID         string
+	IncomingActorID       string
+	IncomingRoles         []string
+	IncomingProvisionedAt string
+	IncomingRotateBy      string
+	EffectiveAt           string
+	ReceiptID             string
+}
+
+type SignerRotationReceiptOutput struct {
+	Version                   string                              `json:"version"`
+	ChainID                   string                              `json:"chain_id"`
+	PolicyVersion             string                              `json:"policy_version"`
+	IdentityVersion           string                              `json:"identity_version"`
+	ReceiptID                 string                              `json:"receipt_id"`
+	EffectiveAt               string                              `json:"effective_at"`
+	OutgoingSigner            SignerManifestEntry                 `json:"outgoing_signer"`
+	IncomingSigner            SignerRotationReplacement           `json:"incoming_signer"`
+	ApprovalRequirements      []SignerRotationApprovalRequirement `json:"approval_requirements"`
+	CoverageStatus            string                              `json:"coverage_status"`
+	MissingRoleCoverage       []string                            `json:"missing_role_coverage"`
+	ReplacementManifestRef    string                              `json:"replacement_manifest_ref"`
+	ReplacementSignerManifest SignerManifestOutput                `json:"replacement_signer_manifest"`
 }
 
 type parsedSignerEntry struct {
@@ -121,6 +182,179 @@ func signerRotationStatus(referenceTime time.Time, warningWindowDays int, signer
 	return "current"
 }
 
+func signerReceiptArtifacts(signerID string, targetTime time.Time) (string, string) {
+	stamp := strings.ToLower(targetTime.UTC().Format("20060102t150405z"))
+	receiptID := fmt.Sprintf("rotation-%s-%s", signerID, stamp)
+	return receiptID, fmt.Sprintf("build/rotation/%s/replacement-signer-manifest.json", receiptID)
+}
+
+func governanceApprovalRoles(bundle Bundle) ([]string, error) {
+	rotationPolicy := stringMap(bundle.CheckpointSigners["rotation_policy"])
+	rawRoles, ok := rotationPolicy["approval_roles"].([]any)
+	if !ok || len(rawRoles) == 0 {
+		return nil, fmt.Errorf("checkpoint signer rotation_policy.approval_roles must not be empty")
+	}
+	roles := make([]string, 0, len(rawRoles))
+	for _, rawRole := range rawRoles {
+		role := fmt.Sprint(rawRole)
+		if role != "" {
+			roles = append(roles, role)
+		}
+	}
+	sort.Strings(roles)
+	return roles, nil
+}
+
+func activeActorsAndBindings(bundle Bundle) (map[string]IdentityActor, map[string]struct{}) {
+	actors := make(map[string]IdentityActor, len(bundle.Identity.Actors))
+	activeRoleBindings := make(map[string]struct{}, len(bundle.Identity.RoleBindings))
+	for _, actor := range bundle.Identity.Actors {
+		actors[actor.ActorID] = actor
+	}
+	for _, binding := range bundle.Identity.RoleBindings {
+		if binding.Status == "active" {
+			activeRoleBindings[binding.ActorID+"|"+binding.Role] = struct{}{}
+		}
+	}
+	return actors, activeRoleBindings
+}
+
+func governanceRequiredRoles(bundle Bundle) []string {
+	required := make([]string, 0)
+	roleUsage := governanceExecutionRoleUsage(bundle)
+	for role := range roleUsage {
+		required = append(required, role)
+	}
+	sort.Strings(required)
+	return required
+}
+
+func parseCurrentSigners(bundle Bundle, referenceTime time.Time, warningWindowDays int) ([]parsedSignerEntry, error) {
+	rawSigners, ok := bundle.CheckpointSigners["signers"].([]any)
+	if !ok || len(rawSigners) == 0 {
+		return nil, fmt.Errorf("at least one checkpoint signer must be configured")
+	}
+
+	parsedSigners := make([]parsedSignerEntry, 0, len(rawSigners))
+	for _, rawSigner := range rawSigners {
+		signer := stringMap(rawSigner)
+		provisionedAt, err := parseRFC3339(signer["provisioned_at"], "checkpoint signer provisioned_at")
+		if err != nil {
+			return nil, err
+		}
+		rotateBy, err := parseRFC3339(signer["rotate_by"], "checkpoint signer rotate_by")
+		if err != nil {
+			return nil, err
+		}
+		status := fmt.Sprint(signer["status"])
+		daysUntilRotation := int(rotateBy.Sub(referenceTime).Hours() / 24)
+		parsedSigners = append(parsedSigners, parsedSignerEntry{
+			ActorID:           fmt.Sprint(signer["actor_id"]),
+			SignerID:          fmt.Sprint(signer["signer_id"]),
+			KeyID:             fmt.Sprint(signer["key_id"]),
+			Status:            status,
+			Roles:             stringSlice(signer["roles"]),
+			ProvisionedAt:     provisionedAt,
+			RotateBy:          rotateBy,
+			RotationStatus:    signerRotationStatus(referenceTime, warningWindowDays, status, rotateBy),
+			DaysUntilRotation: daysUntilRotation,
+		})
+	}
+	return parsedSigners, nil
+}
+
+func validateSignerSet(
+	bundle Bundle,
+	parsedSigners []parsedSignerEntry,
+	referenceTime time.Time,
+	warningWindowDays int,
+	requiredRoles []string,
+) error {
+	actors, activeRoleBindings := activeActorsAndBindings(bundle)
+
+	signerIDs := make(map[string]struct{}, len(parsedSigners))
+	keyIDs := make(map[string]struct{}, len(parsedSigners))
+	activeActorIDs := make(map[string]struct{}, len(parsedSigners))
+	activeRoleCoverage := make(map[string]string)
+
+	for _, signer := range parsedSigners {
+		if signer.ActorID == "" {
+			return fmt.Errorf("checkpoint signer %s must declare actor_id", signer.SignerID)
+		}
+		if signer.SignerID == "" {
+			return fmt.Errorf("checkpoint signer signer_id must not be empty")
+		}
+		if _, exists := signerIDs[signer.SignerID]; exists {
+			return fmt.Errorf("duplicate checkpoint signer_id: %s", signer.SignerID)
+		}
+		if _, exists := keyIDs[signer.KeyID]; exists {
+			return fmt.Errorf("duplicate checkpoint key_id: %s", signer.KeyID)
+		}
+		if signer.Status != "active" && signer.Status != "inactive" {
+			return fmt.Errorf("checkpoint signer %s has invalid status", signer.SignerID)
+		}
+		if len(signer.Roles) == 0 {
+			return fmt.Errorf("checkpoint signer %s must declare at least one role", signer.SignerID)
+		}
+		if !signer.RotateBy.After(signer.ProvisionedAt) {
+			return fmt.Errorf("checkpoint signer %s rotate_by must be after provisioned_at", signer.SignerID)
+		}
+
+		actor, exists := actors[signer.ActorID]
+		if !exists {
+			return fmt.Errorf("checkpoint signer %s references unknown actor %s", signer.SignerID, signer.ActorID)
+		}
+		if actor.Status != "active" {
+			return fmt.Errorf("checkpoint signer %s references inactive actor %s", signer.SignerID, signer.ActorID)
+		}
+
+		for _, role := range signer.Roles {
+			if _, exists := activeRoleBindings[signer.ActorID+"|"+role]; !exists {
+				return fmt.Errorf(
+					"checkpoint signer %s role %s is not backed by an active identity binding",
+					signer.SignerID,
+					role,
+				)
+			}
+		}
+
+		if signer.Status == "active" {
+			if _, exists := activeActorIDs[signer.ActorID]; exists {
+				return fmt.Errorf("duplicate checkpoint signer actor ownership: %s", signer.ActorID)
+			}
+			activeActorIDs[signer.ActorID] = struct{}{}
+			if !signer.RotateBy.After(referenceTime) {
+				return fmt.Errorf("checkpoint signer %s has stale rotation metadata", signer.SignerID)
+			}
+			for _, role := range signer.Roles {
+				if owner, exists := activeRoleCoverage[role]; exists {
+					return fmt.Errorf("duplicate checkpoint signer role coverage: %s (%s, %s)", role, owner, signer.SignerID)
+				}
+				activeRoleCoverage[role] = signer.SignerID
+			}
+			if signerRotationStatus(referenceTime, warningWindowDays, signer.Status, signer.RotateBy) == "stale" {
+				return fmt.Errorf("checkpoint signer %s has stale rotation metadata", signer.SignerID)
+			}
+		}
+
+		signerIDs[signer.SignerID] = struct{}{}
+		keyIDs[signer.KeyID] = struct{}{}
+	}
+
+	missingRoles := make([]string, 0)
+	for _, role := range requiredRoles {
+		if _, exists := activeRoleCoverage[role]; !exists {
+			missingRoles = append(missingRoles, role)
+		}
+	}
+	sort.Strings(missingRoles)
+	if len(missingRoles) > 0 {
+		return fmt.Errorf("checkpoint signer coverage missing roles: %s", commaList(missingRoles))
+	}
+
+	return nil
+}
+
 func ValidateSignerManifestInputs(bundle Bundle) error {
 	if err := ValidateIdentityBootstrap(bundle); err != nil {
 		return err
@@ -145,229 +379,133 @@ func ValidateSignerManifestInputs(bundle Bundle) error {
 	if err != nil || warningWindowDays <= 0 {
 		return fmt.Errorf("checkpoint signer rotation_policy.warning_window_days must be positive")
 	}
-
-	roleUsage := governanceExecutionRoleUsage(bundle)
-	actors := make(map[string]IdentityActor, len(bundle.Identity.Actors))
-	activeRoleBindings := make(map[string]struct{}, len(bundle.Identity.RoleBindings))
-	for _, actor := range bundle.Identity.Actors {
-		actors[actor.ActorID] = actor
-	}
-	for _, binding := range bundle.Identity.RoleBindings {
-		if binding.Status == "active" {
-			activeRoleBindings[binding.ActorID+"|"+binding.Role] = struct{}{}
-		}
+	approvalRoles, err := governanceApprovalRoles(bundle)
+	if err != nil {
+		return err
 	}
 
-	rawSigners, ok := bundle.CheckpointSigners["signers"].([]any)
-	if !ok || len(rawSigners) == 0 {
-		return fmt.Errorf("at least one checkpoint signer must be configured")
+	requiredRoles := governanceRequiredRoles(bundle)
+	parsedSigners, err := parseCurrentSigners(bundle, referenceTime, warningWindowDays)
+	if err != nil {
+		return err
+	}
+	if err := validateSignerSet(bundle, parsedSigners, referenceTime, warningWindowDays, requiredRoles); err != nil {
+		return err
 	}
 
-	signerIDs := make(map[string]struct{}, len(rawSigners))
-	keyIDs := make(map[string]struct{}, len(rawSigners))
-	activeActorIDs := make(map[string]struct{}, len(rawSigners))
-	activeRoleCoverage := make(map[string]string)
-
-	for _, rawSigner := range rawSigners {
-		signer := stringMap(rawSigner)
-		actorID := fmt.Sprint(signer["actor_id"])
-		signerID := fmt.Sprint(signer["signer_id"])
-		keyID := fmt.Sprint(signer["key_id"])
-		sharedSecret := fmt.Sprint(signer["shared_secret"])
-		status := fmt.Sprint(signer["status"])
-		roles := stringSlice(signer["roles"])
-
-		if actorID == "" {
-			return fmt.Errorf("checkpoint signer %s must declare actor_id", signerID)
+	activeRoleCoverage := make(map[string]struct{})
+	for _, signer := range parsedSigners {
+		if signer.Status != "active" {
+			continue
 		}
-		if signerID == "" {
-			return fmt.Errorf("checkpoint signer signer_id must not be empty")
+		for _, role := range signer.Roles {
+			activeRoleCoverage[role] = struct{}{}
 		}
-		if _, exists := signerIDs[signerID]; exists {
-			return fmt.Errorf("duplicate checkpoint signer_id: %s", signerID)
-		}
-		if _, exists := keyIDs[keyID]; exists {
-			return fmt.Errorf("duplicate checkpoint key_id: %s", keyID)
-		}
-		if sharedSecret == "" {
-			return fmt.Errorf("checkpoint signer %s must declare a shared_secret", signerID)
-		}
-		if status != "active" && status != "inactive" {
-			return fmt.Errorf("checkpoint signer %s has invalid status", signerID)
-		}
-		if len(roles) == 0 {
-			return fmt.Errorf("checkpoint signer %s must declare at least one role", signerID)
-		}
-		provisionedAt, err := parseRFC3339(signer["provisioned_at"], "checkpoint signer "+signerID+" provisioned_at")
-		if err != nil {
-			return err
-		}
-		rotateBy, err := parseRFC3339(signer["rotate_by"], "checkpoint signer "+signerID+" rotate_by")
-		if err != nil {
-			return err
-		}
-		if !rotateBy.After(provisionedAt) {
-			return fmt.Errorf("checkpoint signer %s rotate_by must be after provisioned_at", signerID)
-		}
-
-		actor, exists := actors[actorID]
-		if !exists {
-			return fmt.Errorf("checkpoint signer %s references unknown actor %s", signerID, actorID)
-		}
-		if actor.Status != "active" {
-			return fmt.Errorf("checkpoint signer %s references inactive actor %s", signerID, actorID)
-		}
-
-		for _, role := range roles {
-			if _, exists := activeRoleBindings[actorID+"|"+role]; !exists {
-				return fmt.Errorf(
-					"checkpoint signer %s role %s is not backed by an active identity binding",
-					signerID,
-					role,
-				)
-			}
-		}
-
-		if status == "active" {
-			if _, exists := activeActorIDs[actorID]; exists {
-				return fmt.Errorf("duplicate checkpoint signer actor ownership: %s", actorID)
-			}
-			activeActorIDs[actorID] = struct{}{}
-			if !rotateBy.After(referenceTime) {
-				return fmt.Errorf("checkpoint signer %s has stale rotation metadata", signerID)
-			}
-			for _, role := range roles {
-				if owner, exists := activeRoleCoverage[role]; exists {
-					return fmt.Errorf("duplicate checkpoint signer role coverage: %s (%s, %s)", role, owner, signerID)
-				}
-				activeRoleCoverage[role] = signerID
-			}
-			if signerRotationStatus(referenceTime, warningWindowDays, status, rotateBy) == "stale" {
-				return fmt.Errorf("checkpoint signer %s has stale rotation metadata", signerID)
-			}
-		}
-
-		signerIDs[signerID] = struct{}{}
-		keyIDs[keyID] = struct{}{}
 	}
-
-	missingRoles := make([]string, 0)
-	for role := range roleUsage {
+	missingApprovalRoles := make([]string, 0)
+	for _, role := range approvalRoles {
 		if _, exists := activeRoleCoverage[role]; !exists {
-			missingRoles = append(missingRoles, role)
+			missingApprovalRoles = append(missingApprovalRoles, role)
 		}
 	}
-	sort.Strings(missingRoles)
-	if len(missingRoles) > 0 {
-		return fmt.Errorf("checkpoint signer coverage missing roles: %s", commaList(missingRoles))
+	if len(missingApprovalRoles) > 0 {
+		return fmt.Errorf("checkpoint signer approval roles missing active coverage: %s", commaList(missingApprovalRoles))
 	}
-
 	return nil
 }
 
-func SignerManifest(bundle Bundle) (SignerManifestOutput, error) {
-	if err := ValidateSignerManifestInputs(bundle); err != nil {
-		return SignerManifestOutput{}, err
-	}
-
-	rotationPolicy := stringMap(bundle.CheckpointSigners["rotation_policy"])
-	referenceTime, _ := parseRFC3339(rotationPolicy["reference_time"], "checkpoint signer rotation_policy.reference_time")
-	warningWindowDays, _ := intValue(rotationPolicy["warning_window_days"])
-	roleUsage := governanceExecutionRoleUsage(bundle)
-
-	actors := make(map[string]IdentityActor, len(bundle.Identity.Actors))
-	for _, actor := range bundle.Identity.Actors {
-		actors[actor.ActorID] = actor
-	}
-
-	entries := make([]SignerManifestEntry, 0)
-	expiring := make([]string, 0)
-	rotationPlan := make([]SignerRotationPlanEntry, 0)
-
-	rawSigners := bundle.CheckpointSigners["signers"].([]any)
-	parsedSigners := make([]parsedSignerEntry, 0, len(rawSigners))
-	for _, rawSigner := range rawSigners {
-		signer := stringMap(rawSigner)
-		provisionedAt, _ := parseRFC3339(signer["provisioned_at"], "checkpoint signer provisioned_at")
-		rotateBy, _ := parseRFC3339(signer["rotate_by"], "checkpoint signer rotate_by")
-		status := fmt.Sprint(signer["status"])
-		daysUntilRotation := int(rotateBy.Sub(referenceTime).Hours() / 24)
-		parsedSigners = append(parsedSigners, parsedSignerEntry{
-			ActorID:           fmt.Sprint(signer["actor_id"]),
-			SignerID:          fmt.Sprint(signer["signer_id"]),
-			KeyID:             fmt.Sprint(signer["key_id"]),
-			Status:            status,
-			Roles:             stringSlice(signer["roles"]),
-			ProvisionedAt:     provisionedAt,
-			RotateBy:          rotateBy,
-			RotationStatus:    signerRotationStatus(referenceTime, warningWindowDays, status, rotateBy),
-			DaysUntilRotation: daysUntilRotation,
+func signerRoleCoverage(roleUsage map[string][]string, roles []string) []SignerRoleCoverage {
+	coverage := make([]SignerRoleCoverage, 0, len(roles))
+	for _, role := range roles {
+		referencedBy := append([]string(nil), roleUsage[role]...)
+		sort.Strings(referencedBy)
+		coverage = append(coverage, SignerRoleCoverage{
+			Role:         role,
+			ReferencedBy: referencedBy,
 		})
 	}
+	sort.Slice(coverage, func(i, j int) bool {
+		return coverage[i].Role < coverage[j].Role
+	})
+	return coverage
+}
 
-	sort.Slice(parsedSigners, func(i, j int) bool {
-		if parsedSigners[i].RotateBy.Equal(parsedSigners[j].RotateBy) {
-			return parsedSigners[i].SignerID < parsedSigners[j].SignerID
+func buildSignerManifestEntry(
+	actors map[string]IdentityActor,
+	roleUsage map[string][]string,
+	signer parsedSignerEntry,
+) SignerManifestEntry {
+	actor := actors[signer.ActorID]
+	organizationName := ""
+	if actor.OrganizationID != "" {
+		if organization, exists := actors[actor.OrganizationID]; exists {
+			organizationName = organization.DisplayName
 		}
-		return parsedSigners[i].RotateBy.Before(parsedSigners[j].RotateBy)
+	}
+	receiptID, manifestRef := signerReceiptArtifacts(signer.SignerID, signer.RotateBy)
+	return SignerManifestEntry{
+		ActorID:                signer.ActorID,
+		ActorDisplayName:       actor.DisplayName,
+		ActorStatus:            actor.Status,
+		OrganizationID:         actor.OrganizationID,
+		OrganizationName:       organizationName,
+		SignerID:               signer.SignerID,
+		KeyID:                  signer.KeyID,
+		SignerStatus:           signer.Status,
+		Roles:                  append([]string(nil), signer.Roles...),
+		RoleCoverage:           signerRoleCoverage(roleUsage, signer.Roles),
+		ProvisionedAt:          signer.ProvisionedAt.Format(time.RFC3339),
+		RotateBy:               signer.RotateBy.Format(time.RFC3339),
+		RotationStatus:         signer.RotationStatus,
+		DaysUntilRotation:      signer.DaysUntilRotation,
+		NextRotationReceiptID:  receiptID,
+		ReplacementManifestRef: manifestRef,
+	}
+}
+
+func buildSignerManifestOutput(
+	bundle Bundle,
+	parsedSigners []parsedSignerEntry,
+	referenceTime time.Time,
+	warningWindowDays int,
+) SignerManifestOutput {
+	roleUsage := governanceExecutionRoleUsage(bundle)
+	actors, _ := activeActorsAndBindings(bundle)
+
+	sortedForPlan := append([]parsedSignerEntry(nil), parsedSigners...)
+	sort.Slice(sortedForPlan, func(i, j int) bool {
+		if sortedForPlan[i].RotateBy.Equal(sortedForPlan[j].RotateBy) {
+			return sortedForPlan[i].SignerID < sortedForPlan[j].SignerID
+		}
+		return sortedForPlan[i].RotateBy.Before(sortedForPlan[j].RotateBy)
 	})
 
+	entries := make([]SignerManifestEntry, 0, len(sortedForPlan))
+	expiring := make([]string, 0)
+	rotationPlan := make([]SignerRotationPlanEntry, 0)
 	activeCount := 0
-	for _, signer := range parsedSigners {
-		actor := actors[signer.ActorID]
-		roleCoverage := make([]SignerRoleCoverage, 0, len(signer.Roles))
-		for _, role := range signer.Roles {
-			referencedBy := append([]string(nil), roleUsage[role]...)
-			sort.Strings(referencedBy)
-			roleCoverage = append(roleCoverage, SignerRoleCoverage{
-				Role:         role,
-				ReferencedBy: referencedBy,
-			})
-		}
-		sort.Slice(roleCoverage, func(i, j int) bool {
-			return roleCoverage[i].Role < roleCoverage[j].Role
-		})
 
-		organizationName := ""
-		if actor.OrganizationID != "" {
-			if organization, exists := actors[actor.OrganizationID]; exists {
-				organizationName = organization.DisplayName
-			}
-		}
-
-		entry := SignerManifestEntry{
-			ActorID:           signer.ActorID,
-			ActorDisplayName:  actor.DisplayName,
-			ActorStatus:       actor.Status,
-			OrganizationID:    actor.OrganizationID,
-			OrganizationName:  organizationName,
-			SignerID:          signer.SignerID,
-			KeyID:             signer.KeyID,
-			SignerStatus:      signer.Status,
-			Roles:             append([]string(nil), signer.Roles...),
-			RoleCoverage:      roleCoverage,
-			ProvisionedAt:     signer.ProvisionedAt.Format(time.RFC3339),
-			RotateBy:          signer.RotateBy.Format(time.RFC3339),
-			RotationStatus:    signer.RotationStatus,
-			DaysUntilRotation: signer.DaysUntilRotation,
-		}
+	for _, signer := range sortedForPlan {
+		entry := buildSignerManifestEntry(actors, roleUsage, signer)
 		entries = append(entries, entry)
-
-		if signer.Status == "active" {
-			activeCount++
-			rotationPlan = append(rotationPlan, SignerRotationPlanEntry{
-				SignerID:          signer.SignerID,
-				ActorID:           signer.ActorID,
-				Roles:             append([]string(nil), signer.Roles...),
-				RotateBy:          signer.RotateBy.Format(time.RFC3339),
-				RotationStatus:    signer.RotationStatus,
-				DaysUntilRotation: signer.DaysUntilRotation,
-				RecommendedAction: recommendedRotationAction(signer.RotationStatus),
-			})
-			if signer.RotationStatus == "expiring" {
-				expiring = append(expiring, signer.SignerID)
-			}
+		if signer.Status != "active" {
+			continue
 		}
+		activeCount++
+		if signer.RotationStatus == "expiring" {
+			expiring = append(expiring, signer.SignerID)
+		}
+		rotationPlan = append(rotationPlan, SignerRotationPlanEntry{
+			SignerID:               signer.SignerID,
+			ActorID:                signer.ActorID,
+			Roles:                  append([]string(nil), signer.Roles...),
+			RotateBy:               signer.RotateBy.Format(time.RFC3339),
+			RotationStatus:         signer.RotationStatus,
+			DaysUntilRotation:      signer.DaysUntilRotation,
+			RecommendedAction:      recommendedRotationAction(signer.RotationStatus),
+			NextRotationReceiptID:  entry.NextRotationReceiptID,
+			ReplacementManifestRef: entry.ReplacementManifestRef,
+		})
 	}
 
 	sort.Slice(entries, func(i, j int) bool {
@@ -379,7 +517,7 @@ func SignerManifest(bundle Bundle) (SignerManifestOutput, error) {
 	}
 
 	return SignerManifestOutput{
-		Version:             "1.0.0",
+		Version:             "1.1.0",
 		ChainID:             bundle.Topology.ChainID,
 		PolicyVersion:       fmt.Sprint(bundle.CheckpointSigners["version"]),
 		IdentityVersion:     bundle.Identity.Version,
@@ -391,6 +529,249 @@ func SignerManifest(bundle Bundle) (SignerManifestOutput, error) {
 		ExpiringSignerIDs:   expiring,
 		RotationPlan:        rotationPlan,
 		Signers:             entries,
+	}
+}
+
+func SignerManifest(bundle Bundle) (SignerManifestOutput, error) {
+	if err := ValidateSignerManifestInputs(bundle); err != nil {
+		return SignerManifestOutput{}, err
+	}
+
+	rotationPolicy := stringMap(bundle.CheckpointSigners["rotation_policy"])
+	referenceTime, _ := parseRFC3339(rotationPolicy["reference_time"], "checkpoint signer rotation_policy.reference_time")
+	warningWindowDays, _ := intValue(rotationPolicy["warning_window_days"])
+	parsedSigners, err := parseCurrentSigners(bundle, referenceTime, warningWindowDays)
+	if err != nil {
+		return SignerManifestOutput{}, err
+	}
+	return buildSignerManifestOutput(bundle, parsedSigners, referenceTime, warningWindowDays), nil
+}
+
+func findParsedSignerByID(signers []parsedSignerEntry, signerID string) (parsedSignerEntry, bool) {
+	for _, signer := range signers {
+		if signer.SignerID == signerID {
+			return signer, true
+		}
+	}
+	return parsedSignerEntry{}, false
+}
+
+func replacementSigners(signers []parsedSignerEntry, outgoingSignerID string, incoming parsedSignerEntry) []parsedSignerEntry {
+	replaced := make([]parsedSignerEntry, 0, len(signers))
+	for _, signer := range signers {
+		if signer.SignerID == outgoingSignerID {
+			continue
+		}
+		replaced = append(replaced, signer)
+	}
+	replaced = append(replaced, incoming)
+	return replaced
+}
+
+func approvalRequirements(bundle Bundle, parsedSigners []parsedSignerEntry) ([]SignerRotationApprovalRequirement, error) {
+	approvalRoles, err := governanceApprovalRoles(bundle)
+	if err != nil {
+		return nil, err
+	}
+	actors, _ := activeActorsAndBindings(bundle)
+	optionsByRole := make(map[string][]SignerRotationApprovalOption)
+	for _, signer := range parsedSigners {
+		if signer.Status != "active" {
+			continue
+		}
+		actor := actors[signer.ActorID]
+		organizationName := ""
+		if actor.OrganizationID != "" {
+			if organization, exists := actors[actor.OrganizationID]; exists {
+				organizationName = organization.DisplayName
+			}
+		}
+		for _, role := range signer.Roles {
+			optionsByRole[role] = append(optionsByRole[role], SignerRotationApprovalOption{
+				ActorID:          actor.ActorID,
+				ActorDisplayName: actor.DisplayName,
+				OrganizationID:   actor.OrganizationID,
+				OrganizationName: organizationName,
+				SignerID:         signer.SignerID,
+			})
+		}
+	}
+
+	requirements := make([]SignerRotationApprovalRequirement, 0, len(approvalRoles))
+	for _, role := range approvalRoles {
+		options := append([]SignerRotationApprovalOption(nil), optionsByRole[role]...)
+		sort.Slice(options, func(i, j int) bool {
+			if options[i].ActorID == options[j].ActorID {
+				return options[i].SignerID < options[j].SignerID
+			}
+			return options[i].ActorID < options[j].ActorID
+		})
+		requirements = append(requirements, SignerRotationApprovalRequirement{
+			Role:            role,
+			EligibleSigners: options,
+		})
+	}
+	return requirements, nil
+}
+
+func SignerRotationReceipt(bundle Bundle, request SignerRotationReceiptRequest) (SignerRotationReceiptOutput, error) {
+	if err := ValidateSignerManifestInputs(bundle); err != nil {
+		return SignerRotationReceiptOutput{}, err
+	}
+
+	rotationPolicy := stringMap(bundle.CheckpointSigners["rotation_policy"])
+	referenceTime, _ := parseRFC3339(rotationPolicy["reference_time"], "checkpoint signer rotation_policy.reference_time")
+	warningWindowDays, _ := intValue(rotationPolicy["warning_window_days"])
+	parsedSigners, err := parseCurrentSigners(bundle, referenceTime, warningWindowDays)
+	if err != nil {
+		return SignerRotationReceiptOutput{}, err
+	}
+	requiredRoles := governanceRequiredRoles(bundle)
+
+	outgoing, exists := findParsedSignerByID(parsedSigners, request.OutgoingSignerID)
+	if !exists {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("unknown outgoing signer id: %s", request.OutgoingSignerID)
+	}
+	if outgoing.Status != "active" {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("outgoing signer %s must be active", outgoing.SignerID)
+	}
+	if request.IncomingSignerID == "" {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("incoming signer id must be set")
+	}
+	if request.IncomingKeyID == "" {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("incoming key id must be set")
+	}
+	if request.IncomingSignerID == outgoing.SignerID {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("incoming signer id must differ from outgoing signer id")
+	}
+
+	incomingActorID := request.IncomingActorID
+	if incomingActorID == "" {
+		incomingActorID = outgoing.ActorID
+	}
+	incomingRoles := append([]string(nil), request.IncomingRoles...)
+	if len(incomingRoles) == 0 {
+		incomingRoles = append([]string(nil), outgoing.Roles...)
+	}
+	sort.Strings(incomingRoles)
+
+	actors, activeRoleBindings := activeActorsAndBindings(bundle)
+	incomingActor, exists := actors[incomingActorID]
+	if !exists {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("incoming signer references unknown actor %s", incomingActorID)
+	}
+	if incomingActor.Status != "active" {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("incoming signer references inactive actor %s", incomingActorID)
+	}
+	for _, role := range incomingRoles {
+		if _, exists := activeRoleBindings[incomingActorID+"|"+role]; !exists {
+			return SignerRotationReceiptOutput{}, fmt.Errorf(
+				"incoming signer role %s is not backed by an active identity binding",
+				role,
+			)
+		}
+	}
+
+	effectiveAt, err := parseRFC3339(request.EffectiveAt, "signer rotation effective_at")
+	if err != nil {
+		return SignerRotationReceiptOutput{}, err
+	}
+	if !effectiveAt.After(referenceTime) {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("signer rotation effective_at must be after the rotation reference time")
+	}
+	if effectiveAt.After(outgoing.RotateBy) {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("signer rotation effective_at must be on or before the outgoing signer rotate_by time")
+	}
+
+	incomingProvisionedAt := referenceTime
+	if request.IncomingProvisionedAt != "" {
+		incomingProvisionedAt, err = parseRFC3339(request.IncomingProvisionedAt, "incoming signer provisioned_at")
+		if err != nil {
+			return SignerRotationReceiptOutput{}, err
+		}
+	}
+	if incomingProvisionedAt.After(effectiveAt) {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("incoming signer provisioned_at must be on or before effective_at")
+	}
+
+	incomingRotateBy := effectiveAt.Add(90 * 24 * time.Hour)
+	if request.IncomingRotateBy != "" {
+		incomingRotateBy, err = parseRFC3339(request.IncomingRotateBy, "incoming signer rotate_by")
+		if err != nil {
+			return SignerRotationReceiptOutput{}, err
+		}
+	}
+	if !incomingRotateBy.After(effectiveAt) {
+		return SignerRotationReceiptOutput{}, fmt.Errorf("incoming signer rotate_by must be after effective_at")
+	}
+
+	receiptID := request.ReceiptID
+	replacementManifestRef := ""
+	if receiptID == "" {
+		receiptID, replacementManifestRef = signerReceiptArtifacts(outgoing.SignerID, effectiveAt)
+	} else {
+		replacementManifestRef = fmt.Sprintf("build/rotation/%s/replacement-signer-manifest.json", receiptID)
+	}
+
+	incoming := parsedSignerEntry{
+		ActorID:           incomingActorID,
+		SignerID:          request.IncomingSignerID,
+		KeyID:             request.IncomingKeyID,
+		Status:            "active",
+		Roles:             append([]string(nil), incomingRoles...),
+		ProvisionedAt:     incomingProvisionedAt,
+		RotateBy:          incomingRotateBy,
+		RotationStatus:    signerRotationStatus(referenceTime, warningWindowDays, "active", incomingRotateBy),
+		DaysUntilRotation: int(incomingRotateBy.Sub(referenceTime).Hours() / 24),
+	}
+	replacement := replacementSigners(parsedSigners, outgoing.SignerID, incoming)
+	if err := validateSignerSet(bundle, replacement, referenceTime, warningWindowDays, requiredRoles); err != nil {
+		return SignerRotationReceiptOutput{}, err
+	}
+
+	previewManifest := buildSignerManifestOutput(bundle, replacement, referenceTime, warningWindowDays)
+	approvalReqs, err := approvalRequirements(bundle, parsedSigners)
+	if err != nil {
+		return SignerRotationReceiptOutput{}, err
+	}
+
+	roleUsage := governanceExecutionRoleUsage(bundle)
+	outgoingEntry := buildSignerManifestEntry(actors, roleUsage, outgoing)
+
+	incomingOrganizationName := ""
+	if incomingActor.OrganizationID != "" {
+		if organization, exists := actors[incomingActor.OrganizationID]; exists {
+			incomingOrganizationName = organization.DisplayName
+		}
+	}
+
+	return SignerRotationReceiptOutput{
+		Version:         "1.0.0",
+		ChainID:         bundle.Topology.ChainID,
+		PolicyVersion:   fmt.Sprint(bundle.CheckpointSigners["version"]),
+		IdentityVersion: bundle.Identity.Version,
+		ReceiptID:       receiptID,
+		EffectiveAt:     effectiveAt.Format(time.RFC3339),
+		OutgoingSigner:  outgoingEntry,
+		IncomingSigner: SignerRotationReplacement{
+			ActorID:                incomingActorID,
+			ActorDisplayName:       incomingActor.DisplayName,
+			OrganizationID:         incomingActor.OrganizationID,
+			OrganizationName:       incomingOrganizationName,
+			SignerID:               incoming.SignerID,
+			KeyID:                  incoming.KeyID,
+			Roles:                  append([]string(nil), incoming.Roles...),
+			ProvisionedAt:          incoming.ProvisionedAt.Format(time.RFC3339),
+			RotateBy:               incoming.RotateBy.Format(time.RFC3339),
+			EffectiveAt:            effectiveAt.Format(time.RFC3339),
+			RotationReceiptID:      receiptID,
+			ReplacementManifestRef: replacementManifestRef,
+		},
+		ApprovalRequirements:      approvalReqs,
+		CoverageStatus:            "ready",
+		MissingRoleCoverage:       []string{},
+		ReplacementManifestRef:    replacementManifestRef,
+		ReplacementSignerManifest: previewManifest,
 	}, nil
 }
 

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -34,6 +34,9 @@ func TestSignerManifest(t *testing.T) {
 	if manifest.ChainID != "0ai-assurance-1" {
 		t.Fatalf("unexpected chain id: %s", manifest.ChainID)
 	}
+	if manifest.Version != "1.1.0" {
+		t.Fatalf("unexpected manifest version: %s", manifest.Version)
+	}
 	if manifest.SignerCount != 14 {
 		t.Fatalf("expected 14 signers, got %d", manifest.SignerCount)
 	}
@@ -61,6 +64,9 @@ func TestSignerManifest(t *testing.T) {
 		}
 		if signer.RotationStatus != "expiring" {
 			t.Fatalf("expected governance chair signer to be expiring, got %s", signer.RotationStatus)
+		}
+		if signer.NextRotationReceiptID == "" || signer.ReplacementManifestRef == "" {
+			t.Fatalf("expected governance chair signer to include receipt metadata: %+v", signer)
 		}
 		if len(signer.RoleCoverage) != 1 || len(signer.RoleCoverage[0].ReferencedBy) != 1 {
 			t.Fatalf("unexpected governance chair role coverage: %+v", signer.RoleCoverage)
@@ -131,5 +137,111 @@ func TestSignerManifestFailsOnStaleRotationMetadata(t *testing.T) {
 	_, err = SignerManifest(bundle)
 	if err == nil || !strings.Contains(err.Error(), "stale rotation metadata") {
 		t.Fatalf("expected stale rotation error, got %v", err)
+	}
+}
+
+func TestSignerRotationReceipt(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	receipt, err := SignerRotationReceipt(bundle, SignerRotationReceiptRequest{
+		OutgoingSignerID: "governance-chair-bot",
+		IncomingSignerID: "governance-chair-bot-v2",
+		IncomingKeyID:    "governance-chair-dev-v2",
+		EffectiveAt:      "2026-04-24T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationReceipt failed: %v", err)
+	}
+
+	if receipt.CoverageStatus != "ready" {
+		t.Fatalf("unexpected coverage status: %s", receipt.CoverageStatus)
+	}
+	if receipt.ReceiptID == "" || receipt.ReplacementManifestRef == "" {
+		t.Fatalf("expected receipt metadata, got %+v", receipt)
+	}
+	if receipt.OutgoingSigner.SignerID != "governance-chair-bot" {
+		t.Fatalf("unexpected outgoing signer: %+v", receipt.OutgoingSigner)
+	}
+	if receipt.IncomingSigner.SignerID != "governance-chair-bot-v2" {
+		t.Fatalf("unexpected incoming signer: %+v", receipt.IncomingSigner)
+	}
+	if len(receipt.ApprovalRequirements) != 3 {
+		t.Fatalf("expected 3 approval requirements, got %d", len(receipt.ApprovalRequirements))
+	}
+	if receipt.ReplacementSignerManifest.SignerCount != 14 {
+		t.Fatalf("expected replacement manifest with 14 signers, got %d", receipt.ReplacementSignerManifest.SignerCount)
+	}
+}
+
+func TestSignerRotationReceiptFailsOnReplacementCoverageGap(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	bundle.Identity.RoleBindings = append(bundle.Identity.RoleBindings, IdentityRoleBinding{
+		ActorID:   "op-governance-chair-1",
+		Role:      "network_admin",
+		Scope:     "network",
+		GrantedBy: "genesis",
+		Status:    "active",
+	})
+
+	_, err = SignerRotationReceipt(bundle, SignerRotationReceiptRequest{
+		OutgoingSignerID: "governance-chair-bot",
+		IncomingSignerID: "governance-chair-bot-v2",
+		IncomingKeyID:    "governance-chair-dev-v2",
+		IncomingRoles:    []string{"network_admin"},
+		EffectiveAt:      "2026-04-24T00:00:00Z",
+	})
+	if err == nil || !strings.Contains(err.Error(), "checkpoint signer coverage missing roles: governance-chair") {
+		t.Fatalf("expected coverage gap error, got %v", err)
+	}
+}
+
+func TestSignerRotationReceiptFailsOnDuplicateReplacementOwnership(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	bundle.Identity.RoleBindings = append(bundle.Identity.RoleBindings, IdentityRoleBinding{
+		ActorID:   "op-governance-ops-1",
+		Role:      "governance-chair",
+		Scope:     "governance",
+		GrantedBy: "genesis",
+		Status:    "active",
+	})
+
+	_, err = SignerRotationReceipt(bundle, SignerRotationReceiptRequest{
+		OutgoingSignerID: "governance-chair-bot",
+		IncomingSignerID: "governance-chair-bot-v2",
+		IncomingKeyID:    "governance-chair-dev-v2",
+		IncomingActorID:  "op-governance-ops-1",
+		IncomingRoles:    []string{"governance-chair"},
+		EffectiveAt:      "2026-04-24T00:00:00Z",
+	})
+	if err == nil || !strings.Contains(err.Error(), "duplicate checkpoint signer actor ownership") {
+		t.Fatalf("expected duplicate replacement ownership error, got %v", err)
+	}
+}
+
+func TestSignerRotationReceiptFailsOnInvalidEffectiveAtOrdering(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	_, err = SignerRotationReceipt(bundle, SignerRotationReceiptRequest{
+		OutgoingSignerID: "governance-chair-bot",
+		IncomingSignerID: "governance-chair-bot-v2",
+		IncomingKeyID:    "governance-chair-dev-v2",
+		EffectiveAt:      "2026-05-10T00:00:00Z",
+	})
+	if err == nil || !strings.Contains(err.Error(), "effective_at must be on or before the outgoing signer rotate_by time") {
+		t.Fatalf("expected effective_at ordering error, got %v", err)
 	}
 }

--- a/src/assurancectl/config.py
+++ b/src/assurancectl/config.py
@@ -174,6 +174,11 @@ def validate_checkpoint_signers(checkpoint_signers: dict[str, Any], inference_po
         warning_window_days > 0,
         "checkpoint signer rotation_policy.warning_window_days must be positive",
     )
+    approval_roles = [str(role) for role in rotation_policy.get("approval_roles", [])]
+    _assert(
+        approval_roles,
+        "checkpoint signer rotation_policy.approval_roles must not be empty",
+    )
     signers = list(checkpoint_signers["signers"])
     _assert(signers, "at least one checkpoint signer must be configured")
 
@@ -236,6 +241,11 @@ def validate_checkpoint_signers(checkpoint_signers: dict[str, Any], inference_po
     _assert(
         not missing_roles,
         f"checkpoint signer coverage missing roles: {', '.join(missing_roles)}",
+    )
+    missing_approval_roles = sorted(set(approval_roles) - set(active_role_coverage))
+    _assert(
+        not missing_approval_roles,
+        f"checkpoint signer approval roles missing active coverage: {', '.join(missing_approval_roles)}",
     )
 
 


### PR DESCRIPTION
## Summary
- add replacement-aware signer receipt stubs and preview manifest rendering
- extend signer-manifest output with deterministic receipt ids and replacement manifest refs
- validate rotation approval roles, duplicate replacement ownership, coverage preservation, and effective-at ordering

## Testing
- python -m unittest discover -s tests -v
- make validate
- make go-test
- make go-build
- ./0aid signer-manifest --root .
- ./0aid signer-rotation-receipt --root . --outgoing-signer-id governance-chair-bot --incoming-signer-id governance-chair-bot-v2 --incoming-key-id governance-chair-dev-v2 --effective-at 2026-04-24T00:00:00Z
- make signer-rotation-receipt OUTGOING_SIGNER_ID=governance-chair-bot INCOMING_SIGNER_ID=governance-chair-bot-v2 INCOMING_KEY_ID=governance-chair-dev-v2 EFFECTIVE_AT=2026-04-24T00:00:00Z OUT=build/rotation/governance-chair-receipt.json

Closes #18