### PR TITLE
Add signed signer rotation approval bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -25,6 +25,8 @@ help:
 	@echo "  identity-plan    Render the permissioned actor and role bootstrap plan"
 	@echo "  signer-manifest  Render checkpoint signer ownership and rotation plan"
 	@echo "  signer-rotation-receipt Render a replacement-ready signer manifest and rotation receipt stub"
+	@echo "  signer-rotation-approve Generate a signed approval artifact for a rotation receipt"
+	@echo "  signer-rotation-finalize Validate approvals and render a finalized rotation bundle"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -89,6 +91,18 @@ signer-rotation-receipt:
 	@test -n "$(INCOMING_KEY_ID)" || (echo "Usage: make signer-rotation-receipt OUTGOING_SIGNER_ID=governance-chair-bot INCOMING_SIGNER_ID=governance-chair-bot-v2 INCOMING_KEY_ID=governance-chair-dev-v2 EFFECTIVE_AT=2026-04-24T00:00:00Z" && exit 1)
 	@test -n "$(EFFECTIVE_AT)" || (echo "Usage: make signer-rotation-receipt OUTGOING_SIGNER_ID=governance-chair-bot INCOMING_SIGNER_ID=governance-chair-bot-v2 INCOMING_KEY_ID=governance-chair-dev-v2 EFFECTIVE_AT=2026-04-24T00:00:00Z" && exit 1)
 	./0aid signer-rotation-receipt --root . --outgoing-signer-id $(OUTGOING_SIGNER_ID) --incoming-signer-id $(INCOMING_SIGNER_ID) --incoming-key-id $(INCOMING_KEY_ID) --effective-at $(EFFECTIVE_AT) $(if $(INCOMING_ACTOR_ID),--incoming-actor-id $(INCOMING_ACTOR_ID),) $(if $(INCOMING_ROLES),--incoming-roles $(INCOMING_ROLES),) $(if $(INCOMING_PROVISIONED_AT),--incoming-provisioned-at $(INCOMING_PROVISIONED_AT),) $(if $(INCOMING_ROTATE_BY),--incoming-rotate-by $(INCOMING_ROTATE_BY),) $(if $(RECEIPT_ID),--receipt-id $(RECEIPT_ID),) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-approve:
+	@test -n "$(RECEIPT)" || (echo "Usage: make signer-rotation-approve RECEIPT=build/rotation/governance-chair-receipt.json ROLE=governance-ops SIGNER_ID=governance-ops-bot APPROVED_AT=2026-04-23T00:00:00Z" && exit 1)
+	@test -n "$(ROLE)" || (echo "Usage: make signer-rotation-approve RECEIPT=build/rotation/governance-chair-receipt.json ROLE=governance-ops SIGNER_ID=governance-ops-bot APPROVED_AT=2026-04-23T00:00:00Z" && exit 1)
+	@test -n "$(SIGNER_ID)" || (echo "Usage: make signer-rotation-approve RECEIPT=build/rotation/governance-chair-receipt.json ROLE=governance-ops SIGNER_ID=governance-ops-bot APPROVED_AT=2026-04-23T00:00:00Z" && exit 1)
+	@test -n "$(APPROVED_AT)" || (echo "Usage: make signer-rotation-approve RECEIPT=build/rotation/governance-chair-receipt.json ROLE=governance-ops SIGNER_ID=governance-ops-bot APPROVED_AT=2026-04-23T00:00:00Z" && exit 1)
+	./0aid signer-rotation-approve --root . --receipt $(RECEIPT) --role $(ROLE) --signer-id $(SIGNER_ID) --approved-at $(APPROVED_AT) $(if $(SIGNATURE_ID),--signature-id $(SIGNATURE_ID),) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-finalize:
+	@test -n "$(RECEIPT)" || (echo "Usage: make signer-rotation-finalize RECEIPT=build/rotation/governance-chair-receipt.json APPROVALS=build/rotation/governance-chair-approvals.json" && exit 1)
+	@test -n "$(APPROVALS)" || (echo "Usage: make signer-rotation-finalize RECEIPT=build/rotation/governance-chair-receipt.json APPROVALS=build/rotation/governance-chair-approvals.json" && exit 1)
+	./0aid signer-rotation-finalize --root . --receipt $(RECEIPT) --approvals $(APPROVALS) $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ make -C projects/0ai-assurance-network module-plan
 make -C projects/0ai-assurance-network identity-plan
 make -C projects/0ai-assurance-network signer-manifest
 make -C projects/0ai-assurance-network signer-rotation-receipt OUTGOING_SIGNER_ID=governance-chair-bot INCOMING_SIGNER_ID=governance-chair-bot-v2 INCOMING_KEY_ID=governance-chair-dev-v2 EFFECTIVE_AT=2026-04-24T00:00:00Z
+make -C projects/0ai-assurance-network signer-rotation-approve RECEIPT=build/rotation/governance-chair-receipt.json ROLE=governance-ops SIGNER_ID=governance-ops-bot APPROVED_AT=2026-04-23T00:00:00Z
+make -C projects/0ai-assurance-network signer-rotation-finalize RECEIPT=build/rotation/governance-chair-receipt.json APPROVALS=build/rotation/governance-chair-governance-ops.json,build/rotation/governance-chair-token-house.json,build/rotation/governance-chair-telemetry.json
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -189,6 +191,17 @@ the receipt. Rotation receipts fail closed when the replacement would leave a
 required governance role uncovered, reuse another active actor owner, or use an
 invalid effective-at ordering.
 
+`signer-rotation-approve` creates a signed approval artifact for one required
+approval role on top of a receipt stub. It fails closed when the signer is not
+eligible for that role, when the receipt has drifted from current config, or
+when the approval timestamp falls outside signer validity or after the planned
+cutover.
+
+`signer-rotation-finalize` validates the full approval set and emits a finalized
+bundle that can be published together with the replacement manifest. It rejects
+missing roles, duplicate approvers, receipt-digest drift, or invalid approval
+signatures.
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -202,6 +215,8 @@ currently supports:
 - `identity-plan`
 - `signer-manifest`
 - `signer-rotation-receipt`
+- `signer-rotation-approve`
+- `signer-rotation-finalize`
 - `show-plan`
 - `init-genesis`
 - `render-validator`
@@ -224,6 +239,16 @@ Bootstrap examples:
   --incoming-key-id governance-chair-dev-v2 \
   --effective-at 2026-04-24T00:00:00Z \
   --out ./build/rotation/governance-chair-receipt.json
+./0aid signer-rotation-approve --root . \
+  --receipt ./build/rotation/governance-chair-receipt.json \
+  --role governance-ops \
+  --signer-id governance-ops-bot \
+  --approved-at 2026-04-23T00:00:00Z \
+  --out ./build/rotation/governance-chair-governance-ops.json
+./0aid signer-rotation-finalize --root . \
+  --receipt ./build/rotation/governance-chair-receipt.json \
+  --approvals ./build/rotation/governance-chair-governance-ops.json,./build/rotation/governance-chair-token-house.json,./build/rotation/governance-chair-telemetry.json \
+  --out ./build/rotation/governance-chair-approved-bundle.json
 ./0aid init-node --root . --id val-3 --out ./build/nodes/validator-3
 ./0aid collect-validator --bundle ./build/nodes/validator-3 --out ./build/collection/validator-3.json
 ./0aid assemble-genesis --root . --collection ./build/collection --out ./build/assembled/genesis-plan.json

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -144,6 +144,90 @@ func run(args []string) error {
 			return printJSON(receipt)
 		}
 		return project.WriteJSON(filepath.Clean(*out), receipt)
+	case "signer-rotation-approve":
+		fs := flag.NewFlagSet("signer-rotation-approve", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		receiptPath := fs.String("receipt", "", "signer rotation receipt path")
+		role := fs.String("role", "", "approval role")
+		signerID := fs.String("signer-id", "", "approval signer id")
+		approvedAt := fs.String("approved-at", "", "approval timestamp")
+		signatureID := fs.String("signature-id", "", "explicit signature id")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *receiptPath == "" {
+			return errors.New("signer-rotation-approve requires --receipt")
+		}
+		if *role == "" {
+			return errors.New("signer-rotation-approve requires --role")
+		}
+		if *signerID == "" {
+			return errors.New("signer-rotation-approve requires --signer-id")
+		}
+		if *approvedAt == "" {
+			return errors.New("signer-rotation-approve requires --approved-at")
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		var receipt project.SignerRotationReceiptOutput
+		if err := readJSONFile(filepath.Clean(*receiptPath), &receipt); err != nil {
+			return err
+		}
+		approval, err := project.GenerateSignerRotationApproval(bundle, project.SignerRotationApprovalRequest{
+			Receipt:      receipt,
+			ApprovalRole: *role,
+			SignerID:     *signerID,
+			ApprovedAt:   *approvedAt,
+			SignatureID:  *signatureID,
+		})
+		if err != nil {
+			return err
+		}
+		if *out == "" {
+			return printJSON(approval)
+		}
+		return project.WriteJSON(filepath.Clean(*out), approval)
+	case "signer-rotation-finalize":
+		fs := flag.NewFlagSet("signer-rotation-finalize", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		receiptPath := fs.String("receipt", "", "signer rotation receipt path")
+		approvalsPath := fs.String("approvals", "", "approval artifact path")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *receiptPath == "" {
+			return errors.New("signer-rotation-finalize requires --receipt")
+		}
+		if *approvalsPath == "" {
+			return errors.New("signer-rotation-finalize requires --approvals")
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		var receipt project.SignerRotationReceiptOutput
+		if err := readJSONFile(filepath.Clean(*receiptPath), &receipt); err != nil {
+			return err
+		}
+		approvals, err := readSignerRotationApprovals(filepath.Clean(*approvalsPath))
+		if err != nil {
+			return err
+		}
+		finalized, err := project.SignerRotationFinalize(bundle, project.SignerRotationFinalizeRequest{
+			Receipt:   receipt,
+			Approvals: approvals,
+		})
+		if err != nil {
+			return err
+		}
+		if *out == "" {
+			return printJSON(finalized)
+		}
+		return project.WriteJSON(filepath.Clean(*out), finalized)
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -312,8 +396,54 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
+}
+
+func readJSONFile(path string, destination any) error {
+	contents, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(contents, destination); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	return nil
+}
+
+func readSignerRotationApprovals(path string) ([]project.SignerRotationApproval, error) {
+	paths := strings.Split(path, ",")
+	collected := make([]project.SignerRotationApproval, 0, len(paths))
+	for _, rawPath := range paths {
+		cleanPath := filepath.Clean(strings.TrimSpace(rawPath))
+		if cleanPath == "" {
+			continue
+		}
+		contents, err := os.ReadFile(cleanPath)
+		if err != nil {
+			return nil, err
+		}
+		var envelope project.SignerRotationApprovalEnvelope
+		if err := json.Unmarshal(contents, &envelope); err == nil && len(envelope.Approvals) > 0 {
+			collected = append(collected, envelope.Approvals...)
+			continue
+		}
+		var approvals []project.SignerRotationApproval
+		if err := json.Unmarshal(contents, &approvals); err == nil && len(approvals) > 0 {
+			collected = append(collected, approvals...)
+			continue
+		}
+		var single project.SignerRotationApproval
+		if err := json.Unmarshal(contents, &single); err == nil && single.ReceiptID != "" {
+			collected = append(collected, single)
+			continue
+		}
+		return nil, fmt.Errorf("parse %s: expected approval object, array, or envelope", cleanPath)
+	}
+	if len(collected) == 0 {
+		return nil, fmt.Errorf("no approval artifacts found in %s", path)
+	}
+	return collected, nil
 }
 
 func printJSON(value any) error {

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -100,12 +100,67 @@ The replacement preview only renders when:
 - `effective_at` is after the current reference time and on or before the
   outgoing signer `rotate_by`
 
+## Signed approvals
+
+`0aid signer-rotation-approve` turns a receipt stub into a signed approval
+artifact for one required approval role.
+
+Example:
+
+```bash
+./0aid signer-rotation-approve --root . \
+  --receipt ./build/rotation/governance-chair-receipt.json \
+  --role governance-ops \
+  --signer-id governance-ops-bot \
+  --approved-at 2026-04-23T00:00:00Z \
+  --out ./build/rotation/governance-chair-governance-ops.json
+```
+
+Approval artifacts are bound to the exact receipt by `receipt_id`,
+`receipt_digest`, and `replacement_manifest_ref`, and they are signed with the
+configured development HMAC signer for the selected approval role.
+
+Approvals are rejected when:
+
+- the signer is not eligible for the requested approval role
+- the receipt has drifted from the current checkpoint signer configuration
+- `approved_at` falls before signer `provisioned_at` or after signer `rotate_by`
+- `approved_at` falls after the receipt `effective_at`
+
+## Finalized bundles
+
+`0aid signer-rotation-finalize` validates the full approval set and emits a
+publication-ready bundle containing:
+
+- the original receipt stub
+- the verified approval artifacts
+- the replacement signer manifest preview
+- final bundle metadata such as `status = approved` and `finalized_at`
+
+Example:
+
+```bash
+./0aid signer-rotation-finalize --root . \
+  --receipt ./build/rotation/governance-chair-receipt.json \
+  --approvals ./build/rotation/governance-chair-governance-ops.json,./build/rotation/governance-chair-token-house.json,./build/rotation/governance-chair-telemetry.json \
+  --out ./build/rotation/governance-chair-approved-bundle.json
+```
+
+Finalization fails closed when:
+
+- any required approval role is missing
+- the same signer or actor tries to satisfy multiple approval roles
+- approval signatures do not validate against the configured signer secret
+- approval artifacts reference a different receipt digest or replacement manifest
+
 ## Operator workflow
 
 1. Render the current signer manifest and identify any `expiring` signers.
 2. Generate a signer rotation receipt stub for the outgoing signer.
 3. Review the approval actor set and replacement manifest preview.
-4. Collect governance approval against the receipt stub.
-5. Publish the approved receipt together with the replacement signer manifest.
-6. Update `config/governance/checkpoint-signers.json` only after the approved
+4. Collect signed approval artifacts for every required approval role.
+5. Finalize the receipt bundle and verify it remains bound to the replacement
+   manifest preview.
+6. Publish the approved bundle together with the replacement signer manifest.
+7. Update `config/governance/checkpoint-signers.json` only after the approved
    replacement manifest is ready to become the new active state.

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -1,6 +1,10 @@
 package project
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -110,6 +114,67 @@ type SignerRotationReceiptOutput struct {
 	OutgoingSigner            SignerManifestEntry                 `json:"outgoing_signer"`
 	IncomingSigner            SignerRotationReplacement           `json:"incoming_signer"`
 	ApprovalRequirements      []SignerRotationApprovalRequirement `json:"approval_requirements"`
+	CoverageStatus            string                              `json:"coverage_status"`
+	MissingRoleCoverage       []string                            `json:"missing_role_coverage"`
+	ReplacementManifestRef    string                              `json:"replacement_manifest_ref"`
+	ReplacementSignerManifest SignerManifestOutput                `json:"replacement_signer_manifest"`
+}
+
+type SignerRotationApprovalSignature struct {
+	Format      string `json:"format"`
+	SignatureID string `json:"signature_id"`
+	SignedAt    string `json:"signed_at"`
+	ExpiresAt   string `json:"expires_at"`
+	Value       string `json:"value"`
+}
+
+type SignerRotationApproval struct {
+	Version                string                          `json:"version"`
+	ReceiptID              string                          `json:"receipt_id"`
+	ReceiptDigest          string                          `json:"receipt_digest"`
+	ApprovalRole           string                          `json:"approval_role"`
+	ApprovedAt             string                          `json:"approved_at"`
+	SignerID               string                          `json:"signer_id"`
+	KeyID                  string                          `json:"key_id"`
+	ActorID                string                          `json:"actor_id"`
+	ActorDisplayName       string                          `json:"actor_display_name"`
+	OrganizationID         string                          `json:"organization_id,omitempty"`
+	OrganizationName       string                          `json:"organization_name,omitempty"`
+	ReplacementManifestRef string                          `json:"replacement_manifest_ref"`
+	Signature              SignerRotationApprovalSignature `json:"signature"`
+}
+
+type SignerRotationApprovalEnvelope struct {
+	Approvals []SignerRotationApproval `json:"approvals"`
+}
+
+type SignerRotationApprovalRequest struct {
+	Receipt      SignerRotationReceiptOutput
+	ApprovalRole string
+	SignerID     string
+	ApprovedAt   string
+	SignatureID  string
+}
+
+type SignerRotationFinalizeRequest struct {
+	Receipt   SignerRotationReceiptOutput
+	Approvals []SignerRotationApproval
+}
+
+type SignerRotationFinalizedBundle struct {
+	Version                   string                              `json:"version"`
+	Status                    string                              `json:"status"`
+	ReceiptID                 string                              `json:"receipt_id"`
+	ReceiptDigest             string                              `json:"receipt_digest"`
+	ChainID                   string                              `json:"chain_id"`
+	PolicyVersion             string                              `json:"policy_version"`
+	IdentityVersion           string                              `json:"identity_version"`
+	FinalizedAt               string                              `json:"finalized_at"`
+	EffectiveAt               string                              `json:"effective_at"`
+	OutgoingSigner            SignerManifestEntry                 `json:"outgoing_signer"`
+	IncomingSigner            SignerRotationReplacement           `json:"incoming_signer"`
+	ApprovalRequirements      []SignerRotationApprovalRequirement `json:"approval_requirements"`
+	Approvals                 []SignerRotationApproval            `json:"approvals"`
 	CoverageStatus            string                              `json:"coverage_status"`
 	MissingRoleCoverage       []string                            `json:"missing_role_coverage"`
 	ReplacementManifestRef    string                              `json:"replacement_manifest_ref"`
@@ -614,6 +679,281 @@ func approvalRequirements(bundle Bundle, parsedSigners []parsedSignerEntry) ([]S
 	return requirements, nil
 }
 
+func signerRotationReceiptDigest(receipt SignerRotationReceiptOutput) (string, error) {
+	encoded, err := json.Marshal(receipt)
+	if err != nil {
+		return "", fmt.Errorf("marshal signer rotation receipt: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func signerRotationApprovalMessage(
+	receipt SignerRotationReceiptOutput,
+	receiptDigest string,
+	approvalRole string,
+	signerID string,
+	keyID string,
+	approvedAt time.Time,
+) string {
+	parts := []string{
+		"0ai-assurance-network/signer-rotation-approval/v1",
+		receipt.Version,
+		receipt.ChainID,
+		receipt.PolicyVersion,
+		receipt.IdentityVersion,
+		receipt.ReceiptID,
+		receiptDigest,
+		receipt.OutgoingSigner.SignerID,
+		receipt.IncomingSigner.SignerID,
+		receipt.IncomingSigner.KeyID,
+		receipt.EffectiveAt,
+		approvalRole,
+		signerID,
+		keyID,
+		approvedAt.UTC().Format(time.RFC3339),
+		receipt.ReplacementManifestRef,
+	}
+	return joinStrings(parts, "\n")
+}
+
+func buildReceiptRequestFromOutput(receipt SignerRotationReceiptOutput) SignerRotationReceiptRequest {
+	return SignerRotationReceiptRequest{
+		OutgoingSignerID:      receipt.OutgoingSigner.SignerID,
+		IncomingSignerID:      receipt.IncomingSigner.SignerID,
+		IncomingKeyID:         receipt.IncomingSigner.KeyID,
+		IncomingActorID:       receipt.IncomingSigner.ActorID,
+		IncomingRoles:         append([]string(nil), receipt.IncomingSigner.Roles...),
+		IncomingProvisionedAt: receipt.IncomingSigner.ProvisionedAt,
+		IncomingRotateBy:      receipt.IncomingSigner.RotateBy,
+		EffectiveAt:           receipt.EffectiveAt,
+		ReceiptID:             receipt.ReceiptID,
+	}
+}
+
+func ensureReceiptMatchesBundle(bundle Bundle, receipt SignerRotationReceiptOutput) (SignerRotationReceiptOutput, string, error) {
+	expected, err := SignerRotationReceipt(bundle, buildReceiptRequestFromOutput(receipt))
+	if err != nil {
+		return SignerRotationReceiptOutput{}, "", err
+	}
+	expectedJSON, err := json.Marshal(expected)
+	if err != nil {
+		return SignerRotationReceiptOutput{}, "", fmt.Errorf("marshal expected signer rotation receipt: %w", err)
+	}
+	actualJSON, err := json.Marshal(receipt)
+	if err != nil {
+		return SignerRotationReceiptOutput{}, "", fmt.Errorf("marshal actual signer rotation receipt: %w", err)
+	}
+	if !bytesEqual(expectedJSON, actualJSON) {
+		return SignerRotationReceiptOutput{}, "", fmt.Errorf("signer rotation receipt drift detected")
+	}
+	receiptDigest, err := signerRotationReceiptDigest(expected)
+	if err != nil {
+		return SignerRotationReceiptOutput{}, "", err
+	}
+	return expected, receiptDigest, nil
+}
+
+func bytesEqual(a []byte, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for idx := range a {
+		if a[idx] != b[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+func signerPolicyEntry(bundle Bundle, signerID string, keyID string) (map[string]any, error) {
+	rawSigners, ok := bundle.CheckpointSigners["signers"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("checkpoint signer list must be configured")
+	}
+	for _, rawSigner := range rawSigners {
+		signer := stringMap(rawSigner)
+		if fmt.Sprint(signer["signer_id"]) == signerID && fmt.Sprint(signer["key_id"]) == keyID {
+			return signer, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown signer_id/key_id pair: %s/%s", signerID, keyID)
+}
+
+func findKeyIDForSigner(bundle Bundle, signerID string) string {
+	rawSigners, ok := bundle.CheckpointSigners["signers"].([]any)
+	if !ok {
+		return ""
+	}
+	for _, rawSigner := range rawSigners {
+		signer := stringMap(rawSigner)
+		if fmt.Sprint(signer["signer_id"]) == signerID {
+			return fmt.Sprint(signer["key_id"])
+		}
+	}
+	return ""
+}
+
+func eligibleApprovalOption(
+	requirements []SignerRotationApprovalRequirement,
+	role string,
+	signerID string,
+) (SignerRotationApprovalOption, error) {
+	for _, requirement := range requirements {
+		if requirement.Role != role {
+			continue
+		}
+		for _, option := range requirement.EligibleSigners {
+			if option.SignerID == signerID {
+				return option, nil
+			}
+		}
+		return SignerRotationApprovalOption{}, fmt.Errorf("signer %s is not eligible to approve role %s", signerID, role)
+	}
+	return SignerRotationApprovalOption{}, fmt.Errorf("unknown approval role: %s", role)
+}
+
+func signerRotationApprovalExpiry(
+	signerRotateBy time.Time,
+	effectiveAt time.Time,
+	approvedAt time.Time,
+	maxValiditySeconds int,
+) time.Time {
+	expiresAt := approvedAt.Add(time.Duration(maxValiditySeconds) * time.Second)
+	if expiresAt.After(signerRotateBy) {
+		expiresAt = signerRotateBy
+	}
+	if expiresAt.After(effectiveAt) {
+		expiresAt = effectiveAt
+	}
+	return expiresAt.UTC()
+}
+
+func verifySignerRotationApproval(
+	bundle Bundle,
+	receipt SignerRotationReceiptOutput,
+	receiptDigest string,
+	approval SignerRotationApproval,
+	seenSignatureIDs map[string]struct{},
+) (SignerRotationApproval, error) {
+	if approval.ReceiptID != receipt.ReceiptID {
+		return SignerRotationApproval{}, fmt.Errorf("approval receipt_id mismatch for role %s", approval.ApprovalRole)
+	}
+	if approval.ReceiptDigest != receiptDigest {
+		return SignerRotationApproval{}, fmt.Errorf("approval receipt_digest mismatch for role %s", approval.ApprovalRole)
+	}
+	if approval.ReplacementManifestRef != receipt.ReplacementManifestRef {
+		return SignerRotationApproval{}, fmt.Errorf("approval replacement_manifest_ref mismatch for role %s", approval.ApprovalRole)
+	}
+	option, err := eligibleApprovalOption(receipt.ApprovalRequirements, approval.ApprovalRole, approval.SignerID)
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	signerEntry, err := signerPolicyEntry(bundle, approval.SignerID, approval.KeyID)
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	if fmt.Sprint(signerEntry["status"]) != "active" {
+		return SignerRotationApproval{}, fmt.Errorf("approval signer %s must be active", approval.SignerID)
+	}
+	approvedAt, err := parseRFC3339(approval.ApprovedAt, "approval approved_at")
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	signedAt, err := parseRFC3339(approval.Signature.SignedAt, "approval signature signed_at")
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	expiresAt, err := parseRFC3339(approval.Signature.ExpiresAt, "approval signature expires_at")
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	if !approvedAt.Equal(signedAt) {
+		return SignerRotationApproval{}, fmt.Errorf("approval signed_at must equal approved_at for role %s", approval.ApprovalRole)
+	}
+	effectiveAt, err := parseRFC3339(receipt.EffectiveAt, "receipt effective_at")
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	provisionedAt, err := parseRFC3339(signerEntry["provisioned_at"], "checkpoint signer provisioned_at")
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	rotateBy, err := parseRFC3339(signerEntry["rotate_by"], "checkpoint signer rotate_by")
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	if approvedAt.Before(provisionedAt) {
+		return SignerRotationApproval{}, fmt.Errorf("approval approved_at must be on or after signer provisioned_at for role %s", approval.ApprovalRole)
+	}
+	if approvedAt.After(rotateBy) {
+		return SignerRotationApproval{}, fmt.Errorf("approval approved_at must be on or before signer rotate_by for role %s", approval.ApprovalRole)
+	}
+	if approvedAt.After(effectiveAt) {
+		return SignerRotationApproval{}, fmt.Errorf("approval approved_at must be on or before receipt effective_at for role %s", approval.ApprovalRole)
+	}
+	maxValiditySeconds, err := intValue(bundle.CheckpointSigners["maximum_signature_validity_seconds"])
+	if err != nil || maxValiditySeconds <= 0 {
+		return SignerRotationApproval{}, fmt.Errorf("checkpoint signer validity window must be positive")
+	}
+	expectedExpiry := signerRotationApprovalExpiry(rotateBy, effectiveAt, approvedAt, maxValiditySeconds)
+	if !expiresAt.Equal(expectedExpiry) {
+		return SignerRotationApproval{}, fmt.Errorf("approval signature expires_at mismatch for role %s", approval.ApprovalRole)
+	}
+	if approval.Signature.Format != fmt.Sprint(bundle.CheckpointSigners["signature_format"]) {
+		return SignerRotationApproval{}, fmt.Errorf("approval signature format mismatch for role %s", approval.ApprovalRole)
+	}
+	if approval.Signature.SignatureID == "" {
+		return SignerRotationApproval{}, fmt.Errorf("approval signature_id must be set for role %s", approval.ApprovalRole)
+	}
+	if _, exists := seenSignatureIDs[approval.Signature.SignatureID]; exists {
+		return SignerRotationApproval{}, fmt.Errorf("duplicate approval signature_id: %s", approval.Signature.SignatureID)
+	}
+	if approval.ActorID != option.ActorID {
+		return SignerRotationApproval{}, fmt.Errorf("approval actor mismatch for role %s", approval.ApprovalRole)
+	}
+	if approval.ActorDisplayName != option.ActorDisplayName {
+		return SignerRotationApproval{}, fmt.Errorf("approval actor display name mismatch for role %s", approval.ApprovalRole)
+	}
+	if approval.OrganizationID != option.OrganizationID || approval.OrganizationName != option.OrganizationName {
+		return SignerRotationApproval{}, fmt.Errorf("approval organization mismatch for role %s", approval.ApprovalRole)
+	}
+
+	signingMessage := signerRotationApprovalMessage(
+		receipt,
+		receiptDigest,
+		approval.ApprovalRole,
+		approval.SignerID,
+		approval.KeyID,
+		approvedAt,
+	)
+	expectedSignature := hmac.New(sha256.New, []byte(fmt.Sprint(signerEntry["shared_secret"])))
+	expectedSignature.Write([]byte(signingMessage))
+	expectedValue := hex.EncodeToString(expectedSignature.Sum(nil))
+	if !hmac.Equal([]byte(expectedValue), []byte(approval.Signature.Value)) {
+		return SignerRotationApproval{}, fmt.Errorf("approval signature verification failed for role %s", approval.ApprovalRole)
+	}
+	seenSignatureIDs[approval.Signature.SignatureID] = struct{}{}
+	return approval, nil
+}
+
+func finalizedAt(approvals []SignerRotationApproval) (string, error) {
+	latest := time.Time{}
+	for _, approval := range approvals {
+		approvedAt, err := parseRFC3339(approval.ApprovedAt, "approval approved_at")
+		if err != nil {
+			return "", err
+		}
+		if approvedAt.After(latest) {
+			latest = approvedAt
+		}
+	}
+	if latest.IsZero() {
+		return "", fmt.Errorf("at least one approval is required")
+	}
+	return latest.Format(time.RFC3339), nil
+}
+
 func SignerRotationReceipt(bundle Bundle, request SignerRotationReceiptRequest) (SignerRotationReceiptOutput, error) {
 	if err := ValidateSignerManifestInputs(bundle); err != nil {
 		return SignerRotationReceiptOutput{}, err
@@ -772,6 +1112,185 @@ func SignerRotationReceipt(bundle Bundle, request SignerRotationReceiptRequest) 
 		MissingRoleCoverage:       []string{},
 		ReplacementManifestRef:    replacementManifestRef,
 		ReplacementSignerManifest: previewManifest,
+	}, nil
+}
+
+func GenerateSignerRotationApproval(bundle Bundle, request SignerRotationApprovalRequest) (SignerRotationApproval, error) {
+	if err := ValidateSignerManifestInputs(bundle); err != nil {
+		return SignerRotationApproval{}, err
+	}
+	receipt, receiptDigest, err := ensureReceiptMatchesBundle(bundle, request.Receipt)
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	if strings.TrimSpace(request.ApprovalRole) == "" {
+		return SignerRotationApproval{}, fmt.Errorf("approval role must be set")
+	}
+	if strings.TrimSpace(request.SignerID) == "" {
+		return SignerRotationApproval{}, fmt.Errorf("approval signer id must be set")
+	}
+	option, err := eligibleApprovalOption(receipt.ApprovalRequirements, request.ApprovalRole, request.SignerID)
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	signerEntry, err := signerPolicyEntry(bundle, request.SignerID, findKeyIDForSigner(bundle, request.SignerID))
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	approvedAt, err := parseRFC3339(request.ApprovedAt, "approval approved_at")
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	effectiveAt, err := parseRFC3339(receipt.EffectiveAt, "receipt effective_at")
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	provisionedAt, err := parseRFC3339(signerEntry["provisioned_at"], "checkpoint signer provisioned_at")
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	rotateBy, err := parseRFC3339(signerEntry["rotate_by"], "checkpoint signer rotate_by")
+	if err != nil {
+		return SignerRotationApproval{}, err
+	}
+	if approvedAt.Before(provisionedAt) {
+		return SignerRotationApproval{}, fmt.Errorf("approval approved_at must be on or after signer provisioned_at for role %s", request.ApprovalRole)
+	}
+	if approvedAt.After(rotateBy) {
+		return SignerRotationApproval{}, fmt.Errorf("approval approved_at must be on or before signer rotate_by for role %s", request.ApprovalRole)
+	}
+	if approvedAt.After(effectiveAt) {
+		return SignerRotationApproval{}, fmt.Errorf("approval approved_at must be on or before receipt effective_at for role %s", request.ApprovalRole)
+	}
+	maxValiditySeconds, err := intValue(bundle.CheckpointSigners["maximum_signature_validity_seconds"])
+	if err != nil || maxValiditySeconds <= 0 {
+		return SignerRotationApproval{}, fmt.Errorf("checkpoint signer validity window must be positive")
+	}
+	signatureID := request.SignatureID
+	if signatureID == "" {
+		signatureID = fmt.Sprintf(
+			"approve-%s-%s-%s",
+			receipt.ReceiptID,
+			request.ApprovalRole,
+			strings.ToLower(approvedAt.UTC().Format("20060102t150405z")),
+		)
+	}
+	expiresAt := signerRotationApprovalExpiry(rotateBy, effectiveAt, approvedAt, maxValiditySeconds)
+	signingMessage := signerRotationApprovalMessage(
+		receipt,
+		receiptDigest,
+		request.ApprovalRole,
+		fmt.Sprint(signerEntry["signer_id"]),
+		fmt.Sprint(signerEntry["key_id"]),
+		approvedAt,
+	)
+	mac := hmac.New(sha256.New, []byte(fmt.Sprint(signerEntry["shared_secret"])))
+	mac.Write([]byte(signingMessage))
+	organizationID := option.OrganizationID
+	organizationName := option.OrganizationName
+	return SignerRotationApproval{
+		Version:                "1.0.0",
+		ReceiptID:              receipt.ReceiptID,
+		ReceiptDigest:          receiptDigest,
+		ApprovalRole:           request.ApprovalRole,
+		ApprovedAt:             approvedAt.Format(time.RFC3339),
+		SignerID:               fmt.Sprint(signerEntry["signer_id"]),
+		KeyID:                  fmt.Sprint(signerEntry["key_id"]),
+		ActorID:                option.ActorID,
+		ActorDisplayName:       option.ActorDisplayName,
+		OrganizationID:         organizationID,
+		OrganizationName:       organizationName,
+		ReplacementManifestRef: receipt.ReplacementManifestRef,
+		Signature: SignerRotationApprovalSignature{
+			Format:      fmt.Sprint(bundle.CheckpointSigners["signature_format"]),
+			SignatureID: signatureID,
+			SignedAt:    approvedAt.Format(time.RFC3339),
+			ExpiresAt:   expiresAt.Format(time.RFC3339),
+			Value:       hex.EncodeToString(mac.Sum(nil)),
+		},
+	}, nil
+}
+
+func SignerRotationFinalize(bundle Bundle, request SignerRotationFinalizeRequest) (SignerRotationFinalizedBundle, error) {
+	if err := ValidateSignerManifestInputs(bundle); err != nil {
+		return SignerRotationFinalizedBundle{}, err
+	}
+	if len(request.Approvals) == 0 {
+		return SignerRotationFinalizedBundle{}, fmt.Errorf("at least one approval artifact is required")
+	}
+	receipt, receiptDigest, err := ensureReceiptMatchesBundle(bundle, request.Receipt)
+	if err != nil {
+		return SignerRotationFinalizedBundle{}, err
+	}
+	requiredRoles := make(map[string]struct{}, len(receipt.ApprovalRequirements))
+	for _, requirement := range receipt.ApprovalRequirements {
+		requiredRoles[requirement.Role] = struct{}{}
+	}
+	seenRoles := make(map[string]struct{}, len(requiredRoles))
+	seenSigners := make(map[string]struct{}, len(request.Approvals))
+	seenActors := make(map[string]struct{}, len(request.Approvals))
+	seenSignatureIDs := make(map[string]struct{}, len(request.Approvals))
+	verifiedApprovals := make([]SignerRotationApproval, 0, len(request.Approvals))
+	for _, approval := range request.Approvals {
+		if _, exists := requiredRoles[approval.ApprovalRole]; !exists {
+			return SignerRotationFinalizedBundle{}, fmt.Errorf("unexpected approval role: %s", approval.ApprovalRole)
+		}
+		if _, exists := seenRoles[approval.ApprovalRole]; exists {
+			return SignerRotationFinalizedBundle{}, fmt.Errorf("duplicate approval role: %s", approval.ApprovalRole)
+		}
+		if _, exists := seenSigners[approval.SignerID]; exists {
+			return SignerRotationFinalizedBundle{}, fmt.Errorf("duplicate approval signer: %s", approval.SignerID)
+		}
+		if _, exists := seenActors[approval.ActorID]; exists {
+			return SignerRotationFinalizedBundle{}, fmt.Errorf("duplicate approval actor ownership: %s", approval.ActorID)
+		}
+		verified, err := verifySignerRotationApproval(bundle, receipt, receiptDigest, approval, seenSignatureIDs)
+		if err != nil {
+			return SignerRotationFinalizedBundle{}, err
+		}
+		seenRoles[verified.ApprovalRole] = struct{}{}
+		seenSigners[verified.SignerID] = struct{}{}
+		seenActors[verified.ActorID] = struct{}{}
+		verifiedApprovals = append(verifiedApprovals, verified)
+	}
+	missingRoles := make([]string, 0)
+	for role := range requiredRoles {
+		if _, exists := seenRoles[role]; !exists {
+			missingRoles = append(missingRoles, role)
+		}
+	}
+	sort.Strings(missingRoles)
+	if len(missingRoles) > 0 {
+		return SignerRotationFinalizedBundle{}, fmt.Errorf("missing approval coverage for roles: %s", commaList(missingRoles))
+	}
+	sort.Slice(verifiedApprovals, func(i, j int) bool {
+		if verifiedApprovals[i].ApprovalRole == verifiedApprovals[j].ApprovalRole {
+			return verifiedApprovals[i].SignerID < verifiedApprovals[j].SignerID
+		}
+		return verifiedApprovals[i].ApprovalRole < verifiedApprovals[j].ApprovalRole
+	})
+	finalizedAtValue, err := finalizedAt(verifiedApprovals)
+	if err != nil {
+		return SignerRotationFinalizedBundle{}, err
+	}
+	return SignerRotationFinalizedBundle{
+		Version:                   "1.0.0",
+		Status:                    "approved",
+		ReceiptID:                 receipt.ReceiptID,
+		ReceiptDigest:             receiptDigest,
+		ChainID:                   receipt.ChainID,
+		PolicyVersion:             receipt.PolicyVersion,
+		IdentityVersion:           receipt.IdentityVersion,
+		FinalizedAt:               finalizedAtValue,
+		EffectiveAt:               receipt.EffectiveAt,
+		OutgoingSigner:            receipt.OutgoingSigner,
+		IncomingSigner:            receipt.IncomingSigner,
+		ApprovalRequirements:      receipt.ApprovalRequirements,
+		Approvals:                 verifiedApprovals,
+		CoverageStatus:            "approved",
+		MissingRoleCoverage:       []string{},
+		ReplacementManifestRef:    receipt.ReplacementManifestRef,
+		ReplacementSignerManifest: receipt.ReplacementSignerManifest,
 	}, nil
 }
 

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -245,3 +245,144 @@ func TestSignerRotationReceiptFailsOnInvalidEffectiveAtOrdering(t *testing.T) {
 		t.Fatalf("expected effective_at ordering error, got %v", err)
 	}
 }
+
+func mustSignerRotationReceipt(t *testing.T, bundle Bundle) SignerRotationReceiptOutput {
+	t.Helper()
+
+	receipt, err := SignerRotationReceipt(bundle, SignerRotationReceiptRequest{
+		OutgoingSignerID: "governance-chair-bot",
+		IncomingSignerID: "governance-chair-bot-v2",
+		IncomingKeyID:    "governance-chair-dev-v2",
+		EffectiveAt:      "2026-04-24T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationReceipt failed: %v", err)
+	}
+	return receipt
+}
+
+func TestSignerRotationApproval(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	receipt := mustSignerRotationReceipt(t, bundle)
+	approval, err := GenerateSignerRotationApproval(bundle, SignerRotationApprovalRequest{
+		Receipt:      receipt,
+		ApprovalRole: "governance-ops",
+		SignerID:     "governance-ops-bot",
+		ApprovedAt:   "2026-04-23T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("GenerateSignerRotationApproval failed: %v", err)
+	}
+	if approval.ReceiptID != receipt.ReceiptID {
+		t.Fatalf("unexpected receipt id: %s", approval.ReceiptID)
+	}
+	if approval.ApprovalRole != "governance-ops" {
+		t.Fatalf("unexpected approval role: %s", approval.ApprovalRole)
+	}
+	if approval.Signature.Value == "" || approval.Signature.SignatureID == "" {
+		t.Fatalf("expected signature metadata, got %+v", approval.Signature)
+	}
+}
+
+func TestSignerRotationFinalize(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	receipt := mustSignerRotationReceipt(t, bundle)
+	approvals := []SignerRotationApproval{}
+	for _, item := range []struct {
+		role     string
+		signerID string
+	}{
+		{role: "governance-ops", signerID: "governance-ops-bot"},
+		{role: "token-house-secretariat", signerID: "token-house-secretariat-bot"},
+		{role: "telemetry-ops", signerID: "telemetry-ops-bot"},
+	} {
+		approval, err := GenerateSignerRotationApproval(bundle, SignerRotationApprovalRequest{
+			Receipt:      receipt,
+			ApprovalRole: item.role,
+			SignerID:     item.signerID,
+			ApprovedAt:   "2026-04-23T00:00:00Z",
+		})
+		if err != nil {
+			t.Fatalf("GenerateSignerRotationApproval(%s) failed: %v", item.role, err)
+		}
+		approvals = append(approvals, approval)
+	}
+
+	finalized, err := SignerRotationFinalize(bundle, SignerRotationFinalizeRequest{
+		Receipt:   receipt,
+		Approvals: approvals,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationFinalize failed: %v", err)
+	}
+	if finalized.Status != "approved" {
+		t.Fatalf("unexpected finalized status: %s", finalized.Status)
+	}
+	if len(finalized.Approvals) != 3 {
+		t.Fatalf("expected 3 approvals, got %d", len(finalized.Approvals))
+	}
+	if finalized.ReplacementManifestRef != receipt.ReplacementManifestRef {
+		t.Fatalf("unexpected replacement manifest ref: %s", finalized.ReplacementManifestRef)
+	}
+}
+
+func TestSignerRotationFinalizeFailsOnMissingApprovalCoverage(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	receipt := mustSignerRotationReceipt(t, bundle)
+	approval, err := GenerateSignerRotationApproval(bundle, SignerRotationApprovalRequest{
+		Receipt:      receipt,
+		ApprovalRole: "governance-ops",
+		SignerID:     "governance-ops-bot",
+		ApprovedAt:   "2026-04-23T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("GenerateSignerRotationApproval failed: %v", err)
+	}
+
+	_, err = SignerRotationFinalize(bundle, SignerRotationFinalizeRequest{
+		Receipt:   receipt,
+		Approvals: []SignerRotationApproval{approval},
+	})
+	if err == nil || !strings.Contains(err.Error(), "missing approval coverage for roles") {
+		t.Fatalf("expected missing approval coverage error, got %v", err)
+	}
+}
+
+func TestSignerRotationFinalizeFailsOnApprovalReceiptDrift(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	receipt := mustSignerRotationReceipt(t, bundle)
+	approval, err := GenerateSignerRotationApproval(bundle, SignerRotationApprovalRequest{
+		Receipt:      receipt,
+		ApprovalRole: "governance-ops",
+		SignerID:     "governance-ops-bot",
+		ApprovedAt:   "2026-04-23T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("GenerateSignerRotationApproval failed: %v", err)
+	}
+	approval.ReceiptDigest = "deadbeef"
+
+	_, err = SignerRotationFinalize(bundle, SignerRotationFinalizeRequest{
+		Receipt:   receipt,
+		Approvals: []SignerRotationApproval{approval},
+	})
+	if err == nil || !strings.Contains(err.Error(), "approval receipt_digest mismatch") {
+		t.Fatalf("expected approval receipt drift error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add signed signer-rotation approval artifacts and finalized receipt bundles
- extend 0aid with signer-rotation-approve and signer-rotation-finalize
- document the approval/finalization workflow and add signer rotation tests

## Testing
- make validate
- make go-test
- make go-build
- python -m unittest discover -s tests -v
- ./0aid signer-rotation-receipt --root . --outgoing-signer-id governance-chair-bot --incoming-signer-id governance-chair-bot-v2 --incoming-key-id governance-chair-dev-v2 --effective-at 2026-04-24T00:00:00Z --out build/rotation/governance-chair-receipt.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role governance-ops --signer-id governance-ops-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-governance-ops.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role token-house-secretariat --signer-id token-house-secretariat-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-token-house.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role telemetry-ops --signer-id telemetry-ops-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-telemetry.json
- ./0aid signer-rotation-finalize --root . --receipt build/rotation/governance-chair-receipt.json --approvals build/rotation/governance-chair-governance-ops.json,build/rotation/governance-chair-token-house.json,build/rotation/governance-chair-telemetry.json --out build/rotation/governance-chair-approved-bundle.json

Closes #20