### PR TITLE
Add signer rotation activation plans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -27,6 +27,7 @@ help:
 	@echo "  signer-rotation-receipt Render a replacement-ready signer manifest and rotation receipt stub"
 	@echo "  signer-rotation-approve Generate a signed approval artifact for a rotation receipt"
 	@echo "  signer-rotation-finalize Validate approvals and render a finalized rotation bundle"
+	@echo "  signer-rotation-activate Render an activation plan and checkpoint-signer policy patch"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -103,6 +104,11 @@ signer-rotation-finalize:
 	@test -n "$(RECEIPT)" || (echo "Usage: make signer-rotation-finalize RECEIPT=build/rotation/governance-chair-receipt.json APPROVALS=build/rotation/governance-chair-approvals.json" && exit 1)
 	@test -n "$(APPROVALS)" || (echo "Usage: make signer-rotation-finalize RECEIPT=build/rotation/governance-chair-receipt.json APPROVALS=build/rotation/governance-chair-approvals.json" && exit 1)
 	./0aid signer-rotation-finalize --root . --receipt $(RECEIPT) --approvals $(APPROVALS) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-activate:
+	@test -n "$(BUNDLE)" || (echo "Usage: make signer-rotation-activate BUNDLE=build/rotation/governance-chair-approved-bundle.json INCOMING_SHARED_SECRET=dev-secret-governance-chair-v2" && exit 1)
+	@test -n "$(INCOMING_SHARED_SECRET)" || (echo "Usage: make signer-rotation-activate BUNDLE=build/rotation/governance-chair-approved-bundle.json INCOMING_SHARED_SECRET=dev-secret-governance-chair-v2" && exit 1)
+	./0aid signer-rotation-activate --root . --bundle $(BUNDLE) --incoming-shared-secret $(INCOMING_SHARED_SECRET) $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ make -C projects/0ai-assurance-network signer-manifest
 make -C projects/0ai-assurance-network signer-rotation-receipt OUTGOING_SIGNER_ID=governance-chair-bot INCOMING_SIGNER_ID=governance-chair-bot-v2 INCOMING_KEY_ID=governance-chair-dev-v2 EFFECTIVE_AT=2026-04-24T00:00:00Z
 make -C projects/0ai-assurance-network signer-rotation-approve RECEIPT=build/rotation/governance-chair-receipt.json ROLE=governance-ops SIGNER_ID=governance-ops-bot APPROVED_AT=2026-04-23T00:00:00Z
 make -C projects/0ai-assurance-network signer-rotation-finalize RECEIPT=build/rotation/governance-chair-receipt.json APPROVALS=build/rotation/governance-chair-governance-ops.json,build/rotation/governance-chair-token-house.json,build/rotation/governance-chair-telemetry.json
+make -C projects/0ai-assurance-network signer-rotation-activate BUNDLE=build/rotation/governance-chair-approved-bundle.json INCOMING_SHARED_SECRET=dev-secret-governance-chair-v2
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -202,6 +203,12 @@ bundle that can be published together with the replacement manifest. It rejects
 missing roles, duplicate approvers, receipt-digest drift, or invalid approval
 signatures.
 
+`signer-rotation-activate` consumes an approved bundle and emits a deterministic
+activation plan plus a machine-readable replacement policy for
+`config/governance/checkpoint-signers.json`. It fails closed when the approved
+bundle has drifted from the current policy lineage or when the incoming signer
+secret is missing.
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -217,6 +224,7 @@ currently supports:
 - `signer-rotation-receipt`
 - `signer-rotation-approve`
 - `signer-rotation-finalize`
+- `signer-rotation-activate`
 - `show-plan`
 - `init-genesis`
 - `render-validator`
@@ -249,6 +257,10 @@ Bootstrap examples:
   --receipt ./build/rotation/governance-chair-receipt.json \
   --approvals ./build/rotation/governance-chair-governance-ops.json,./build/rotation/governance-chair-token-house.json,./build/rotation/governance-chair-telemetry.json \
   --out ./build/rotation/governance-chair-approved-bundle.json
+./0aid signer-rotation-activate --root . \
+  --bundle ./build/rotation/governance-chair-approved-bundle.json \
+  --incoming-shared-secret dev-secret-governance-chair-v2 \
+  --out ./build/rotation/governance-chair-activation-plan.json
 ./0aid init-node --root . --id val-3 --out ./build/nodes/validator-3
 ./0aid collect-validator --bundle ./build/nodes/validator-3 --out ./build/collection/validator-3.json
 ./0aid assemble-genesis --root . --collection ./build/collection --out ./build/assembled/genesis-plan.json

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -228,6 +228,40 @@ func run(args []string) error {
 			return printJSON(finalized)
 		}
 		return project.WriteJSON(filepath.Clean(*out), finalized)
+	case "signer-rotation-activate":
+		fs := flag.NewFlagSet("signer-rotation-activate", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		bundlePath := fs.String("bundle", "", "finalized rotation bundle path")
+		incomingSharedSecret := fs.String("incoming-shared-secret", "", "incoming signer shared secret")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *bundlePath == "" {
+			return errors.New("signer-rotation-activate requires --bundle")
+		}
+		if *incomingSharedSecret == "" {
+			return errors.New("signer-rotation-activate requires --incoming-shared-secret")
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		var finalized project.SignerRotationFinalizedBundle
+		if err := readJSONFile(filepath.Clean(*bundlePath), &finalized); err != nil {
+			return err
+		}
+		activation, err := project.SignerRotationActivation(bundle, project.SignerRotationActivationRequest{
+			FinalizedBundle:      finalized,
+			IncomingSharedSecret: *incomingSharedSecret,
+		})
+		if err != nil {
+			return err
+		}
+		if *out == "" {
+			return printJSON(activation)
+		}
+		return project.WriteJSON(filepath.Clean(*out), activation)
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -396,7 +430,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -153,6 +153,36 @@ Finalization fails closed when:
 - approval signatures do not validate against the configured signer secret
 - approval artifacts reference a different receipt digest or replacement manifest
 
+## Activation plans
+
+`0aid signer-rotation-activate` consumes an approved bundle and emits the next
+operator artifact: a deterministic activation plan plus a full replacement
+policy payload for `config/governance/checkpoint-signers.json`.
+
+Example:
+
+```bash
+./0aid signer-rotation-activate --root . \
+  --bundle ./build/rotation/governance-chair-approved-bundle.json \
+  --incoming-shared-secret dev-secret-governance-chair-v2 \
+  --out ./build/rotation/governance-chair-activation-plan.json
+```
+
+The activation plan includes:
+
+- the current and target checkpoint signer policy versions
+- a policy patch summary for removing the outgoing signer and adding the approved replacement
+- a fully rendered resulting checkpoint signer policy
+- ordered activation steps for publishing and applying the approved rotation
+
+Activation fails closed when:
+
+- the approved bundle no longer matches the current signer policy lineage
+- the outgoing signer is already absent from the current policy
+- the incoming signer already exists in the current policy
+- the incoming shared secret is missing
+- the resulting policy would fail signer-manifest validation
+
 ## Operator workflow
 
 1. Render the current signer manifest and identify any `expiring` signers.
@@ -161,6 +191,7 @@ Finalization fails closed when:
 4. Collect signed approval artifacts for every required approval role.
 5. Finalize the receipt bundle and verify it remains bound to the replacement
    manifest preview.
-6. Publish the approved bundle together with the replacement signer manifest.
-7. Update `config/governance/checkpoint-signers.json` only after the approved
+6. Render the activation plan and resulting checkpoint signer policy payload.
+7. Publish the approved bundle together with the replacement signer manifest.
+8. Update `config/governance/checkpoint-signers.json` only after the approved
    replacement manifest is ready to become the new active state.

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -181,6 +181,65 @@ type SignerRotationFinalizedBundle struct {
 	ReplacementSignerManifest SignerManifestOutput                `json:"replacement_signer_manifest"`
 }
 
+type CheckpointSignerPolicySigner struct {
+	ActorID       string   `json:"actor_id"`
+	SignerID      string   `json:"signer_id"`
+	KeyID         string   `json:"key_id"`
+	Status        string   `json:"status"`
+	ProvisionedAt string   `json:"provisioned_at"`
+	RotateBy      string   `json:"rotate_by"`
+	Roles         []string `json:"roles"`
+	SharedSecret  string   `json:"shared_secret"`
+}
+
+type CheckpointSignerPolicyRotationPolicy struct {
+	ReferenceTime     string   `json:"reference_time"`
+	WarningWindowDays int      `json:"warning_window_days"`
+	ApprovalRoles     []string `json:"approval_roles"`
+}
+
+type CheckpointSignerPolicyOutput struct {
+	Version                       string                               `json:"version"`
+	SignatureFormat               string                               `json:"signature_format"`
+	RequireSignaturesForEventLogs bool                                 `json:"require_signatures_for_event_logs"`
+	MaximumSignatureValidity      int                                  `json:"maximum_signature_validity_seconds"`
+	RotationPolicy                CheckpointSignerPolicyRotationPolicy `json:"rotation_policy"`
+	Signers                       []CheckpointSignerPolicySigner       `json:"signers"`
+}
+
+type SignerRotationPolicyPatch struct {
+	PolicyPath           string                       `json:"policy_path"`
+	PolicyVersionFrom    string                       `json:"policy_version_from"`
+	PolicyVersionTo      string                       `json:"policy_version_to"`
+	ReferenceTimeFrom    string                       `json:"reference_time_from"`
+	ReferenceTimeTo      string                       `json:"reference_time_to"`
+	RemoveSignerID       string                       `json:"remove_signer_id"`
+	AddSigner            CheckpointSignerPolicySigner `json:"add_signer"`
+	ResultingSignerCount int                          `json:"resulting_signer_count"`
+}
+
+type SignerRotationActivationRequest struct {
+	FinalizedBundle      SignerRotationFinalizedBundle
+	IncomingSharedSecret string
+}
+
+type SignerRotationActivationPlan struct {
+	Version              string                       `json:"version"`
+	Status               string                       `json:"status"`
+	ReceiptID            string                       `json:"receipt_id"`
+	ChainID              string                       `json:"chain_id"`
+	PolicyPath           string                       `json:"policy_path"`
+	CurrentPolicyVersion string                       `json:"current_policy_version"`
+	TargetPolicyVersion  string                       `json:"target_policy_version"`
+	EffectiveAt          string                       `json:"effective_at"`
+	FinalizedAt          string                       `json:"finalized_at"`
+	OutgoingSignerID     string                       `json:"outgoing_signer_id"`
+	IncomingSignerID     string                       `json:"incoming_signer_id"`
+	ActivationSteps      []string                     `json:"activation_steps"`
+	PolicyPatch          SignerRotationPolicyPatch    `json:"policy_patch"`
+	ResultingPolicy      CheckpointSignerPolicyOutput `json:"resulting_policy"`
+}
+
 type parsedSignerEntry struct {
 	ActorID           string
 	SignerID          string
@@ -954,6 +1013,133 @@ func finalizedAt(approvals []SignerRotationApproval) (string, error) {
 	return latest.Format(time.RFC3339), nil
 }
 
+func buildFinalizeRequestFromBundle(bundle SignerRotationFinalizedBundle) SignerRotationFinalizeRequest {
+	return SignerRotationFinalizeRequest{
+		Receipt: SignerRotationReceiptOutput{
+			Version:                   bundle.Version,
+			ChainID:                   bundle.ChainID,
+			PolicyVersion:             bundle.PolicyVersion,
+			IdentityVersion:           bundle.IdentityVersion,
+			ReceiptID:                 bundle.ReceiptID,
+			EffectiveAt:               bundle.EffectiveAt,
+			OutgoingSigner:            bundle.OutgoingSigner,
+			IncomingSigner:            bundle.IncomingSigner,
+			ApprovalRequirements:      append([]SignerRotationApprovalRequirement(nil), bundle.ApprovalRequirements...),
+			CoverageStatus:            "ready",
+			MissingRoleCoverage:       append([]string(nil), bundle.MissingRoleCoverage...),
+			ReplacementManifestRef:    bundle.ReplacementManifestRef,
+			ReplacementSignerManifest: bundle.ReplacementSignerManifest,
+		},
+		Approvals: append([]SignerRotationApproval(nil), bundle.Approvals...),
+	}
+}
+
+func ensureFinalizedBundleMatchesBundle(bundle Bundle, finalized SignerRotationFinalizedBundle) (SignerRotationFinalizedBundle, error) {
+	request := buildFinalizeRequestFromBundle(finalized)
+	expectedReceipt, err := SignerRotationReceipt(bundle, buildReceiptRequestFromOutput(request.Receipt))
+	if err != nil {
+		return SignerRotationFinalizedBundle{}, err
+	}
+	expected, err := SignerRotationFinalize(bundle, SignerRotationFinalizeRequest{
+		Receipt:   expectedReceipt,
+		Approvals: request.Approvals,
+	})
+	if err != nil {
+		return SignerRotationFinalizedBundle{}, fmt.Errorf("signer rotation finalized bundle drift detected: %w", err)
+	}
+	expectedJSON, err := json.Marshal(expected)
+	if err != nil {
+		return SignerRotationFinalizedBundle{}, fmt.Errorf("marshal expected signer rotation finalized bundle: %w", err)
+	}
+	actualJSON, err := json.Marshal(finalized)
+	if err != nil {
+		return SignerRotationFinalizedBundle{}, fmt.Errorf("marshal actual signer rotation finalized bundle: %w", err)
+	}
+	if !bytesEqual(expectedJSON, actualJSON) {
+		return SignerRotationFinalizedBundle{}, fmt.Errorf("signer rotation finalized bundle drift detected")
+	}
+	return expected, nil
+}
+
+func currentSignerPolicy(bundle Bundle) (CheckpointSignerPolicyOutput, error) {
+	rotationPolicy := stringMap(bundle.CheckpointSigners["rotation_policy"])
+	warningWindowDays, err := intValue(rotationPolicy["warning_window_days"])
+	if err != nil {
+		return CheckpointSignerPolicyOutput{}, fmt.Errorf("checkpoint signer rotation_policy.warning_window_days must be positive")
+	}
+	approvalRoles, err := governanceApprovalRoles(bundle)
+	if err != nil {
+		return CheckpointSignerPolicyOutput{}, err
+	}
+	rawSigners, ok := bundle.CheckpointSigners["signers"].([]any)
+	if !ok {
+		return CheckpointSignerPolicyOutput{}, fmt.Errorf("checkpoint signer list must be configured")
+	}
+	signers := make([]CheckpointSignerPolicySigner, 0, len(rawSigners))
+	for _, rawSigner := range rawSigners {
+		signer := stringMap(rawSigner)
+		signers = append(signers, CheckpointSignerPolicySigner{
+			ActorID:       fmt.Sprint(signer["actor_id"]),
+			SignerID:      fmt.Sprint(signer["signer_id"]),
+			KeyID:         fmt.Sprint(signer["key_id"]),
+			Status:        fmt.Sprint(signer["status"]),
+			ProvisionedAt: fmt.Sprint(signer["provisioned_at"]),
+			RotateBy:      fmt.Sprint(signer["rotate_by"]),
+			Roles:         append([]string(nil), stringSlice(signer["roles"])...),
+			SharedSecret:  fmt.Sprint(signer["shared_secret"]),
+		})
+	}
+	sort.Slice(signers, func(i, j int) bool {
+		return signers[i].SignerID < signers[j].SignerID
+	})
+	return CheckpointSignerPolicyOutput{
+		Version:                       fmt.Sprint(bundle.CheckpointSigners["version"]),
+		SignatureFormat:               fmt.Sprint(bundle.CheckpointSigners["signature_format"]),
+		RequireSignaturesForEventLogs: fmt.Sprint(bundle.CheckpointSigners["require_signatures_for_event_logs"]) == "true",
+		MaximumSignatureValidity:      maxIntValue(bundle.CheckpointSigners["maximum_signature_validity_seconds"]),
+		RotationPolicy: CheckpointSignerPolicyRotationPolicy{
+			ReferenceTime:     fmt.Sprint(rotationPolicy["reference_time"]),
+			WarningWindowDays: warningWindowDays,
+			ApprovalRoles:     append([]string(nil), approvalRoles...),
+		},
+		Signers: signers,
+	}, nil
+}
+
+func maxIntValue(value any) int {
+	parsed, _ := intValue(value)
+	return parsed
+}
+
+func activationPolicyVersion(currentVersion string, receiptID string) string {
+	return fmt.Sprintf("%s+%s", currentVersion, receiptID)
+}
+
+func policySignerFromReplacement(replacement SignerRotationReplacement, sharedSecret string) CheckpointSignerPolicySigner {
+	return CheckpointSignerPolicySigner{
+		ActorID:       replacement.ActorID,
+		SignerID:      replacement.SignerID,
+		KeyID:         replacement.KeyID,
+		Status:        "active",
+		ProvisionedAt: replacement.ProvisionedAt,
+		RotateBy:      replacement.RotateBy,
+		Roles:         append([]string(nil), replacement.Roles...),
+		SharedSecret:  sharedSecret,
+	}
+}
+
+func policyOutputToCheckpointSignerMap(policy CheckpointSignerPolicyOutput) (map[string]any, error) {
+	encoded, err := json.Marshal(policy)
+	if err != nil {
+		return nil, fmt.Errorf("marshal checkpoint signer policy output: %w", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("decode checkpoint signer policy output: %w", err)
+	}
+	return decoded, nil
+}
+
 func SignerRotationReceipt(bundle Bundle, request SignerRotationReceiptRequest) (SignerRotationReceiptOutput, error) {
 	if err := ValidateSignerManifestInputs(bundle); err != nil {
 		return SignerRotationReceiptOutput{}, err
@@ -1291,6 +1477,97 @@ func SignerRotationFinalize(bundle Bundle, request SignerRotationFinalizeRequest
 		MissingRoleCoverage:       []string{},
 		ReplacementManifestRef:    receipt.ReplacementManifestRef,
 		ReplacementSignerManifest: receipt.ReplacementSignerManifest,
+	}, nil
+}
+
+func SignerRotationActivation(bundle Bundle, request SignerRotationActivationRequest) (SignerRotationActivationPlan, error) {
+	if err := ValidateSignerManifestInputs(bundle); err != nil {
+		return SignerRotationActivationPlan{}, err
+	}
+	if strings.TrimSpace(request.IncomingSharedSecret) == "" {
+		return SignerRotationActivationPlan{}, fmt.Errorf("incoming shared secret must be set")
+	}
+	finalized, err := ensureFinalizedBundleMatchesBundle(bundle, request.FinalizedBundle)
+	if err != nil {
+		return SignerRotationActivationPlan{}, err
+	}
+	currentPolicy, err := currentSignerPolicy(bundle)
+	if err != nil {
+		return SignerRotationActivationPlan{}, err
+	}
+	signers := make([]CheckpointSignerPolicySigner, 0, len(currentPolicy.Signers))
+	foundOutgoing := false
+	foundIncoming := false
+	for _, signer := range currentPolicy.Signers {
+		if signer.SignerID == finalized.OutgoingSigner.SignerID {
+			foundOutgoing = true
+			continue
+		}
+		if signer.SignerID == finalized.IncomingSigner.SignerID {
+			foundIncoming = true
+		}
+		signers = append(signers, signer)
+	}
+	if !foundOutgoing {
+		return SignerRotationActivationPlan{}, fmt.Errorf("outgoing signer %s is not present in current checkpoint signer policy", finalized.OutgoingSigner.SignerID)
+	}
+	if foundIncoming {
+		return SignerRotationActivationPlan{}, fmt.Errorf("incoming signer %s already exists in current checkpoint signer policy", finalized.IncomingSigner.SignerID)
+	}
+
+	incomingSigner := policySignerFromReplacement(finalized.IncomingSigner, request.IncomingSharedSecret)
+	signers = append(signers, incomingSigner)
+	sort.Slice(signers, func(i, j int) bool {
+		return signers[i].SignerID < signers[j].SignerID
+	})
+
+	resultingPolicy := currentPolicy
+	resultingPolicy.Version = activationPolicyVersion(currentPolicy.Version, finalized.ReceiptID)
+	resultingPolicy.RotationPolicy.ReferenceTime = finalized.EffectiveAt
+	resultingPolicy.Signers = signers
+
+	updatedSignerMap, err := policyOutputToCheckpointSignerMap(resultingPolicy)
+	if err != nil {
+		return SignerRotationActivationPlan{}, err
+	}
+	validationBundle := bundle
+	validationBundle.CheckpointSigners = updatedSignerMap
+	if err := ValidateSignerManifestInputs(validationBundle); err != nil {
+		return SignerRotationActivationPlan{}, err
+	}
+
+	steps := []string{
+		"Verify the finalized signer rotation bundle remains bound to the current checkpoint signer policy lineage.",
+		fmt.Sprintf("Replace signer %s with %s in config/governance/checkpoint-signers.json.", finalized.OutgoingSigner.SignerID, finalized.IncomingSigner.SignerID),
+		fmt.Sprintf("Set checkpoint signer policy version to %s and advance rotation reference_time to %s.", resultingPolicy.Version, finalized.EffectiveAt),
+		fmt.Sprintf("Publish the approved bundle and replacement manifest at %s before activation.", finalized.ReplacementManifestRef),
+		"Reload signer-manifest validation against the patched policy before any governance replay or remediation signing resumes.",
+	}
+
+	return SignerRotationActivationPlan{
+		Version:              "1.0.0",
+		Status:               "ready",
+		ReceiptID:            finalized.ReceiptID,
+		ChainID:              finalized.ChainID,
+		PolicyPath:           "config/governance/checkpoint-signers.json",
+		CurrentPolicyVersion: currentPolicy.Version,
+		TargetPolicyVersion:  resultingPolicy.Version,
+		EffectiveAt:          finalized.EffectiveAt,
+		FinalizedAt:          finalized.FinalizedAt,
+		OutgoingSignerID:     finalized.OutgoingSigner.SignerID,
+		IncomingSignerID:     finalized.IncomingSigner.SignerID,
+		ActivationSteps:      steps,
+		PolicyPatch: SignerRotationPolicyPatch{
+			PolicyPath:           "config/governance/checkpoint-signers.json",
+			PolicyVersionFrom:    currentPolicy.Version,
+			PolicyVersionTo:      resultingPolicy.Version,
+			ReferenceTimeFrom:    currentPolicy.RotationPolicy.ReferenceTime,
+			ReferenceTimeTo:      resultingPolicy.RotationPolicy.ReferenceTime,
+			RemoveSignerID:       finalized.OutgoingSigner.SignerID,
+			AddSigner:            incomingSigner,
+			ResultingSignerCount: len(resultingPolicy.Signers),
+		},
+		ResultingPolicy: resultingPolicy,
 	}, nil
 }
 

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -386,3 +386,101 @@ func TestSignerRotationFinalizeFailsOnApprovalReceiptDrift(t *testing.T) {
 		t.Fatalf("expected approval receipt drift error, got %v", err)
 	}
 }
+
+func mustSignerRotationFinalizedBundle(t *testing.T, bundle Bundle) SignerRotationFinalizedBundle {
+	t.Helper()
+
+	receipt := mustSignerRotationReceipt(t, bundle)
+	approvals := []SignerRotationApproval{}
+	for _, item := range []struct {
+		role     string
+		signerID string
+	}{
+		{role: "governance-ops", signerID: "governance-ops-bot"},
+		{role: "token-house-secretariat", signerID: "token-house-secretariat-bot"},
+		{role: "telemetry-ops", signerID: "telemetry-ops-bot"},
+	} {
+		approval, err := GenerateSignerRotationApproval(bundle, SignerRotationApprovalRequest{
+			Receipt:      receipt,
+			ApprovalRole: item.role,
+			SignerID:     item.signerID,
+			ApprovedAt:   "2026-04-23T00:00:00Z",
+		})
+		if err != nil {
+			t.Fatalf("GenerateSignerRotationApproval(%s) failed: %v", item.role, err)
+		}
+		approvals = append(approvals, approval)
+	}
+
+	finalized, err := SignerRotationFinalize(bundle, SignerRotationFinalizeRequest{
+		Receipt:   receipt,
+		Approvals: approvals,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationFinalize failed: %v", err)
+	}
+	return finalized
+}
+
+func TestSignerRotationActivation(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	finalized := mustSignerRotationFinalizedBundle(t, bundle)
+	activation, err := SignerRotationActivation(bundle, SignerRotationActivationRequest{
+		FinalizedBundle:      finalized,
+		IncomingSharedSecret: "dev-secret-governance-chair-v2",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivation failed: %v", err)
+	}
+	if activation.Status != "ready" {
+		t.Fatalf("unexpected activation status: %s", activation.Status)
+	}
+	if activation.PolicyPatch.RemoveSignerID != "governance-chair-bot" {
+		t.Fatalf("unexpected removed signer: %s", activation.PolicyPatch.RemoveSignerID)
+	}
+	if activation.PolicyPatch.AddSigner.SignerID != "governance-chair-bot-v2" {
+		t.Fatalf("unexpected replacement signer: %s", activation.PolicyPatch.AddSigner.SignerID)
+	}
+	if activation.ResultingPolicy.RotationPolicy.ReferenceTime != finalized.EffectiveAt {
+		t.Fatalf("unexpected resulting reference time: %s", activation.ResultingPolicy.RotationPolicy.ReferenceTime)
+	}
+	if activation.TargetPolicyVersion == activation.CurrentPolicyVersion {
+		t.Fatalf("expected target policy version to differ from current version")
+	}
+}
+
+func TestSignerRotationActivationFailsWithoutIncomingSharedSecret(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	finalized := mustSignerRotationFinalizedBundle(t, bundle)
+	_, err = SignerRotationActivation(bundle, SignerRotationActivationRequest{
+		FinalizedBundle: finalized,
+	})
+	if err == nil || !strings.Contains(err.Error(), "incoming shared secret must be set") {
+		t.Fatalf("expected missing shared secret error, got %v", err)
+	}
+}
+
+func TestSignerRotationActivationFailsOnBundleDrift(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	finalized := mustSignerRotationFinalizedBundle(t, bundle)
+	bundle.CheckpointSigners["version"] = "checkpoint-signers-2026-04-18"
+	_, err = SignerRotationActivation(bundle, SignerRotationActivationRequest{
+		FinalizedBundle:      finalized,
+		IncomingSharedSecret: "dev-secret-governance-chair-v2",
+	})
+	if err == nil || !strings.Contains(err.Error(), "signer rotation finalized bundle drift detected") {
+		t.Fatalf("expected finalized bundle drift error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add signer-rotation activation plans and checkpoint-signer policy patch output
- extend 0aid with signer-rotation-activate
- document the activation workflow and add activation tests

## Testing
- make validate
- make go-test
- make go-build
- python -m unittest discover -s tests -v
- ./0aid signer-rotation-receipt --root . --outgoing-signer-id governance-chair-bot --incoming-signer-id governance-chair-bot-v2 --incoming-key-id governance-chair-dev-v2 --effective-at 2026-04-24T00:00:00Z --out build/rotation/governance-chair-receipt.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role governance-ops --signer-id governance-ops-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-governance-ops.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role token-house-secretariat --signer-id token-house-secretariat-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-token-house.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role telemetry-ops --signer-id telemetry-ops-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-telemetry.json
- ./0aid signer-rotation-finalize --root . --receipt build/rotation/governance-chair-receipt.json --approvals build/rotation/governance-chair-governance-ops.json,build/rotation/governance-chair-token-house.json,build/rotation/governance-chair-telemetry.json --out build/rotation/governance-chair-approved-bundle.json
- ./0aid signer-rotation-activate --root . --bundle build/rotation/governance-chair-approved-bundle.json --incoming-shared-secret dev-secret-governance-chair-v2 --out build/rotation/governance-chair-activation-plan.json

Closes #22