### PR TITLE
Add signer rotation apply and verification receipts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -28,6 +28,8 @@ help:
 	@echo "  signer-rotation-approve Generate a signed approval artifact for a rotation receipt"
 	@echo "  signer-rotation-finalize Validate approvals and render a finalized rotation bundle"
 	@echo "  signer-rotation-activate Render an activation plan and checkpoint-signer policy patch"
+	@echo "  signer-rotation-apply Validate an activation plan and emit the applied checkpoint signer policy"
+	@echo "  signer-rotation-verify Sign a post-activation verification receipt against the applied policy"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -109,6 +111,15 @@ signer-rotation-activate:
 	@test -n "$(BUNDLE)" || (echo "Usage: make signer-rotation-activate BUNDLE=build/rotation/governance-chair-approved-bundle.json INCOMING_SHARED_SECRET=dev-secret-governance-chair-v2" && exit 1)
 	@test -n "$(INCOMING_SHARED_SECRET)" || (echo "Usage: make signer-rotation-activate BUNDLE=build/rotation/governance-chair-approved-bundle.json INCOMING_SHARED_SECRET=dev-secret-governance-chair-v2" && exit 1)
 	./0aid signer-rotation-activate --root . --bundle $(BUNDLE) --incoming-shared-secret $(INCOMING_SHARED_SECRET) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-apply:
+	@test -n "$(PLAN)" || (echo "Usage: make signer-rotation-apply PLAN=build/rotation/governance-chair-activation-plan.json" && exit 1)
+	./0aid signer-rotation-apply --root . --plan $(PLAN) $(if $(POLICY_OUT),--policy-out $(POLICY_OUT),) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-verify:
+	@test -n "$(PLAN)" || (echo "Usage: make signer-rotation-verify PLAN=build/rotation/governance-chair-activation-plan.json VERIFIED_AT=2026-04-24T00:15:00Z" && exit 1)
+	@test -n "$(VERIFIED_AT)" || (echo "Usage: make signer-rotation-verify PLAN=build/rotation/governance-chair-activation-plan.json VERIFIED_AT=2026-04-24T00:15:00Z" && exit 1)
+	./0aid signer-rotation-verify --root . --plan $(PLAN) --verified-at $(VERIFIED_AT) $(if $(POLICY),--policy $(POLICY),) $(if $(SIGNATURE_ID),--signature-id $(SIGNATURE_ID),) $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ make -C projects/0ai-assurance-network signer-rotation-receipt OUTGOING_SIGNER_I
 make -C projects/0ai-assurance-network signer-rotation-approve RECEIPT=build/rotation/governance-chair-receipt.json ROLE=governance-ops SIGNER_ID=governance-ops-bot APPROVED_AT=2026-04-23T00:00:00Z
 make -C projects/0ai-assurance-network signer-rotation-finalize RECEIPT=build/rotation/governance-chair-receipt.json APPROVALS=build/rotation/governance-chair-governance-ops.json,build/rotation/governance-chair-token-house.json,build/rotation/governance-chair-telemetry.json
 make -C projects/0ai-assurance-network signer-rotation-activate BUNDLE=build/rotation/governance-chair-approved-bundle.json INCOMING_SHARED_SECRET=dev-secret-governance-chair-v2
+make -C projects/0ai-assurance-network signer-rotation-apply PLAN=build/rotation/governance-chair-activation-plan.json POLICY_OUT=build/rotation/governance-chair-applied-policy.json
+make -C projects/0ai-assurance-network signer-rotation-verify PLAN=build/rotation/governance-chair-activation-plan.json POLICY=build/rotation/governance-chair-applied-policy.json VERIFIED_AT=2026-04-24T00:15:00Z
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -209,6 +211,18 @@ activation plan plus a machine-readable replacement policy for
 bundle has drifted from the current policy lineage or when the incoming signer
 secret is missing.
 
+`signer-rotation-apply` validates the activation plan against the current
+policy lineage and emits the exact applied checkpoint signer policy plus stable
+digests for the plan and policy payload. Operators can direct the resulting
+policy into a standalone file with `--policy-out` or write that file directly
+to `config/governance/checkpoint-signers.json`.
+
+`signer-rotation-verify` signs a post-activation verification receipt against
+the applied policy using the newly activated signer. Verification fails closed
+when the applied policy drifts from the activation plan, the outgoing signer is
+still present, the incoming signer is missing, or the verification timestamp
+falls outside the new signer validity window.
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -225,6 +239,8 @@ currently supports:
 - `signer-rotation-approve`
 - `signer-rotation-finalize`
 - `signer-rotation-activate`
+- `signer-rotation-apply`
+- `signer-rotation-verify`
 - `show-plan`
 - `init-genesis`
 - `render-validator`
@@ -261,6 +277,15 @@ Bootstrap examples:
   --bundle ./build/rotation/governance-chair-approved-bundle.json \
   --incoming-shared-secret dev-secret-governance-chair-v2 \
   --out ./build/rotation/governance-chair-activation-plan.json
+./0aid signer-rotation-apply --root . \
+  --plan ./build/rotation/governance-chair-activation-plan.json \
+  --policy-out ./build/rotation/governance-chair-applied-policy.json \
+  --out ./build/rotation/governance-chair-apply-result.json
+./0aid signer-rotation-verify --root . \
+  --plan ./build/rotation/governance-chair-activation-plan.json \
+  --policy ./build/rotation/governance-chair-applied-policy.json \
+  --verified-at 2026-04-24T00:15:00Z \
+  --out ./build/rotation/governance-chair-verification.json
 ./0aid init-node --root . --id val-3 --out ./build/nodes/validator-3
 ./0aid collect-validator --bundle ./build/nodes/validator-3 --out ./build/collection/validator-3.json
 ./0aid assemble-genesis --root . --collection ./build/collection --out ./build/assembled/genesis-plan.json

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -262,6 +262,87 @@ func run(args []string) error {
 			return printJSON(activation)
 		}
 		return project.WriteJSON(filepath.Clean(*out), activation)
+	case "signer-rotation-apply":
+		fs := flag.NewFlagSet("signer-rotation-apply", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		planPath := fs.String("plan", "", "activation plan path")
+		policyOut := fs.String("policy-out", "", "applied policy output path")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *planPath == "" {
+			return errors.New("signer-rotation-apply requires --plan")
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		var plan project.SignerRotationActivationPlan
+		if err := readJSONFile(filepath.Clean(*planPath), &plan); err != nil {
+			return err
+		}
+		applyResult, err := project.SignerRotationApply(bundle, project.SignerRotationApplyRequest{
+			ActivationPlan: plan,
+		})
+		if err != nil {
+			return err
+		}
+		if *policyOut != "" {
+			if err := project.WriteJSON(filepath.Clean(*policyOut), applyResult.AppliedPolicy); err != nil {
+				return err
+			}
+		}
+		if *out == "" {
+			return printJSON(applyResult)
+		}
+		return project.WriteJSON(filepath.Clean(*out), applyResult)
+	case "signer-rotation-verify":
+		fs := flag.NewFlagSet("signer-rotation-verify", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		planPath := fs.String("plan", "", "activation plan path")
+		policyPath := fs.String("policy", "", "applied checkpoint signer policy path")
+		verifiedAt := fs.String("verified-at", "", "verification timestamp")
+		signatureID := fs.String("signature-id", "", "explicit signature id")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *planPath == "" {
+			return errors.New("signer-rotation-verify requires --plan")
+		}
+		if *verifiedAt == "" {
+			return errors.New("signer-rotation-verify requires --verified-at")
+		}
+		bundle, err := project.LoadBundle(*root)
+		if err != nil {
+			return err
+		}
+		var plan project.SignerRotationActivationPlan
+		if err := readJSONFile(filepath.Clean(*planPath), &plan); err != nil {
+			return err
+		}
+		resolvedPolicyPath := strings.TrimSpace(*policyPath)
+		if resolvedPolicyPath == "" {
+			resolvedPolicyPath = filepath.Join(*root, filepath.FromSlash(plan.PolicyPath))
+		}
+		var policy project.CheckpointSignerPolicyOutput
+		if err := readJSONFile(filepath.Clean(resolvedPolicyPath), &policy); err != nil {
+			return err
+		}
+		receipt, err := project.SignerRotationVerify(bundle, project.SignerRotationVerifyRequest{
+			ActivationPlan: plan,
+			Policy:         policy,
+			VerifiedAt:     *verifiedAt,
+			SignatureID:    *signatureID,
+		})
+		if err != nil {
+			return err
+		}
+		if *out == "" {
+			return printJSON(receipt)
+		}
+		return project.WriteJSON(filepath.Clean(*out), receipt)
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -430,7 +511,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -183,6 +183,67 @@ Activation fails closed when:
 - the incoming shared secret is missing
 - the resulting policy would fail signer-manifest validation
 
+## Apply results
+
+`0aid signer-rotation-apply` validates the activation plan against the current
+policy lineage and emits a machine-readable apply result plus the exact
+checkpoint signer policy that should become active.
+
+Example:
+
+```bash
+./0aid signer-rotation-apply --root . \
+  --plan ./build/rotation/governance-chair-activation-plan.json \
+  --policy-out ./build/rotation/governance-chair-applied-policy.json \
+  --out ./build/rotation/governance-chair-apply-result.json
+```
+
+The apply result includes:
+
+- `activation_plan_digest`
+- `applied_policy_digest`
+- the exact `applied_policy`
+- `target_policy_version`
+- the deterministic effective cutover time
+
+Apply fails closed when:
+
+- the activation plan no longer matches the current policy lineage
+- the resulting policy payload differs from the plan output
+- the resulting policy would fail signer-manifest validation
+
+## Post-activation verification receipts
+
+`0aid signer-rotation-verify` signs a post-activation verification receipt
+against the applied checkpoint signer policy using the newly activated signer.
+
+Example:
+
+```bash
+./0aid signer-rotation-verify --root . \
+  --plan ./build/rotation/governance-chair-activation-plan.json \
+  --policy ./build/rotation/governance-chair-applied-policy.json \
+  --verified-at 2026-04-24T00:15:00Z \
+  --out ./build/rotation/governance-chair-verification.json
+```
+
+Verification receipts include:
+
+- the activation plan digest
+- the applied policy digest
+- the signer/key that verified the activation
+- actor and organization ownership context
+- a signed verification receipt with validity bounds
+
+Verification fails closed when:
+
+- the applied policy drifts from the activation plan
+- the outgoing signer is still present
+- the incoming signer is missing
+- the incoming signer lacks a shared secret
+- `verified_at` falls before `effective_at`, before `provisioned_at`, or after
+  the incoming signer `rotate_by`
+
 ## Operator workflow
 
 1. Render the current signer manifest and identify any `expiring` signers.
@@ -192,6 +253,10 @@ Activation fails closed when:
 5. Finalize the receipt bundle and verify it remains bound to the replacement
    manifest preview.
 6. Render the activation plan and resulting checkpoint signer policy payload.
-7. Publish the approved bundle together with the replacement signer manifest.
-8. Update `config/governance/checkpoint-signers.json` only after the approved
+7. Apply the activation plan and emit the exact replacement
+   `checkpoint-signers.json` payload.
+8. Publish the approved bundle together with the replacement signer manifest.
+9. Update `config/governance/checkpoint-signers.json` only after the approved
    replacement manifest is ready to become the new active state.
+10. Sign and retain a post-activation verification receipt proving the new
+    signer set became active exactly as planned.

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -240,6 +240,57 @@ type SignerRotationActivationPlan struct {
 	ResultingPolicy      CheckpointSignerPolicyOutput `json:"resulting_policy"`
 }
 
+type SignerRotationApplyRequest struct {
+	ActivationPlan SignerRotationActivationPlan
+}
+
+type SignerRotationApplyResult struct {
+	Version              string                       `json:"version"`
+	Status               string                       `json:"status"`
+	ReceiptID            string                       `json:"receipt_id"`
+	ChainID              string                       `json:"chain_id"`
+	PolicyPath           string                       `json:"policy_path"`
+	TargetPolicyVersion  string                       `json:"target_policy_version"`
+	ActivationPlanDigest string                       `json:"activation_plan_digest"`
+	AppliedPolicyDigest  string                       `json:"applied_policy_digest"`
+	AppliedPolicy        CheckpointSignerPolicyOutput `json:"applied_policy"`
+	AppliedAtEffect      string                       `json:"applied_at_effective_time"`
+}
+
+type SignerRotationVerificationSignature struct {
+	Format      string `json:"format"`
+	SignatureID string `json:"signature_id"`
+	SignedAt    string `json:"signed_at"`
+	ExpiresAt   string `json:"expires_at"`
+	Value       string `json:"value"`
+}
+
+type SignerRotationVerificationReceipt struct {
+	Version              string                              `json:"version"`
+	Status               string                              `json:"status"`
+	ReceiptID            string                              `json:"receipt_id"`
+	ChainID              string                              `json:"chain_id"`
+	ActivationPlanDigest string                              `json:"activation_plan_digest"`
+	PolicyDigest         string                              `json:"policy_digest"`
+	VerifiedAt           string                              `json:"verified_at"`
+	PolicyPath           string                              `json:"policy_path"`
+	TargetPolicyVersion  string                              `json:"target_policy_version"`
+	SignerID             string                              `json:"signer_id"`
+	KeyID                string                              `json:"key_id"`
+	ActorID              string                              `json:"actor_id"`
+	ActorDisplayName     string                              `json:"actor_display_name"`
+	OrganizationID       string                              `json:"organization_id,omitempty"`
+	OrganizationName     string                              `json:"organization_name,omitempty"`
+	Signature            SignerRotationVerificationSignature `json:"signature"`
+}
+
+type SignerRotationVerifyRequest struct {
+	ActivationPlan SignerRotationActivationPlan
+	Policy         CheckpointSignerPolicyOutput
+	VerifiedAt     string
+	SignatureID    string
+}
+
 type parsedSignerEntry struct {
 	ActorID           string
 	SignerID          string
@@ -1140,6 +1191,146 @@ func policyOutputToCheckpointSignerMap(policy CheckpointSignerPolicyOutput) (map
 	return decoded, nil
 }
 
+func activationPlanDigest(plan SignerRotationActivationPlan) (string, error) {
+	encoded, err := json.Marshal(plan)
+	if err != nil {
+		return "", fmt.Errorf("marshal signer rotation activation plan: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func checkpointSignerPolicyDigest(policy CheckpointSignerPolicyOutput) (string, error) {
+	encoded, err := json.Marshal(policy)
+	if err != nil {
+		return "", fmt.Errorf("marshal checkpoint signer policy: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func signerRotationVerificationMessage(
+	plan SignerRotationActivationPlan,
+	planDigest string,
+	policyDigest string,
+	policyPath string,
+	signerID string,
+	keyID string,
+	verifiedAt time.Time,
+) string {
+	parts := []string{
+		"0ai-assurance-network/signer-rotation-verification/v1",
+		plan.Version,
+		plan.ChainID,
+		plan.ReceiptID,
+		planDigest,
+		policyDigest,
+		policyPath,
+		plan.TargetPolicyVersion,
+		signerID,
+		keyID,
+		verifiedAt.UTC().Format(time.RFC3339),
+	}
+	return joinStrings(parts, "\n")
+}
+
+func signerRotationVerificationExpiry(
+	signerRotateBy time.Time,
+	verifiedAt time.Time,
+	maxValiditySeconds int,
+) time.Time {
+	expiresAt := verifiedAt.Add(time.Duration(maxValiditySeconds) * time.Second)
+	if expiresAt.After(signerRotateBy) {
+		expiresAt = signerRotateBy
+	}
+	return expiresAt.UTC()
+}
+
+func policySignerByID(policy CheckpointSignerPolicyOutput, signerID string) (CheckpointSignerPolicySigner, bool) {
+	for _, signer := range policy.Signers {
+		if signer.SignerID == signerID {
+			return signer, true
+		}
+	}
+	return CheckpointSignerPolicySigner{}, false
+}
+
+func actorContext(bundle Bundle, actorID string) (IdentityActor, string) {
+	actors, _ := activeActorsAndBindings(bundle)
+	actor := actors[actorID]
+	organizationName := ""
+	if actor.OrganizationID != "" {
+		if organization, exists := actors[actor.OrganizationID]; exists {
+			organizationName = organization.DisplayName
+		}
+	}
+	return actor, organizationName
+}
+
+func ensureActivationPlanMatchesBundle(bundle Bundle, plan SignerRotationActivationPlan) (SignerRotationActivationPlan, error) {
+	currentPolicy, err := currentSignerPolicy(bundle)
+	if err != nil {
+		return SignerRotationActivationPlan{}, err
+	}
+	if plan.PolicyPath != "config/governance/checkpoint-signers.json" {
+		return SignerRotationActivationPlan{}, fmt.Errorf("unexpected activation policy path: %s", plan.PolicyPath)
+	}
+	if plan.CurrentPolicyVersion != currentPolicy.Version || plan.PolicyPatch.PolicyVersionFrom != currentPolicy.Version {
+		return SignerRotationActivationPlan{}, fmt.Errorf("signer rotation activation plan drift detected")
+	}
+	if plan.PolicyPatch.ReferenceTimeFrom != currentPolicy.RotationPolicy.ReferenceTime {
+		return SignerRotationActivationPlan{}, fmt.Errorf("signer rotation activation plan drift detected")
+	}
+	if strings.TrimSpace(plan.PolicyPatch.AddSigner.SharedSecret) == "" {
+		return SignerRotationActivationPlan{}, fmt.Errorf("activation plan add_signer.shared_secret must be set")
+	}
+	signers := make([]CheckpointSignerPolicySigner, 0, len(currentPolicy.Signers))
+	foundOutgoing := false
+	foundIncoming := false
+	for _, signer := range currentPolicy.Signers {
+		if signer.SignerID == plan.PolicyPatch.RemoveSignerID {
+			foundOutgoing = true
+			continue
+		}
+		if signer.SignerID == plan.PolicyPatch.AddSigner.SignerID {
+			foundIncoming = true
+		}
+		signers = append(signers, signer)
+	}
+	if !foundOutgoing || foundIncoming {
+		return SignerRotationActivationPlan{}, fmt.Errorf("signer rotation activation plan drift detected")
+	}
+	signers = append(signers, plan.PolicyPatch.AddSigner)
+	sort.Slice(signers, func(i, j int) bool {
+		return signers[i].SignerID < signers[j].SignerID
+	})
+	expectedPolicy := currentPolicy
+	expectedPolicy.Version = plan.PolicyPatch.PolicyVersionTo
+	expectedPolicy.RotationPolicy.ReferenceTime = plan.PolicyPatch.ReferenceTimeTo
+	expectedPolicy.Signers = signers
+	expectedJSON, err := json.Marshal(expectedPolicy)
+	if err != nil {
+		return SignerRotationActivationPlan{}, fmt.Errorf("marshal expected signer rotation activation policy: %w", err)
+	}
+	actualJSON, err := json.Marshal(plan.ResultingPolicy)
+	if err != nil {
+		return SignerRotationActivationPlan{}, fmt.Errorf("marshal actual signer rotation activation policy: %w", err)
+	}
+	if !bytesEqual(expectedJSON, actualJSON) {
+		return SignerRotationActivationPlan{}, fmt.Errorf("signer rotation activation plan drift detected")
+	}
+	validationMap, err := policyOutputToCheckpointSignerMap(expectedPolicy)
+	if err != nil {
+		return SignerRotationActivationPlan{}, err
+	}
+	validationBundle := bundle
+	validationBundle.CheckpointSigners = validationMap
+	if err := ValidateSignerManifestInputs(validationBundle); err != nil {
+		return SignerRotationActivationPlan{}, err
+	}
+	return plan, nil
+}
+
 func SignerRotationReceipt(bundle Bundle, request SignerRotationReceiptRequest) (SignerRotationReceiptOutput, error) {
 	if err := ValidateSignerManifestInputs(bundle); err != nil {
 		return SignerRotationReceiptOutput{}, err
@@ -1568,6 +1759,164 @@ func SignerRotationActivation(bundle Bundle, request SignerRotationActivationReq
 			ResultingSignerCount: len(resultingPolicy.Signers),
 		},
 		ResultingPolicy: resultingPolicy,
+	}, nil
+}
+
+func SignerRotationApply(bundle Bundle, request SignerRotationApplyRequest) (SignerRotationApplyResult, error) {
+	if err := ValidateSignerManifestInputs(bundle); err != nil {
+		return SignerRotationApplyResult{}, err
+	}
+	plan, err := ensureActivationPlanMatchesBundle(bundle, request.ActivationPlan)
+	if err != nil {
+		return SignerRotationApplyResult{}, err
+	}
+	planDigest, err := activationPlanDigest(plan)
+	if err != nil {
+		return SignerRotationApplyResult{}, err
+	}
+	policyDigest, err := checkpointSignerPolicyDigest(plan.ResultingPolicy)
+	if err != nil {
+		return SignerRotationApplyResult{}, err
+	}
+	return SignerRotationApplyResult{
+		Version:              "1.0.0",
+		Status:               "applied",
+		ReceiptID:            plan.ReceiptID,
+		ChainID:              plan.ChainID,
+		PolicyPath:           plan.PolicyPath,
+		TargetPolicyVersion:  plan.TargetPolicyVersion,
+		ActivationPlanDigest: planDigest,
+		AppliedPolicyDigest:  policyDigest,
+		AppliedPolicy:        plan.ResultingPolicy,
+		AppliedAtEffect:      plan.EffectiveAt,
+	}, nil
+}
+
+func SignerRotationVerify(bundle Bundle, request SignerRotationVerifyRequest) (SignerRotationVerificationReceipt, error) {
+	if err := ValidateSignerManifestInputs(bundle); err != nil {
+		return SignerRotationVerificationReceipt{}, err
+	}
+	plan, err := ensureActivationPlanMatchesBundle(bundle, request.ActivationPlan)
+	if err != nil {
+		return SignerRotationVerificationReceipt{}, err
+	}
+	planDigest, err := activationPlanDigest(plan)
+	if err != nil {
+		return SignerRotationVerificationReceipt{}, err
+	}
+	expectedPolicyJSON, err := json.Marshal(plan.ResultingPolicy)
+	if err != nil {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("marshal expected activation policy: %w", err)
+	}
+	actualPolicyJSON, err := json.Marshal(request.Policy)
+	if err != nil {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("marshal verification policy: %w", err)
+	}
+	if !bytesEqual(expectedPolicyJSON, actualPolicyJSON) {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("signer rotation applied policy drift detected")
+	}
+	validationMap, err := policyOutputToCheckpointSignerMap(request.Policy)
+	if err != nil {
+		return SignerRotationVerificationReceipt{}, err
+	}
+	validationBundle := bundle
+	validationBundle.CheckpointSigners = validationMap
+	if err := ValidateSignerManifestInputs(validationBundle); err != nil {
+		return SignerRotationVerificationReceipt{}, err
+	}
+	if request.Policy.Version != plan.TargetPolicyVersion {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("verification policy version mismatch")
+	}
+	if request.Policy.RotationPolicy.ReferenceTime != plan.EffectiveAt {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("verification policy reference_time mismatch")
+	}
+	if _, exists := policySignerByID(request.Policy, plan.OutgoingSignerID); exists {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("verification policy still contains outgoing signer %s", plan.OutgoingSignerID)
+	}
+	incomingSigner, exists := policySignerByID(request.Policy, plan.IncomingSignerID)
+	if !exists {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("verification policy missing incoming signer %s", plan.IncomingSignerID)
+	}
+	if strings.TrimSpace(incomingSigner.SharedSecret) == "" {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("verification signer shared_secret must be set")
+	}
+	verifiedAt, err := parseRFC3339(request.VerifiedAt, "verification verified_at")
+	if err != nil {
+		return SignerRotationVerificationReceipt{}, err
+	}
+	effectiveAt, err := parseRFC3339(plan.EffectiveAt, "activation effective_at")
+	if err != nil {
+		return SignerRotationVerificationReceipt{}, err
+	}
+	provisionedAt, err := parseRFC3339(incomingSigner.ProvisionedAt, "verification signer provisioned_at")
+	if err != nil {
+		return SignerRotationVerificationReceipt{}, err
+	}
+	rotateBy, err := parseRFC3339(incomingSigner.RotateBy, "verification signer rotate_by")
+	if err != nil {
+		return SignerRotationVerificationReceipt{}, err
+	}
+	if verifiedAt.Before(effectiveAt) {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("verification verified_at must be on or after activation effective_at")
+	}
+	if verifiedAt.Before(provisionedAt) {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("verification verified_at must be on or after signer provisioned_at")
+	}
+	if verifiedAt.After(rotateBy) {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("verification verified_at must be on or before signer rotate_by")
+	}
+	maxValiditySeconds := request.Policy.MaximumSignatureValidity
+	if maxValiditySeconds <= 0 {
+		return SignerRotationVerificationReceipt{}, fmt.Errorf("checkpoint signer validity window must be positive")
+	}
+	policyDigest, err := checkpointSignerPolicyDigest(request.Policy)
+	if err != nil {
+		return SignerRotationVerificationReceipt{}, err
+	}
+	signatureID := strings.TrimSpace(request.SignatureID)
+	if signatureID == "" {
+		signatureID = fmt.Sprintf(
+			"verify-%s-%s",
+			plan.ReceiptID,
+			strings.ToLower(verifiedAt.UTC().Format("20060102t150405z")),
+		)
+	}
+	signatureMessage := signerRotationVerificationMessage(
+		plan,
+		planDigest,
+		policyDigest,
+		plan.PolicyPath,
+		incomingSigner.SignerID,
+		incomingSigner.KeyID,
+		verifiedAt,
+	)
+	mac := hmac.New(sha256.New, []byte(incomingSigner.SharedSecret))
+	mac.Write([]byte(signatureMessage))
+	expiresAt := signerRotationVerificationExpiry(rotateBy, verifiedAt, maxValiditySeconds)
+	actor, organizationName := actorContext(bundle, incomingSigner.ActorID)
+	return SignerRotationVerificationReceipt{
+		Version:              "1.0.0",
+		Status:               "verified",
+		ReceiptID:            plan.ReceiptID,
+		ChainID:              plan.ChainID,
+		ActivationPlanDigest: planDigest,
+		PolicyDigest:         policyDigest,
+		VerifiedAt:           verifiedAt.Format(time.RFC3339),
+		PolicyPath:           plan.PolicyPath,
+		TargetPolicyVersion:  plan.TargetPolicyVersion,
+		SignerID:             incomingSigner.SignerID,
+		KeyID:                incomingSigner.KeyID,
+		ActorID:              actor.ActorID,
+		ActorDisplayName:     actor.DisplayName,
+		OrganizationID:       actor.OrganizationID,
+		OrganizationName:     organizationName,
+		Signature: SignerRotationVerificationSignature{
+			Format:      request.Policy.SignatureFormat,
+			SignatureID: signatureID,
+			SignedAt:    verifiedAt.Format(time.RFC3339),
+			ExpiresAt:   expiresAt.Format(time.RFC3339),
+			Value:       hex.EncodeToString(mac.Sum(nil)),
+		},
 	}, nil
 }
 

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -484,3 +484,121 @@ func TestSignerRotationActivationFailsOnBundleDrift(t *testing.T) {
 		t.Fatalf("expected finalized bundle drift error, got %v", err)
 	}
 }
+
+func mustSignerRotationActivationPlan(t *testing.T, bundle Bundle) SignerRotationActivationPlan {
+	t.Helper()
+
+	finalized := mustSignerRotationFinalizedBundle(t, bundle)
+	activation, err := SignerRotationActivation(bundle, SignerRotationActivationRequest{
+		FinalizedBundle:      finalized,
+		IncomingSharedSecret: "dev-secret-governance-chair-v2",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivation failed: %v", err)
+	}
+	return activation
+}
+
+func TestSignerRotationApply(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	plan := mustSignerRotationActivationPlan(t, bundle)
+	result, err := SignerRotationApply(bundle, SignerRotationApplyRequest{
+		ActivationPlan: plan,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationApply failed: %v", err)
+	}
+	if result.Status != "applied" {
+		t.Fatalf("unexpected apply status: %s", result.Status)
+	}
+	if result.TargetPolicyVersion != plan.TargetPolicyVersion {
+		t.Fatalf("unexpected target policy version: %s", result.TargetPolicyVersion)
+	}
+	if result.ActivationPlanDigest == "" || result.AppliedPolicyDigest == "" {
+		t.Fatalf("expected apply digests, got %+v", result)
+	}
+	encodedExpected, err := json.Marshal(plan.ResultingPolicy)
+	if err != nil {
+		t.Fatalf("marshal expected applied policy: %v", err)
+	}
+	encodedActual, err := json.Marshal(result.AppliedPolicy)
+	if err != nil {
+		t.Fatalf("marshal actual applied policy: %v", err)
+	}
+	if !bytesEqual(encodedExpected, encodedActual) {
+		t.Fatalf("applied policy does not match activation result")
+	}
+}
+
+func TestSignerRotationApplyFailsOnPlanDrift(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	plan := mustSignerRotationActivationPlan(t, bundle)
+	plan.PolicyPatch.RemoveSignerID = "nonexistent-signer"
+	_, err = SignerRotationApply(bundle, SignerRotationApplyRequest{
+		ActivationPlan: plan,
+	})
+	if err == nil || !strings.Contains(err.Error(), "signer rotation activation plan drift detected") {
+		t.Fatalf("expected activation plan drift error, got %v", err)
+	}
+}
+
+func TestSignerRotationVerify(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	plan := mustSignerRotationActivationPlan(t, bundle)
+	applied, err := SignerRotationApply(bundle, SignerRotationApplyRequest{
+		ActivationPlan: plan,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationApply failed: %v", err)
+	}
+	receipt, err := SignerRotationVerify(bundle, SignerRotationVerifyRequest{
+		ActivationPlan: plan,
+		Policy:         applied.AppliedPolicy,
+		VerifiedAt:     "2026-04-24T00:15:00Z",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationVerify failed: %v", err)
+	}
+	if receipt.Status != "verified" {
+		t.Fatalf("unexpected verification status: %s", receipt.Status)
+	}
+	if receipt.SignerID != "governance-chair-bot-v2" {
+		t.Fatalf("unexpected verification signer: %s", receipt.SignerID)
+	}
+	if receipt.Signature.Value == "" || receipt.Signature.SignatureID == "" {
+		t.Fatalf("expected verification signature metadata, got %+v", receipt.Signature)
+	}
+}
+
+func TestSignerRotationVerifyFailsOnPolicyDrift(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	plan := mustSignerRotationActivationPlan(t, bundle)
+	policy, err := currentSignerPolicy(bundle)
+	if err != nil {
+		t.Fatalf("currentSignerPolicy failed: %v", err)
+	}
+	_, err = SignerRotationVerify(bundle, SignerRotationVerifyRequest{
+		ActivationPlan: plan,
+		Policy:         policy,
+		VerifiedAt:     "2026-04-24T00:15:00Z",
+	})
+	if err == nil || !strings.Contains(err.Error(), "signer rotation applied policy drift detected") {
+		t.Fatalf("expected applied policy drift error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add deterministic signer rotation apply output and post-activation verification receipts
- expose apply and verify through 0aid and make targets
- document and test the full receipt -> approve -> finalize -> activate -> apply -> verify workflow

## Testing
- make validate
- make go-test
- make go-build
- python -m unittest discover -s tests -v
- ./0aid signer-rotation-receipt --root . --outgoing-signer-id governance-chair-bot --incoming-signer-id governance-chair-bot-v2 --incoming-key-id governance-chair-dev-v2 --effective-at 2026-04-24T00:00:00Z --out build/rotation/governance-chair-receipt.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role governance-ops --signer-id governance-ops-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-governance-ops.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role token-house-secretariat --signer-id token-house-secretariat-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-token-house.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role telemetry-ops --signer-id telemetry-ops-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-telemetry.json
- ./0aid signer-rotation-finalize --root . --receipt build/rotation/governance-chair-receipt.json --approvals build/rotation/governance-chair-governance-ops.json,build/rotation/governance-chair-token-house.json,build/rotation/governance-chair-telemetry.json --out build/rotation/governance-chair-approved-bundle.json
- ./0aid signer-rotation-activate --root . --bundle build/rotation/governance-chair-approved-bundle.json --incoming-shared-secret dev-secret-governance-chair-v2 --out build/rotation/governance-chair-activation-plan.json
- ./0aid signer-rotation-apply --root . --plan build/rotation/governance-chair-activation-plan.json --policy-out build/rotation/governance-chair-applied-policy.json --out build/rotation/governance-chair-apply-result.json
- ./0aid signer-rotation-verify --root . --plan build/rotation/governance-chair-activation-plan.json --policy build/rotation/governance-chair-applied-policy.json --verified-at 2026-04-24T00:15:00Z --out build/rotation/governance-chair-verification.json

Closes #24