### PR TITLE
Add signer rotation activation audit ledger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -30,6 +30,7 @@ help:
 	@echo "  signer-rotation-activate Render an activation plan and checkpoint-signer policy patch"
 	@echo "  signer-rotation-apply Validate an activation plan and emit the applied checkpoint signer policy"
 	@echo "  signer-rotation-verify Sign a post-activation verification receipt against the applied policy"
+	@echo "  signer-rotation-ledger-append Append a verified activation record into the audit ledger"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -120,6 +121,11 @@ signer-rotation-verify:
 	@test -n "$(PLAN)" || (echo "Usage: make signer-rotation-verify PLAN=build/rotation/governance-chair-activation-plan.json VERIFIED_AT=2026-04-24T00:15:00Z" && exit 1)
 	@test -n "$(VERIFIED_AT)" || (echo "Usage: make signer-rotation-verify PLAN=build/rotation/governance-chair-activation-plan.json VERIFIED_AT=2026-04-24T00:15:00Z" && exit 1)
 	./0aid signer-rotation-verify --root . --plan $(PLAN) --verified-at $(VERIFIED_AT) $(if $(POLICY),--policy $(POLICY),) $(if $(SIGNATURE_ID),--signature-id $(SIGNATURE_ID),) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-ledger-append:
+	@test -n "$(APPLY)" || (echo "Usage: make signer-rotation-ledger-append APPLY=build/rotation/governance-chair-apply-result.json VERIFICATION=build/rotation/governance-chair-verification.json" && exit 1)
+	@test -n "$(VERIFICATION)" || (echo "Usage: make signer-rotation-ledger-append APPLY=build/rotation/governance-chair-apply-result.json VERIFICATION=build/rotation/governance-chair-verification.json" && exit 1)
+	./0aid signer-rotation-ledger-append --apply $(APPLY) --verification $(VERIFICATION) $(if $(LEDGER),--ledger $(LEDGER),) $(if $(LEDGER_OUT),--ledger-out $(LEDGER_OUT),) $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ make -C projects/0ai-assurance-network signer-rotation-finalize RECEIPT=build/ro
 make -C projects/0ai-assurance-network signer-rotation-activate BUNDLE=build/rotation/governance-chair-approved-bundle.json INCOMING_SHARED_SECRET=dev-secret-governance-chair-v2
 make -C projects/0ai-assurance-network signer-rotation-apply PLAN=build/rotation/governance-chair-activation-plan.json POLICY_OUT=build/rotation/governance-chair-applied-policy.json
 make -C projects/0ai-assurance-network signer-rotation-verify PLAN=build/rotation/governance-chair-activation-plan.json POLICY=build/rotation/governance-chair-applied-policy.json VERIFIED_AT=2026-04-24T00:15:00Z
+make -C projects/0ai-assurance-network signer-rotation-ledger-append APPLY=build/rotation/governance-chair-apply-result.json VERIFICATION=build/rotation/governance-chair-verification.json LEDGER_OUT=build/rotation/activation-audit-ledger.json
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -223,6 +224,12 @@ when the applied policy drifts from the activation plan, the outgoing signer is
 still present, the incoming signer is missing, or the verification timestamp
 falls outside the new signer validity window.
 
+`signer-rotation-ledger-append` binds the apply result and verification receipt
+into an append-only activation audit ledger. It rejects mismatched receipt or
+policy digests, duplicate receipt IDs, duplicate target policy versions,
+replayed verification signatures, and non-monotonic effective or verified
+timestamps.
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -241,6 +248,7 @@ currently supports:
 - `signer-rotation-activate`
 - `signer-rotation-apply`
 - `signer-rotation-verify`
+- `signer-rotation-ledger-append`
 - `show-plan`
 - `init-genesis`
 - `render-validator`
@@ -286,6 +294,11 @@ Bootstrap examples:
   --policy ./build/rotation/governance-chair-applied-policy.json \
   --verified-at 2026-04-24T00:15:00Z \
   --out ./build/rotation/governance-chair-verification.json
+./0aid signer-rotation-ledger-append \
+  --apply ./build/rotation/governance-chair-apply-result.json \
+  --verification ./build/rotation/governance-chair-verification.json \
+  --ledger-out ./build/rotation/activation-audit-ledger.json \
+  --out ./build/rotation/governance-chair-ledger-append.json
 ./0aid init-node --root . --id val-3 --out ./build/nodes/validator-3
 ./0aid collect-validator --bundle ./build/nodes/validator-3 --out ./build/collection/validator-3.json
 ./0aid assemble-genesis --root . --collection ./build/collection --out ./build/assembled/genesis-plan.json

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -343,6 +343,60 @@ func run(args []string) error {
 			return printJSON(receipt)
 		}
 		return project.WriteJSON(filepath.Clean(*out), receipt)
+	case "signer-rotation-ledger-append":
+		fs := flag.NewFlagSet("signer-rotation-ledger-append", flag.ContinueOnError)
+		applyPath := fs.String("apply", "", "signer rotation apply result path")
+		verificationPath := fs.String("verification", "", "signer rotation verification receipt path")
+		ledgerPath := fs.String("ledger", "", "existing activation audit ledger path")
+		ledgerOut := fs.String("ledger-out", "", "updated activation audit ledger output path")
+		out := fs.String("out", "", "append result output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *applyPath == "" {
+			return errors.New("signer-rotation-ledger-append requires --apply")
+		}
+		if *verificationPath == "" {
+			return errors.New("signer-rotation-ledger-append requires --verification")
+		}
+		var applyResult project.SignerRotationApplyResult
+		if err := readJSONFile(filepath.Clean(*applyPath), &applyResult); err != nil {
+			return err
+		}
+		var verification project.SignerRotationVerificationReceipt
+		if err := readJSONFile(filepath.Clean(*verificationPath), &verification); err != nil {
+			return err
+		}
+		ledger := project.SignerRotationActivationAuditLedger{}
+		if strings.TrimSpace(*ledgerPath) != "" {
+			contents, err := os.ReadFile(filepath.Clean(*ledgerPath))
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					return err
+				}
+			} else if len(contents) > 0 {
+				if err := json.Unmarshal(contents, &ledger); err != nil {
+					return fmt.Errorf("parse %s: %w", *ledgerPath, err)
+				}
+			}
+		}
+		appendResult, err := project.SignerRotationActivationAuditAppend(project.SignerRotationActivationAuditAppendRequest{
+			ApplyResult:         applyResult,
+			VerificationReceipt: verification,
+			ExistingLedger:      ledger,
+		})
+		if err != nil {
+			return err
+		}
+		if *ledgerOut != "" {
+			if err := project.WriteJSON(filepath.Clean(*ledgerOut), appendResult.Ledger); err != nil {
+				return err
+			}
+		}
+		if *out == "" {
+			return printJSON(appendResult)
+		}
+		return project.WriteJSON(filepath.Clean(*out), appendResult)
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -511,7 +565,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -244,6 +244,46 @@ Verification fails closed when:
 - `verified_at` falls before `effective_at`, before `provisioned_at`, or after
   the incoming signer `rotate_by`
 
+## Activation audit ledger
+
+`0aid signer-rotation-ledger-append` appends a verified activation record into
+an append-only audit ledger.
+
+Example:
+
+```bash
+./0aid signer-rotation-ledger-append \
+  --apply ./build/rotation/governance-chair-apply-result.json \
+  --verification ./build/rotation/governance-chair-verification.json \
+  --ledger-out ./build/rotation/activation-audit-ledger.json \
+  --out ./build/rotation/governance-chair-ledger-append.json
+```
+
+The append result includes:
+
+- the appended audit entry
+- the updated ledger
+- a stable append index
+
+Each audit entry binds:
+
+- `receipt_id`
+- `target_policy_version`
+- `activation_plan_digest`
+- `applied_policy_digest`
+- `effective_at`
+- `verified_at`
+- the verifying signer/key and actor ownership context
+- the verification signature envelope
+
+Ledger append fails closed when:
+
+- the apply result and verification receipt disagree on receipt or policy digests
+- the verification signature metadata is missing
+- the same `receipt_id`, `target_policy_version`, or `signature_id` already exists
+- the new record would move `effective_at` or `verified_at` backward
+- an existing ledger entry is already malformed
+
 ## Operator workflow
 
 1. Render the current signer manifest and identify any `expiring` signers.
@@ -260,3 +300,5 @@ Verification fails closed when:
    replacement manifest is ready to become the new active state.
 10. Sign and retain a post-activation verification receipt proving the new
     signer set became active exactly as planned.
+11. Append the apply + verification outputs into the activation audit ledger so
+    the signer lineage stays append-only and reviewable over time.

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -291,6 +291,49 @@ type SignerRotationVerifyRequest struct {
 	SignatureID    string
 }
 
+type SignerRotationActivationAuditEntry struct {
+	Version              string                              `json:"version"`
+	Status               string                              `json:"status"`
+	ReceiptID            string                              `json:"receipt_id"`
+	ChainID              string                              `json:"chain_id"`
+	PolicyPath           string                              `json:"policy_path"`
+	TargetPolicyVersion  string                              `json:"target_policy_version"`
+	EffectiveAt          string                              `json:"effective_at"`
+	VerifiedAt           string                              `json:"verified_at"`
+	ActivationPlanDigest string                              `json:"activation_plan_digest"`
+	AppliedPolicyDigest  string                              `json:"applied_policy_digest"`
+	SignerID             string                              `json:"signer_id"`
+	KeyID                string                              `json:"key_id"`
+	ActorID              string                              `json:"actor_id"`
+	ActorDisplayName     string                              `json:"actor_display_name"`
+	OrganizationID       string                              `json:"organization_id,omitempty"`
+	OrganizationName     string                              `json:"organization_name,omitempty"`
+	Signature            SignerRotationVerificationSignature `json:"signature"`
+}
+
+type SignerRotationActivationAuditLedger struct {
+	Version    string                               `json:"version"`
+	Status     string                               `json:"status"`
+	ChainID    string                               `json:"chain_id"`
+	PolicyPath string                               `json:"policy_path"`
+	EntryCount int                                  `json:"entry_count"`
+	Entries    []SignerRotationActivationAuditEntry `json:"entries"`
+}
+
+type SignerRotationActivationAuditAppendRequest struct {
+	ApplyResult         SignerRotationApplyResult
+	VerificationReceipt SignerRotationVerificationReceipt
+	ExistingLedger      SignerRotationActivationAuditLedger
+}
+
+type SignerRotationActivationAuditAppendResult struct {
+	Version       string                              `json:"version"`
+	Status        string                              `json:"status"`
+	AppendedIndex int                                 `json:"appended_index"`
+	AppendedEntry SignerRotationActivationAuditEntry  `json:"appended_entry"`
+	Ledger        SignerRotationActivationAuditLedger `json:"ledger"`
+}
+
 type parsedSignerEntry struct {
 	ActorID           string
 	SignerID          string
@@ -1917,6 +1960,164 @@ func SignerRotationVerify(bundle Bundle, request SignerRotationVerifyRequest) (S
 			ExpiresAt:   expiresAt.Format(time.RFC3339),
 			Value:       hex.EncodeToString(mac.Sum(nil)),
 		},
+	}, nil
+}
+
+func activationAuditEntry(
+	applyResult SignerRotationApplyResult,
+	verification SignerRotationVerificationReceipt,
+) SignerRotationActivationAuditEntry {
+	return SignerRotationActivationAuditEntry{
+		Version:              "1.0.0",
+		Status:               "verified",
+		ReceiptID:            verification.ReceiptID,
+		ChainID:              verification.ChainID,
+		PolicyPath:           verification.PolicyPath,
+		TargetPolicyVersion:  verification.TargetPolicyVersion,
+		EffectiveAt:          applyResult.AppliedAtEffect,
+		VerifiedAt:           verification.VerifiedAt,
+		ActivationPlanDigest: verification.ActivationPlanDigest,
+		AppliedPolicyDigest:  verification.PolicyDigest,
+		SignerID:             verification.SignerID,
+		KeyID:                verification.KeyID,
+		ActorID:              verification.ActorID,
+		ActorDisplayName:     verification.ActorDisplayName,
+		OrganizationID:       verification.OrganizationID,
+		OrganizationName:     verification.OrganizationName,
+		Signature:            verification.Signature,
+	}
+}
+
+func SignerRotationActivationAuditAppend(
+	request SignerRotationActivationAuditAppendRequest,
+) (SignerRotationActivationAuditAppendResult, error) {
+	if request.ApplyResult.Status != "applied" {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("signer rotation apply result must have status applied")
+	}
+	if request.VerificationReceipt.Status != "verified" {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("signer rotation verification receipt must have status verified")
+	}
+	if request.ApplyResult.ReceiptID != request.VerificationReceipt.ReceiptID {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit receipt_id mismatch")
+	}
+	if request.ApplyResult.ChainID != request.VerificationReceipt.ChainID {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit chain_id mismatch")
+	}
+	if request.ApplyResult.PolicyPath != request.VerificationReceipt.PolicyPath {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit policy_path mismatch")
+	}
+	if request.ApplyResult.TargetPolicyVersion != request.VerificationReceipt.TargetPolicyVersion {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit target_policy_version mismatch")
+	}
+	if request.ApplyResult.ActivationPlanDigest != request.VerificationReceipt.ActivationPlanDigest {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit activation_plan_digest mismatch")
+	}
+	if request.ApplyResult.AppliedPolicyDigest != request.VerificationReceipt.PolicyDigest {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit policy_digest mismatch")
+	}
+	if strings.TrimSpace(request.VerificationReceipt.Signature.SignatureID) == "" {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit verification signature_id must be set")
+	}
+	if strings.TrimSpace(request.VerificationReceipt.Signature.Value) == "" {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit verification signature must be set")
+	}
+	effectiveAt, err := parseRFC3339(request.ApplyResult.AppliedAtEffect, "activation audit effective_at")
+	if err != nil {
+		return SignerRotationActivationAuditAppendResult{}, err
+	}
+	verifiedAt, err := parseRFC3339(request.VerificationReceipt.VerifiedAt, "activation audit verified_at")
+	if err != nil {
+		return SignerRotationActivationAuditAppendResult{}, err
+	}
+	if verifiedAt.Before(effectiveAt) {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit verified_at must be on or after effective_at")
+	}
+	ledger := request.ExistingLedger
+	if ledger.Version == "" {
+		ledger = SignerRotationActivationAuditLedger{
+			Version:    "1.0.0",
+			Status:     "active",
+			ChainID:    request.ApplyResult.ChainID,
+			PolicyPath: request.ApplyResult.PolicyPath,
+			Entries:    []SignerRotationActivationAuditEntry{},
+		}
+	}
+	if ledger.Version != "1.0.0" {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("unexpected activation audit ledger version: %s", ledger.Version)
+	}
+	if ledger.Status == "" {
+		ledger.Status = "active"
+	}
+	if ledger.ChainID != request.ApplyResult.ChainID {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit ledger chain_id mismatch")
+	}
+	if ledger.PolicyPath != request.ApplyResult.PolicyPath {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit ledger policy_path mismatch")
+	}
+
+	var lastEffectiveAt time.Time
+	var lastVerifiedAt time.Time
+	seenReceiptIDs := make(map[string]struct{}, len(ledger.Entries))
+	seenTargetVersions := make(map[string]struct{}, len(ledger.Entries))
+	seenSignatureIDs := make(map[string]struct{}, len(ledger.Entries))
+	for _, entry := range ledger.Entries {
+		if _, exists := seenReceiptIDs[entry.ReceiptID]; exists {
+			return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("duplicate activation audit receipt_id in ledger: %s", entry.ReceiptID)
+		}
+		seenReceiptIDs[entry.ReceiptID] = struct{}{}
+		if _, exists := seenTargetVersions[entry.TargetPolicyVersion]; exists {
+			return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("duplicate activation audit target_policy_version in ledger: %s", entry.TargetPolicyVersion)
+		}
+		seenTargetVersions[entry.TargetPolicyVersion] = struct{}{}
+		if _, exists := seenSignatureIDs[entry.Signature.SignatureID]; exists {
+			return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("duplicate activation audit signature_id in ledger: %s", entry.Signature.SignatureID)
+		}
+		seenSignatureIDs[entry.Signature.SignatureID] = struct{}{}
+
+		entryEffectiveAt, err := parseRFC3339(entry.EffectiveAt, "activation audit ledger effective_at")
+		if err != nil {
+			return SignerRotationActivationAuditAppendResult{}, err
+		}
+		entryVerifiedAt, err := parseRFC3339(entry.VerifiedAt, "activation audit ledger verified_at")
+		if err != nil {
+			return SignerRotationActivationAuditAppendResult{}, err
+		}
+		if entryVerifiedAt.Before(entryEffectiveAt) {
+			return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit ledger entry verified_at must be on or after effective_at")
+		}
+		if entryEffectiveAt.After(lastEffectiveAt) {
+			lastEffectiveAt = entryEffectiveAt
+		}
+		if entryVerifiedAt.After(lastVerifiedAt) {
+			lastVerifiedAt = entryVerifiedAt
+		}
+	}
+
+	if _, exists := seenReceiptIDs[request.ApplyResult.ReceiptID]; exists {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit receipt_id already recorded: %s", request.ApplyResult.ReceiptID)
+	}
+	if _, exists := seenTargetVersions[request.ApplyResult.TargetPolicyVersion]; exists {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit target_policy_version already recorded: %s", request.ApplyResult.TargetPolicyVersion)
+	}
+	if _, exists := seenSignatureIDs[request.VerificationReceipt.Signature.SignatureID]; exists {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit signature_id already recorded: %s", request.VerificationReceipt.Signature.SignatureID)
+	}
+	if !lastEffectiveAt.IsZero() && !effectiveAt.After(lastEffectiveAt) {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit effective_at must be strictly increasing")
+	}
+	if !lastVerifiedAt.IsZero() && !verifiedAt.After(lastVerifiedAt) {
+		return SignerRotationActivationAuditAppendResult{}, fmt.Errorf("activation audit verified_at must be strictly increasing")
+	}
+
+	entry := activationAuditEntry(request.ApplyResult, request.VerificationReceipt)
+	ledger.Entries = append(ledger.Entries, entry)
+	ledger.EntryCount = len(ledger.Entries)
+	return SignerRotationActivationAuditAppendResult{
+		Version:       "1.0.0",
+		Status:        "appended",
+		AppendedIndex: len(ledger.Entries) - 1,
+		AppendedEntry: entry,
+		Ledger:        ledger,
 	}, nil
 }
 

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -602,3 +602,157 @@ func TestSignerRotationVerifyFailsOnPolicyDrift(t *testing.T) {
 		t.Fatalf("expected applied policy drift error, got %v", err)
 	}
 }
+
+func mustSignerRotationApplyResult(t *testing.T, bundle Bundle) SignerRotationApplyResult {
+	t.Helper()
+
+	plan := mustSignerRotationActivationPlan(t, bundle)
+	result, err := SignerRotationApply(bundle, SignerRotationApplyRequest{
+		ActivationPlan: plan,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationApply failed: %v", err)
+	}
+	return result
+}
+
+func mustSignerRotationVerificationReceipt(t *testing.T, bundle Bundle) SignerRotationVerificationReceipt {
+	t.Helper()
+
+	plan := mustSignerRotationActivationPlan(t, bundle)
+	applied := mustSignerRotationApplyResult(t, bundle)
+	receipt, err := SignerRotationVerify(bundle, SignerRotationVerifyRequest{
+		ActivationPlan: plan,
+		Policy:         applied.AppliedPolicy,
+		VerifiedAt:     "2026-04-24T00:15:00Z",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationVerify failed: %v", err)
+	}
+	return receipt
+}
+
+func TestSignerRotationActivationAuditAppend(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	appendResult, err := SignerRotationActivationAuditAppend(SignerRotationActivationAuditAppendRequest{
+		ApplyResult:         mustSignerRotationApplyResult(t, bundle),
+		VerificationReceipt: mustSignerRotationVerificationReceipt(t, bundle),
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditAppend failed: %v", err)
+	}
+	if appendResult.Status != "appended" {
+		t.Fatalf("unexpected append status: %s", appendResult.Status)
+	}
+	if appendResult.AppendedIndex != 0 {
+		t.Fatalf("unexpected appended index: %d", appendResult.AppendedIndex)
+	}
+	if appendResult.Ledger.EntryCount != 1 || len(appendResult.Ledger.Entries) != 1 {
+		t.Fatalf("expected one ledger entry, got %+v", appendResult.Ledger)
+	}
+	if appendResult.AppendedEntry.ReceiptID != "rotation-governance-chair-bot-20260424t000000z" {
+		t.Fatalf("unexpected appended receipt id: %s", appendResult.AppendedEntry.ReceiptID)
+	}
+}
+
+func TestSignerRotationActivationAuditAppendFailsOnDigestMismatch(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	applyResult := mustSignerRotationApplyResult(t, bundle)
+	verification := mustSignerRotationVerificationReceipt(t, bundle)
+	verification.PolicyDigest = "deadbeef"
+	_, err = SignerRotationActivationAuditAppend(SignerRotationActivationAuditAppendRequest{
+		ApplyResult:         applyResult,
+		VerificationReceipt: verification,
+	})
+	if err == nil || !strings.Contains(err.Error(), "activation audit policy_digest mismatch") {
+		t.Fatalf("expected activation audit digest mismatch error, got %v", err)
+	}
+}
+
+func TestSignerRotationActivationAuditAppendFailsOnDuplicateReceipt(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	applyResult := mustSignerRotationApplyResult(t, bundle)
+	verification := mustSignerRotationVerificationReceipt(t, bundle)
+	existing := SignerRotationActivationAuditLedger{
+		Version:    "1.0.0",
+		Status:     "active",
+		ChainID:    applyResult.ChainID,
+		PolicyPath: applyResult.PolicyPath,
+		Entries: []SignerRotationActivationAuditEntry{
+			activationAuditEntry(applyResult, verification),
+		},
+		EntryCount: 1,
+	}
+	_, err = SignerRotationActivationAuditAppend(SignerRotationActivationAuditAppendRequest{
+		ApplyResult:         applyResult,
+		VerificationReceipt: verification,
+		ExistingLedger:      existing,
+	})
+	if err == nil || !strings.Contains(err.Error(), "activation audit receipt_id already recorded") {
+		t.Fatalf("expected duplicate receipt error, got %v", err)
+	}
+}
+
+func TestSignerRotationActivationAuditAppendFailsOnOutOfOrderVerification(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	applyResult := mustSignerRotationApplyResult(t, bundle)
+	verification := mustSignerRotationVerificationReceipt(t, bundle)
+	existing := SignerRotationActivationAuditLedger{
+		Version:    "1.0.0",
+		Status:     "active",
+		ChainID:    applyResult.ChainID,
+		PolicyPath: applyResult.PolicyPath,
+		Entries: []SignerRotationActivationAuditEntry{
+			{
+				Version:              "1.0.0",
+				Status:               "verified",
+				ReceiptID:            "rotation-older-20260423t000000z",
+				ChainID:              applyResult.ChainID,
+				PolicyPath:           applyResult.PolicyPath,
+				TargetPolicyVersion:  "checkpoint-signers-older",
+				EffectiveAt:          "2026-04-23T23:59:00Z",
+				VerifiedAt:           "2026-04-24T00:16:00Z",
+				ActivationPlanDigest: "older-plan",
+				AppliedPolicyDigest:  "older-policy",
+				SignerID:             "governance-chair-bot-v2",
+				KeyID:                "governance-chair-dev-v2",
+				ActorID:              "op-governance-chair-1",
+				ActorDisplayName:     "Governance Chair 1",
+				OrganizationID:       "org-0ai-core",
+				OrganizationName:     "0AI Core",
+				Signature: SignerRotationVerificationSignature{
+					Format:      "0ai-hmac-sha256-v1",
+					SignatureID: "older-signature",
+					SignedAt:    "2026-04-24T00:16:00Z",
+					ExpiresAt:   "2026-04-25T00:16:00Z",
+					Value:       "older-value",
+				},
+			},
+		},
+		EntryCount: 1,
+	}
+	_, err = SignerRotationActivationAuditAppend(SignerRotationActivationAuditAppendRequest{
+		ApplyResult:         applyResult,
+		VerificationReceipt: verification,
+		ExistingLedger:      existing,
+	})
+	if err == nil || !strings.Contains(err.Error(), "activation audit verified_at must be strictly increasing") {
+		t.Fatalf("expected out-of-order verification error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add append-only activation audit ledger artifacts for signer rotation apply + verify outputs
- expose ledger append through 0aid and make targets
- document and test digest checks, duplicate detection, and monotonic ordering rules

## Testing
- make validate
- make go-test
- make go-build
- python -m unittest discover -s tests -v
- ./0aid signer-rotation-receipt --root . --outgoing-signer-id governance-chair-bot --incoming-signer-id governance-chair-bot-v2 --incoming-key-id governance-chair-dev-v2 --effective-at 2026-04-24T00:00:00Z --out build/rotation/governance-chair-receipt.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role governance-ops --signer-id governance-ops-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-governance-ops.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role token-house-secretariat --signer-id token-house-secretariat-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-token-house.json
- ./0aid signer-rotation-approve --root . --receipt build/rotation/governance-chair-receipt.json --role telemetry-ops --signer-id telemetry-ops-bot --approved-at 2026-04-23T00:00:00Z --out build/rotation/governance-chair-telemetry.json
- ./0aid signer-rotation-finalize --root . --receipt build/rotation/governance-chair-receipt.json --approvals build/rotation/governance-chair-governance-ops.json,build/rotation/governance-chair-token-house.json,build/rotation/governance-chair-telemetry.json --out build/rotation/governance-chair-approved-bundle.json
- ./0aid signer-rotation-activate --root . --bundle build/rotation/governance-chair-approved-bundle.json --incoming-shared-secret dev-secret-governance-chair-v2 --out build/rotation/governance-chair-activation-plan.json
- ./0aid signer-rotation-apply --root . --plan build/rotation/governance-chair-activation-plan.json --policy-out build/rotation/governance-chair-applied-policy.json --out build/rotation/governance-chair-apply-result.json
- ./0aid signer-rotation-verify --root . --plan build/rotation/governance-chair-activation-plan.json --policy build/rotation/governance-chair-applied-policy.json --verified-at 2026-04-24T00:15:00Z --out build/rotation/governance-chair-verification.json
- ./0aid signer-rotation-ledger-append --apply build/rotation/governance-chair-apply-result.json --verification build/rotation/governance-chair-verification.json --ledger-out build/rotation/activation-audit-ledger.json --out build/rotation/governance-chair-ledger-append.json

Closes #27