### PR TITLE
Add activation audit ledger reconciliation reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append signer-rotation-ledger-reconcile init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -31,6 +31,7 @@ help:
 	@echo "  signer-rotation-apply Validate an activation plan and emit the applied checkpoint signer policy"
 	@echo "  signer-rotation-verify Sign a post-activation verification receipt against the applied policy"
 	@echo "  signer-rotation-ledger-append Append a verified activation record into the audit ledger"
+	@echo "  signer-rotation-ledger-reconcile Reconcile the activation audit ledger against the current signer policy"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -126,6 +127,9 @@ signer-rotation-ledger-append:
 	@test -n "$(APPLY)" || (echo "Usage: make signer-rotation-ledger-append APPLY=build/rotation/governance-chair-apply-result.json VERIFICATION=build/rotation/governance-chair-verification.json" && exit 1)
 	@test -n "$(VERIFICATION)" || (echo "Usage: make signer-rotation-ledger-append APPLY=build/rotation/governance-chair-apply-result.json VERIFICATION=build/rotation/governance-chair-verification.json" && exit 1)
 	./0aid signer-rotation-ledger-append --apply $(APPLY) --verification $(VERIFICATION) $(if $(LEDGER),--ledger $(LEDGER),) $(if $(LEDGER_OUT),--ledger-out $(LEDGER_OUT),) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-ledger-reconcile:
+	./0aid signer-rotation-ledger-reconcile --root . $(if $(LEDGER),--ledger $(LEDGER),) $(if $(POLICY),--policy $(POLICY),) $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ make -C projects/0ai-assurance-network signer-rotation-activate BUNDLE=build/rot
 make -C projects/0ai-assurance-network signer-rotation-apply PLAN=build/rotation/governance-chair-activation-plan.json POLICY_OUT=build/rotation/governance-chair-applied-policy.json
 make -C projects/0ai-assurance-network signer-rotation-verify PLAN=build/rotation/governance-chair-activation-plan.json POLICY=build/rotation/governance-chair-applied-policy.json VERIFIED_AT=2026-04-24T00:15:00Z
 make -C projects/0ai-assurance-network signer-rotation-ledger-append APPLY=build/rotation/governance-chair-apply-result.json VERIFICATION=build/rotation/governance-chair-verification.json LEDGER_OUT=build/rotation/activation-audit-ledger.json
+make -C projects/0ai-assurance-network signer-rotation-ledger-reconcile LEDGER=build/rotation/activation-audit-ledger.json POLICY=build/rotation/governance-chair-applied-policy.json
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -230,6 +231,12 @@ policy digests, duplicate receipt IDs, duplicate target policy versions,
 replayed verification signatures, and non-monotonic effective or verified
 timestamps.
 
+`signer-rotation-ledger-reconcile` reads the activation audit ledger against a
+current checkpoint signer policy and reports whether the active policy can be
+explained by the latest recorded activation. It surfaces missing ledger
+coverage, duplicate continuity records, and any current policy version or
+digest that no longer matches the recorded ledger lineage.
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -249,6 +256,7 @@ currently supports:
 - `signer-rotation-apply`
 - `signer-rotation-verify`
 - `signer-rotation-ledger-append`
+- `signer-rotation-ledger-reconcile`
 - `show-plan`
 - `init-genesis`
 - `render-validator`
@@ -299,6 +307,10 @@ Bootstrap examples:
   --verification ./build/rotation/governance-chair-verification.json \
   --ledger-out ./build/rotation/activation-audit-ledger.json \
   --out ./build/rotation/governance-chair-ledger-append.json
+./0aid signer-rotation-ledger-reconcile \
+  --ledger ./build/rotation/activation-audit-ledger.json \
+  --policy ./build/rotation/governance-chair-applied-policy.json \
+  --out ./build/rotation/governance-chair-ledger-reconcile.json
 ./0aid init-node --root . --id val-3 --out ./build/nodes/validator-3
 ./0aid collect-validator --bundle ./build/nodes/validator-3 --out ./build/collection/validator-3.json
 ./0aid assemble-genesis --root . --collection ./build/collection --out ./build/assembled/genesis-plan.json

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -397,6 +397,50 @@ func run(args []string) error {
 			return printJSON(appendResult)
 		}
 		return project.WriteJSON(filepath.Clean(*out), appendResult)
+	case "signer-rotation-ledger-reconcile":
+		fs := flag.NewFlagSet("signer-rotation-ledger-reconcile", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		ledgerPath := fs.String("ledger", "", "activation audit ledger path")
+		policyPath := fs.String("policy", "", "checkpoint signer policy path")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		resolvedLedgerPath := strings.TrimSpace(*ledgerPath)
+		if resolvedLedgerPath == "" {
+			resolvedLedgerPath = filepath.Join(*root, "build/rotation/activation-audit-ledger.json")
+		}
+		resolvedPolicyPath := strings.TrimSpace(*policyPath)
+		if resolvedPolicyPath == "" {
+			resolvedPolicyPath = filepath.Join(*root, "config/governance/checkpoint-signers.json")
+		}
+		ledger := project.SignerRotationActivationAuditLedger{}
+		ledgerContents, err := os.ReadFile(filepath.Clean(resolvedLedgerPath))
+		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+		} else if len(ledgerContents) > 0 {
+			if err := json.Unmarshal(ledgerContents, &ledger); err != nil {
+				return fmt.Errorf("parse %s: %w", resolvedLedgerPath, err)
+			}
+		}
+		var policy project.CheckpointSignerPolicyOutput
+		if err := readJSONFile(filepath.Clean(resolvedPolicyPath), &policy); err != nil {
+			return err
+		}
+		report, err := project.SignerRotationActivationAuditReconcile(project.SignerRotationActivationAuditReconcileRequest{
+			Ledger:     ledger,
+			Policy:     policy,
+			PolicyPath: "config/governance/checkpoint-signers.json",
+		})
+		if err != nil {
+			return err
+		}
+		if *out == "" {
+			return printJSON(report)
+		}
+		return project.WriteJSON(filepath.Clean(*out), report)
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -565,7 +609,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|signer-rotation-ledger-reconcile|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -284,6 +284,36 @@ Ledger append fails closed when:
 - the new record would move `effective_at` or `verified_at` backward
 - an existing ledger entry is already malformed
 
+## Ledger reconciliation
+
+`0aid signer-rotation-ledger-reconcile` compares the activation audit ledger
+against a current checkpoint signer policy and reports whether the active policy
+is fully explained by the recorded ledger lineage.
+
+Example:
+
+```bash
+./0aid signer-rotation-ledger-reconcile \
+  --ledger ./build/rotation/activation-audit-ledger.json \
+  --policy ./build/rotation/governance-chair-applied-policy.json \
+  --out ./build/rotation/governance-chair-ledger-reconcile.json
+```
+
+The reconciliation report includes:
+
+- the current policy version and digest
+- the latest recorded receipt id, target policy version, and applied policy digest
+- whether the current policy is explained by the ledger
+- continuity issues such as missing coverage, duplicates, or lineage mismatch
+
+Reconciliation surfaces gaps when:
+
+- the ledger is empty but the current policy already appears rotated
+- the latest recorded target policy version does not match the current policy
+- the latest recorded applied policy digest does not match the current policy
+- duplicate receipt ids, target policy versions, or signature ids exist in the ledger
+- `effective_at` or `verified_at` ordering is not strictly increasing across entries
+
 ## Operator workflow
 
 1. Render the current signer manifest and identify any `expiring` signers.
@@ -302,3 +332,5 @@ Ledger append fails closed when:
     signer set became active exactly as planned.
 11. Append the apply + verification outputs into the activation audit ledger so
     the signer lineage stays append-only and reviewable over time.
+12. Reconcile the current checkpoint signer policy against that ledger before
+    treating the rotation lineage as continuous and complete.

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -334,6 +334,27 @@ type SignerRotationActivationAuditAppendResult struct {
 	Ledger        SignerRotationActivationAuditLedger `json:"ledger"`
 }
 
+type SignerRotationActivationAuditReconcileRequest struct {
+	Ledger     SignerRotationActivationAuditLedger
+	Policy     CheckpointSignerPolicyOutput
+	PolicyPath string
+}
+
+type SignerRotationActivationAuditReconcileReport struct {
+	Version                string   `json:"version"`
+	Status                 string   `json:"status"`
+	ChainID                string   `json:"chain_id"`
+	PolicyPath             string   `json:"policy_path"`
+	CurrentPolicyVersion   string   `json:"current_policy_version"`
+	CurrentPolicyDigest    string   `json:"current_policy_digest"`
+	EntryCount             int      `json:"entry_count"`
+	LatestReceiptID        string   `json:"latest_receipt_id,omitempty"`
+	LatestTargetVersion    string   `json:"latest_target_policy_version,omitempty"`
+	LatestPolicyDigest     string   `json:"latest_applied_policy_digest,omitempty"`
+	CurrentPolicyExplained bool     `json:"current_policy_explained"`
+	Issues                 []string `json:"issues"`
+}
+
 type parsedSignerEntry struct {
 	ActorID           string
 	SignerID          string
@@ -2119,6 +2140,135 @@ func SignerRotationActivationAuditAppend(
 		AppendedEntry: entry,
 		Ledger:        ledger,
 	}, nil
+}
+
+func SignerRotationActivationAuditReconcile(
+	request SignerRotationActivationAuditReconcileRequest,
+) (SignerRotationActivationAuditReconcileReport, error) {
+	policyDigest, err := checkpointSignerPolicyDigest(request.Policy)
+	if err != nil {
+		return SignerRotationActivationAuditReconcileReport{}, err
+	}
+	policyPath := strings.TrimSpace(request.PolicyPath)
+	if policyPath == "" {
+		policyPath = request.Ledger.PolicyPath
+	}
+	report := SignerRotationActivationAuditReconcileReport{
+		Version:                "1.0.0",
+		Status:                 "consistent",
+		ChainID:                request.Policy.Version,
+		PolicyPath:             policyPath,
+		CurrentPolicyVersion:   request.Policy.Version,
+		CurrentPolicyDigest:    policyDigest,
+		EntryCount:             len(request.Ledger.Entries),
+		CurrentPolicyExplained: false,
+		Issues:                 []string{},
+	}
+	if request.Policy.Version == "" {
+		return SignerRotationActivationAuditReconcileReport{}, fmt.Errorf("reconciliation policy version must be set")
+	}
+	report.ChainID = ""
+	if len(request.Ledger.Entries) > 0 {
+		report.ChainID = request.Ledger.Entries[0].ChainID
+	}
+	if report.ChainID == "" {
+		report.ChainID = request.Ledger.ChainID
+	}
+	if report.ChainID == "" {
+		report.ChainID = "unknown"
+	}
+	if request.Ledger.Version != "" && request.Ledger.Version != "1.0.0" {
+		report.Issues = append(report.Issues, fmt.Sprintf("unexpected activation audit ledger version: %s", request.Ledger.Version))
+	}
+	if request.Ledger.ChainID != "" && request.Ledger.ChainID != report.ChainID {
+		report.Issues = append(report.Issues, "activation audit ledger chain_id does not match current policy lineage")
+	}
+	if request.Ledger.PolicyPath != "" && policyPath != "" && request.Ledger.PolicyPath != policyPath {
+		report.Issues = append(report.Issues, "activation audit ledger policy_path does not match reconciliation policy path")
+	}
+	if len(request.Ledger.Entries) == 0 {
+		if strings.Contains(request.Policy.Version, "+rotation-") {
+			report.Issues = append(report.Issues, "current checkpoint signer policy appears rotated but activation audit ledger is empty")
+			report.Status = "gap"
+		} else {
+			report.CurrentPolicyExplained = true
+		}
+		return report, nil
+	}
+
+	seenReceiptIDs := make(map[string]struct{}, len(request.Ledger.Entries))
+	seenTargetVersions := make(map[string]struct{}, len(request.Ledger.Entries))
+	seenSignatureIDs := make(map[string]struct{}, len(request.Ledger.Entries))
+	lastEffectiveAt := time.Time{}
+	lastVerifiedAt := time.Time{}
+	latest := request.Ledger.Entries[len(request.Ledger.Entries)-1]
+	report.LatestReceiptID = latest.ReceiptID
+	report.LatestTargetVersion = latest.TargetPolicyVersion
+	report.LatestPolicyDigest = latest.AppliedPolicyDigest
+
+	for _, entry := range request.Ledger.Entries {
+		if _, exists := seenReceiptIDs[entry.ReceiptID]; exists {
+			report.Issues = append(report.Issues, fmt.Sprintf("duplicate activation audit receipt_id in ledger: %s", entry.ReceiptID))
+		}
+		seenReceiptIDs[entry.ReceiptID] = struct{}{}
+		if _, exists := seenTargetVersions[entry.TargetPolicyVersion]; exists {
+			report.Issues = append(report.Issues, fmt.Sprintf("duplicate activation audit target_policy_version in ledger: %s", entry.TargetPolicyVersion))
+		}
+		seenTargetVersions[entry.TargetPolicyVersion] = struct{}{}
+		if _, exists := seenSignatureIDs[entry.Signature.SignatureID]; exists {
+			report.Issues = append(report.Issues, fmt.Sprintf("duplicate activation audit signature_id in ledger: %s", entry.Signature.SignatureID))
+		}
+		seenSignatureIDs[entry.Signature.SignatureID] = struct{}{}
+		if entry.ChainID != "" && entry.ChainID != report.ChainID {
+			report.Issues = append(report.Issues, fmt.Sprintf("activation audit entry %s chain_id mismatch", entry.ReceiptID))
+		}
+		if policyPath != "" && entry.PolicyPath != "" && entry.PolicyPath != policyPath {
+			report.Issues = append(report.Issues, fmt.Sprintf("activation audit entry %s policy_path mismatch", entry.ReceiptID))
+		}
+		effectiveAt, err := parseRFC3339(entry.EffectiveAt, "activation audit entry effective_at")
+		if err != nil {
+			return SignerRotationActivationAuditReconcileReport{}, err
+		}
+		verifiedAt, err := parseRFC3339(entry.VerifiedAt, "activation audit entry verified_at")
+		if err != nil {
+			return SignerRotationActivationAuditReconcileReport{}, err
+		}
+		if verifiedAt.Before(effectiveAt) {
+			report.Issues = append(report.Issues, fmt.Sprintf("activation audit entry %s verified_at is before effective_at", entry.ReceiptID))
+		}
+		if !lastEffectiveAt.IsZero() && !effectiveAt.After(lastEffectiveAt) {
+			report.Issues = append(report.Issues, "activation audit ledger effective_at is not strictly increasing")
+		}
+		if !lastVerifiedAt.IsZero() && !verifiedAt.After(lastVerifiedAt) {
+			report.Issues = append(report.Issues, "activation audit ledger verified_at is not strictly increasing")
+		}
+		lastEffectiveAt = effectiveAt
+		lastVerifiedAt = verifiedAt
+	}
+
+	if latest.TargetPolicyVersion != request.Policy.Version {
+		report.Issues = append(report.Issues, "current checkpoint signer policy version is not explained by the latest activation audit entry")
+	}
+	if latest.AppliedPolicyDigest != policyDigest {
+		report.Issues = append(report.Issues, "current checkpoint signer policy digest is not explained by the latest activation audit entry")
+	}
+	report.CurrentPolicyExplained = latest.TargetPolicyVersion == request.Policy.Version && latest.AppliedPolicyDigest == policyDigest
+	if !report.CurrentPolicyExplained && strings.Contains(request.Policy.Version, "+rotation-") {
+		report.Issues = append(report.Issues, "current checkpoint signer policy cannot be explained by the activation audit ledger lineage")
+	}
+
+	if len(report.Issues) == 0 {
+		report.Status = "consistent"
+		return report, nil
+	}
+	report.Status = "gap"
+	for _, issue := range report.Issues {
+		if strings.Contains(issue, "duplicate activation audit") || strings.Contains(issue, "not strictly increasing") || strings.Contains(issue, "mismatch") {
+			report.Status = "invalid"
+			break
+		}
+	}
+	return report, nil
 }
 
 func recommendedRotationAction(rotationStatus string) string {

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -756,3 +756,99 @@ func TestSignerRotationActivationAuditAppendFailsOnOutOfOrderVerification(t *tes
 		t.Fatalf("expected out-of-order verification error, got %v", err)
 	}
 }
+
+func mustSignerRotationActivationAuditLedger(t *testing.T, bundle Bundle) SignerRotationActivationAuditLedger {
+	t.Helper()
+
+	appendResult, err := SignerRotationActivationAuditAppend(SignerRotationActivationAuditAppendRequest{
+		ApplyResult:         mustSignerRotationApplyResult(t, bundle),
+		VerificationReceipt: mustSignerRotationVerificationReceipt(t, bundle),
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditAppend failed: %v", err)
+	}
+	return appendResult.Ledger
+}
+
+func TestSignerRotationActivationAuditReconcile(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	applied := mustSignerRotationApplyResult(t, bundle)
+	ledger := mustSignerRotationActivationAuditLedger(t, bundle)
+	report, err := SignerRotationActivationAuditReconcile(SignerRotationActivationAuditReconcileRequest{
+		Ledger:     ledger,
+		Policy:     applied.AppliedPolicy,
+		PolicyPath: "config/governance/checkpoint-signers.json",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditReconcile failed: %v", err)
+	}
+	if report.Status != "consistent" {
+		t.Fatalf("unexpected reconcile status: %s", report.Status)
+	}
+	if !report.CurrentPolicyExplained {
+		t.Fatalf("expected current policy to be explained")
+	}
+	if len(report.Issues) != 0 {
+		t.Fatalf("expected no reconciliation issues, got %+v", report.Issues)
+	}
+}
+
+func TestSignerRotationActivationAuditReconcileFlagsEmptyLedgerGap(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	applied := mustSignerRotationApplyResult(t, bundle)
+	report, err := SignerRotationActivationAuditReconcile(SignerRotationActivationAuditReconcileRequest{
+		Ledger:     SignerRotationActivationAuditLedger{},
+		Policy:     applied.AppliedPolicy,
+		PolicyPath: "config/governance/checkpoint-signers.json",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditReconcile failed: %v", err)
+	}
+	if report.Status != "gap" {
+		t.Fatalf("unexpected reconcile status: %s", report.Status)
+	}
+	if report.CurrentPolicyExplained {
+		t.Fatalf("expected unexplained current policy for empty ledger")
+	}
+	if len(report.Issues) == 0 || !strings.Contains(report.Issues[0], "activation audit ledger is empty") {
+		t.Fatalf("expected empty-ledger issue, got %+v", report.Issues)
+	}
+}
+
+func TestSignerRotationActivationAuditReconcileFlagsCurrentPolicyMismatch(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	ledger := mustSignerRotationActivationAuditLedger(t, bundle)
+	currentPolicy, err := currentSignerPolicy(bundle)
+	if err != nil {
+		t.Fatalf("currentSignerPolicy failed: %v", err)
+	}
+	report, err := SignerRotationActivationAuditReconcile(SignerRotationActivationAuditReconcileRequest{
+		Ledger:     ledger,
+		Policy:     currentPolicy,
+		PolicyPath: "config/governance/checkpoint-signers.json",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditReconcile failed: %v", err)
+	}
+	if report.Status != "gap" {
+		t.Fatalf("unexpected reconcile status: %s", report.Status)
+	}
+	if report.CurrentPolicyExplained {
+		t.Fatalf("expected current policy mismatch to remain unexplained")
+	}
+	if len(report.Issues) == 0 {
+		t.Fatalf("expected reconciliation issues for current policy mismatch")
+	}
+}


### PR DESCRIPTION
## Summary
- add activation audit ledger reconciliation reports for signer rotation continuity
- expose reconciliation through 0aid and make targets
- document and test continuity gaps, duplicate detection, and current-policy lineage checks

## Testing
- make validate
- make go-test
- make go-build
- python -m unittest discover -s tests -v
- ./0aid signer-rotation-ledger-reconcile --ledger build/rotation/activation-audit-ledger.json --policy build/rotation/governance-chair-applied-policy.json --out build/rotation/governance-chair-ledger-reconcile.json
- ./0aid signer-rotation-ledger-reconcile --root . --ledger build/rotation/activation-audit-ledger.json --out build/rotation/governance-chair-ledger-reconcile-current.json

Closes #29