### PR TITLE
Add activation audit ledger export package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append signer-rotation-ledger-reconcile init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append signer-rotation-ledger-reconcile signer-rotation-ledger-export init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -32,6 +32,7 @@ help:
 	@echo "  signer-rotation-verify Sign a post-activation verification receipt against the applied policy"
 	@echo "  signer-rotation-ledger-append Append a verified activation record into the audit ledger"
 	@echo "  signer-rotation-ledger-reconcile Reconcile the activation audit ledger against the current signer policy"
+	@echo "  signer-rotation-ledger-export Export the activation audit ledger with baseline snapshot and continuity report"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -130,6 +131,9 @@ signer-rotation-ledger-append:
 
 signer-rotation-ledger-reconcile:
 	./0aid signer-rotation-ledger-reconcile --root . $(if $(LEDGER),--ledger $(LEDGER),) $(if $(POLICY),--policy $(POLICY),) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-ledger-export:
+	./0aid signer-rotation-ledger-export --root . $(if $(LEDGER),--ledger $(LEDGER),) $(if $(POLICY),--policy $(POLICY),) $(if $(RECONCILE),--reconcile $(RECONCILE),) $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ make -C projects/0ai-assurance-network signer-rotation-apply PLAN=build/rotation
 make -C projects/0ai-assurance-network signer-rotation-verify PLAN=build/rotation/governance-chair-activation-plan.json POLICY=build/rotation/governance-chair-applied-policy.json VERIFIED_AT=2026-04-24T00:15:00Z
 make -C projects/0ai-assurance-network signer-rotation-ledger-append APPLY=build/rotation/governance-chair-apply-result.json VERIFICATION=build/rotation/governance-chair-verification.json LEDGER_OUT=build/rotation/activation-audit-ledger.json
 make -C projects/0ai-assurance-network signer-rotation-ledger-reconcile LEDGER=build/rotation/activation-audit-ledger.json POLICY=build/rotation/governance-chair-applied-policy.json
+make -C projects/0ai-assurance-network signer-rotation-ledger-export LEDGER=build/rotation/activation-audit-ledger.json POLICY=build/rotation/governance-chair-applied-policy.json OUT=build/rotation/governance-chair-audit-export.json
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -237,6 +238,18 @@ explained by the latest recorded activation. It surfaces missing ledger
 coverage, duplicate continuity records, and any current policy version or
 digest that no longer matches the recorded ledger lineage.
 
+`signer-rotation-ledger-export` packages that same ledger lineage into a stable
+offline review artifact. The export bundles:
+
+- the current checkpoint signer policy and digest
+- the append-only activation audit ledger
+- the reconciliation report
+- a baseline snapshot covering the latest ledger lineage and current continuity state
+
+Exports fail closed when the reconciliation report contradicts the ledger or
+current policy digests, so operators cannot archive a self-inconsistent bundle
+as if it were a valid baseline.
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -257,6 +270,7 @@ currently supports:
 - `signer-rotation-verify`
 - `signer-rotation-ledger-append`
 - `signer-rotation-ledger-reconcile`
+- `signer-rotation-ledger-export`
 - `show-plan`
 - `init-genesis`
 - `render-validator`

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 const version = "0.1.0-dev"
+const checkpointSignerPolicyPath = "config/governance/checkpoint-signers.json"
 
 func main() {
 	if err := run(os.Args[1:]); err != nil {
@@ -414,16 +415,9 @@ func run(args []string) error {
 		if resolvedPolicyPath == "" {
 			resolvedPolicyPath = filepath.Join(*root, "config/governance/checkpoint-signers.json")
 		}
-		ledger := project.SignerRotationActivationAuditLedger{}
-		ledgerContents, err := os.ReadFile(filepath.Clean(resolvedLedgerPath))
+		ledger, err := readActivationAuditLedger(resolvedLedgerPath)
 		if err != nil {
-			if !errors.Is(err, os.ErrNotExist) {
-				return err
-			}
-		} else if len(ledgerContents) > 0 {
-			if err := json.Unmarshal(ledgerContents, &ledger); err != nil {
-				return fmt.Errorf("parse %s: %w", resolvedLedgerPath, err)
-			}
+			return err
 		}
 		var policy project.CheckpointSignerPolicyOutput
 		if err := readJSONFile(filepath.Clean(resolvedPolicyPath), &policy); err != nil {
@@ -432,7 +426,7 @@ func run(args []string) error {
 		report, err := project.SignerRotationActivationAuditReconcile(project.SignerRotationActivationAuditReconcileRequest{
 			Ledger:     ledger,
 			Policy:     policy,
-			PolicyPath: "config/governance/checkpoint-signers.json",
+			PolicyPath: checkpointSignerPolicyPath,
 		})
 		if err != nil {
 			return err
@@ -441,6 +435,60 @@ func run(args []string) error {
 			return printJSON(report)
 		}
 		return project.WriteJSON(filepath.Clean(*out), report)
+	case "signer-rotation-ledger-export":
+		fs := flag.NewFlagSet("signer-rotation-ledger-export", flag.ContinueOnError)
+		root := fs.String("root", ".", "project root")
+		ledgerPath := fs.String("ledger", "", "activation audit ledger path")
+		policyPath := fs.String("policy", "", "checkpoint signer policy path")
+		reconcilePath := fs.String("reconcile", "", "existing reconciliation report path")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		resolvedLedgerPath := strings.TrimSpace(*ledgerPath)
+		if resolvedLedgerPath == "" {
+			resolvedLedgerPath = filepath.Join(*root, "build/rotation/activation-audit-ledger.json")
+		}
+		resolvedPolicyPath := strings.TrimSpace(*policyPath)
+		if resolvedPolicyPath == "" {
+			resolvedPolicyPath = filepath.Join(*root, "config/governance/checkpoint-signers.json")
+		}
+		ledger, err := readActivationAuditLedger(resolvedLedgerPath)
+		if err != nil {
+			return err
+		}
+		var policy project.CheckpointSignerPolicyOutput
+		if err := readJSONFile(filepath.Clean(resolvedPolicyPath), &policy); err != nil {
+			return err
+		}
+		var report project.SignerRotationActivationAuditReconcileReport
+		if strings.TrimSpace(*reconcilePath) != "" {
+			if err := readJSONFile(filepath.Clean(*reconcilePath), &report); err != nil {
+				return err
+			}
+		} else {
+			report, err = project.SignerRotationActivationAuditReconcile(project.SignerRotationActivationAuditReconcileRequest{
+				Ledger:     ledger,
+				Policy:     policy,
+				PolicyPath: checkpointSignerPolicyPath,
+			})
+			if err != nil {
+				return err
+			}
+		}
+		exportPackage, err := project.SignerRotationActivationAuditExport(project.SignerRotationActivationAuditExportRequest{
+			Ledger:         ledger,
+			Policy:         policy,
+			Reconciliation: report,
+			PolicyPath:     checkpointSignerPolicyPath,
+		})
+		if err != nil {
+			return err
+		}
+		if *out == "" {
+			return printJSON(exportPackage)
+		}
+		return project.WriteJSON(filepath.Clean(*out), exportPackage)
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -609,7 +657,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|signer-rotation-ledger-reconcile|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|signer-rotation-ledger-reconcile|signer-rotation-ledger-export|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 
@@ -622,6 +670,24 @@ func readJSONFile(path string, destination any) error {
 		return fmt.Errorf("parse %s: %w", path, err)
 	}
 	return nil
+}
+
+func readActivationAuditLedger(path string) (project.SignerRotationActivationAuditLedger, error) {
+	ledger := project.SignerRotationActivationAuditLedger{}
+	contents, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ledger, nil
+		}
+		return ledger, err
+	}
+	if len(contents) == 0 {
+		return ledger, nil
+	}
+	if err := json.Unmarshal(contents, &ledger); err != nil {
+		return ledger, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return ledger, nil
 }
 
 func readSignerRotationApprovals(path string) ([]project.SignerRotationApproval, error) {

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -314,6 +314,33 @@ Reconciliation surfaces gaps when:
 - duplicate receipt ids, target policy versions, or signature ids exist in the ledger
 - `effective_at` or `verified_at` ordering is not strictly increasing across entries
 
+## Ledger export packages
+
+`0aid signer-rotation-ledger-export` packages the current checkpoint signer
+policy, the activation audit ledger, and the reconciliation report into one
+stable export artifact for offline review or retention.
+
+Example:
+
+```bash
+./0aid signer-rotation-ledger-export \
+  --ledger ./build/rotation/activation-audit-ledger.json \
+  --policy ./build/rotation/governance-chair-applied-policy.json \
+  --out ./build/rotation/governance-chair-audit-export.json
+```
+
+The export package includes:
+
+- the current checkpoint signer policy and digest
+- the append-only activation audit ledger
+- the reconciliation report
+- a baseline snapshot with the latest ledger lineage, current policy digest,
+  and continuity status
+
+Operators may also pass `--reconcile` to reuse a saved reconciliation report.
+Export still fails closed when that report contradicts the supplied ledger or
+current policy digest.
+
 ## Operator workflow
 
 1. Render the current signer manifest and identify any `expiring` signers.
@@ -334,3 +361,5 @@ Reconciliation surfaces gaps when:
     the signer lineage stays append-only and reviewable over time.
 12. Reconcile the current checkpoint signer policy against that ledger before
     treating the rotation lineage as continuous and complete.
+13. Export the policy, ledger, and reconciliation state into a stable audit
+    package before archiving the rotation baseline.

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -355,6 +355,41 @@ type SignerRotationActivationAuditReconcileReport struct {
 	Issues                 []string `json:"issues"`
 }
 
+type SignerRotationActivationAuditBaselineSnapshot struct {
+	Version                string                              `json:"version"`
+	Status                 string                              `json:"status"`
+	ChainID                string                              `json:"chain_id"`
+	PolicyPath             string                              `json:"policy_path"`
+	LedgerEntryCount       int                                 `json:"ledger_entry_count"`
+	CurrentPolicyVersion   string                              `json:"current_policy_version"`
+	CurrentPolicyDigest    string                              `json:"current_policy_digest"`
+	CurrentPolicyExplained bool                                `json:"current_policy_explained"`
+	LatestReceiptID        string                              `json:"latest_receipt_id,omitempty"`
+	LatestTargetVersion    string                              `json:"latest_target_policy_version,omitempty"`
+	LatestPolicyDigest     string                              `json:"latest_applied_policy_digest,omitempty"`
+	LatestEntry            *SignerRotationActivationAuditEntry `json:"latest_entry,omitempty"`
+	ReconciliationStatus   string                              `json:"reconciliation_status"`
+	ContinuityIssues       []string                            `json:"continuity_issues"`
+}
+
+type SignerRotationActivationAuditExportRequest struct {
+	Ledger         SignerRotationActivationAuditLedger
+	Policy         CheckpointSignerPolicyOutput
+	Reconciliation SignerRotationActivationAuditReconcileReport
+	PolicyPath     string
+}
+
+type SignerRotationActivationAuditExportPackage struct {
+	Version          string                                        `json:"version"`
+	Status           string                                        `json:"status"`
+	ChainID          string                                        `json:"chain_id"`
+	PolicyPath       string                                        `json:"policy_path"`
+	BaselineSnapshot SignerRotationActivationAuditBaselineSnapshot `json:"baseline_snapshot"`
+	CurrentPolicy    CheckpointSignerPolicyOutput                  `json:"current_policy"`
+	Ledger           SignerRotationActivationAuditLedger           `json:"ledger"`
+	Reconciliation   SignerRotationActivationAuditReconcileReport  `json:"reconciliation"`
+}
+
 type parsedSignerEntry struct {
 	ActorID           string
 	SignerID          string
@@ -2156,7 +2191,7 @@ func SignerRotationActivationAuditReconcile(
 	report := SignerRotationActivationAuditReconcileReport{
 		Version:                "1.0.0",
 		Status:                 "consistent",
-		ChainID:                request.Policy.Version,
+		ChainID:                "",
 		PolicyPath:             policyPath,
 		CurrentPolicyVersion:   request.Policy.Version,
 		CurrentPolicyDigest:    policyDigest,
@@ -2269,6 +2304,117 @@ func SignerRotationActivationAuditReconcile(
 		}
 	}
 	return report, nil
+}
+
+func SignerRotationActivationAuditExport(
+	request SignerRotationActivationAuditExportRequest,
+) (SignerRotationActivationAuditExportPackage, error) {
+	if request.Policy.Version == "" {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit export policy version must be set")
+	}
+	report := request.Reconciliation
+	if report.Version != "1.0.0" {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("unexpected activation audit reconciliation report version: %s", report.Version)
+	}
+	if request.Ledger.Version != "" && request.Ledger.Version != "1.0.0" {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("unexpected activation audit ledger version: %s", request.Ledger.Version)
+	}
+	policyDigest, err := checkpointSignerPolicyDigest(request.Policy)
+	if err != nil {
+		return SignerRotationActivationAuditExportPackage{}, err
+	}
+	policyPath := strings.TrimSpace(request.PolicyPath)
+	if policyPath == "" {
+		policyPath = strings.TrimSpace(report.PolicyPath)
+	}
+	if policyPath == "" {
+		policyPath = strings.TrimSpace(request.Ledger.PolicyPath)
+	}
+	if policyPath == "" {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit export policy path must be set")
+	}
+	if report.PolicyPath != "" && report.PolicyPath != policyPath {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit reconciliation policy_path mismatch")
+	}
+	if request.Ledger.PolicyPath != "" && request.Ledger.PolicyPath != policyPath {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit ledger policy_path mismatch")
+	}
+	if report.CurrentPolicyVersion != request.Policy.Version {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit reconciliation current_policy_version mismatch")
+	}
+	if report.CurrentPolicyDigest != policyDigest {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit reconciliation current_policy_digest mismatch")
+	}
+	if report.EntryCount != len(request.Ledger.Entries) {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit reconciliation entry_count mismatch")
+	}
+
+	chainID := strings.TrimSpace(report.ChainID)
+	if chainID == "" {
+		if len(request.Ledger.Entries) > 0 {
+			chainID = request.Ledger.Entries[0].ChainID
+		}
+		if chainID == "" {
+			chainID = request.Ledger.ChainID
+		}
+	}
+	if chainID == "" {
+		chainID = "unknown"
+	}
+	if request.Ledger.ChainID != "" && request.Ledger.ChainID != chainID {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit ledger chain_id mismatch")
+	}
+	if report.ChainID != "" && report.ChainID != chainID {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit reconciliation chain_id mismatch")
+	}
+
+	var latestEntry *SignerRotationActivationAuditEntry
+	if len(request.Ledger.Entries) > 0 {
+		entry := request.Ledger.Entries[len(request.Ledger.Entries)-1]
+		if report.LatestReceiptID != entry.ReceiptID {
+			return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit reconciliation latest_receipt_id mismatch")
+		}
+		if report.LatestTargetVersion != entry.TargetPolicyVersion {
+			return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit reconciliation latest_target_policy_version mismatch")
+		}
+		if report.LatestPolicyDigest != entry.AppliedPolicyDigest {
+			return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit reconciliation latest_applied_policy_digest mismatch")
+		}
+		entryCopy := entry
+		latestEntry = &entryCopy
+	} else if report.LatestReceiptID != "" || report.LatestTargetVersion != "" || report.LatestPolicyDigest != "" {
+		return SignerRotationActivationAuditExportPackage{}, fmt.Errorf("activation audit reconciliation latest entry metadata mismatch")
+	}
+
+	exportStatus := report.Status
+	if exportStatus == "" {
+		exportStatus = "unknown"
+	}
+	return SignerRotationActivationAuditExportPackage{
+		Version:    "1.0.0",
+		Status:     exportStatus,
+		ChainID:    chainID,
+		PolicyPath: policyPath,
+		BaselineSnapshot: SignerRotationActivationAuditBaselineSnapshot{
+			Version:                "1.0.0",
+			Status:                 exportStatus,
+			ChainID:                chainID,
+			PolicyPath:             policyPath,
+			LedgerEntryCount:       len(request.Ledger.Entries),
+			CurrentPolicyVersion:   request.Policy.Version,
+			CurrentPolicyDigest:    policyDigest,
+			CurrentPolicyExplained: report.CurrentPolicyExplained,
+			LatestReceiptID:        report.LatestReceiptID,
+			LatestTargetVersion:    report.LatestTargetVersion,
+			LatestPolicyDigest:     report.LatestPolicyDigest,
+			LatestEntry:            latestEntry,
+			ReconciliationStatus:   report.Status,
+			ContinuityIssues:       append([]string(nil), report.Issues...),
+		},
+		CurrentPolicy:  request.Policy,
+		Ledger:         request.Ledger,
+		Reconciliation: report,
+	}, nil
 }
 
 func recommendedRotationAction(rotationStatus string) string {

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -852,3 +852,101 @@ func TestSignerRotationActivationAuditReconcileFlagsCurrentPolicyMismatch(t *tes
 		t.Fatalf("expected reconciliation issues for current policy mismatch")
 	}
 }
+
+func mustSignerRotationActivationAuditReconcileReport(
+	t *testing.T,
+	ledger SignerRotationActivationAuditLedger,
+	policy CheckpointSignerPolicyOutput,
+) SignerRotationActivationAuditReconcileReport {
+	t.Helper()
+
+	report, err := SignerRotationActivationAuditReconcile(SignerRotationActivationAuditReconcileRequest{
+		Ledger:     ledger,
+		Policy:     policy,
+		PolicyPath: "config/governance/checkpoint-signers.json",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditReconcile failed: %v", err)
+	}
+	return report
+}
+
+func TestSignerRotationActivationAuditExport(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	applied := mustSignerRotationApplyResult(t, bundle)
+	ledger := mustSignerRotationActivationAuditLedger(t, bundle)
+	report := mustSignerRotationActivationAuditReconcileReport(t, ledger, applied.AppliedPolicy)
+	exportPackage, err := SignerRotationActivationAuditExport(SignerRotationActivationAuditExportRequest{
+		Ledger:         ledger,
+		Policy:         applied.AppliedPolicy,
+		Reconciliation: report,
+		PolicyPath:     "config/governance/checkpoint-signers.json",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditExport failed: %v", err)
+	}
+	if exportPackage.Status != "consistent" {
+		t.Fatalf("unexpected export status: %s", exportPackage.Status)
+	}
+	if exportPackage.BaselineSnapshot.CurrentPolicyVersion != applied.AppliedPolicy.Version {
+		t.Fatalf("unexpected baseline current policy version: %s", exportPackage.BaselineSnapshot.CurrentPolicyVersion)
+	}
+	if exportPackage.BaselineSnapshot.LedgerEntryCount != 1 {
+		t.Fatalf("unexpected baseline ledger entry count: %d", exportPackage.BaselineSnapshot.LedgerEntryCount)
+	}
+	if exportPackage.BaselineSnapshot.LatestEntry == nil {
+		t.Fatal("expected latest baseline entry")
+	}
+	if exportPackage.BaselineSnapshot.LatestEntry.ReceiptID != report.LatestReceiptID {
+		t.Fatalf("unexpected latest baseline receipt id: %s", exportPackage.BaselineSnapshot.LatestEntry.ReceiptID)
+	}
+	if len(exportPackage.BaselineSnapshot.ContinuityIssues) != 0 {
+		t.Fatalf("expected no continuity issues, got %+v", exportPackage.BaselineSnapshot.ContinuityIssues)
+	}
+}
+
+func TestSignerRotationActivationAuditExportFailsOnReconciliationDigestMismatch(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	applied := mustSignerRotationApplyResult(t, bundle)
+	ledger := mustSignerRotationActivationAuditLedger(t, bundle)
+	report := mustSignerRotationActivationAuditReconcileReport(t, ledger, applied.AppliedPolicy)
+	report.CurrentPolicyDigest = "deadbeef"
+	_, err = SignerRotationActivationAuditExport(SignerRotationActivationAuditExportRequest{
+		Ledger:         ledger,
+		Policy:         applied.AppliedPolicy,
+		Reconciliation: report,
+		PolicyPath:     "config/governance/checkpoint-signers.json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "activation audit reconciliation current_policy_digest mismatch") {
+		t.Fatalf("expected reconciliation digest mismatch error, got %v", err)
+	}
+}
+
+func TestSignerRotationActivationAuditExportFailsOnLatestReceiptMismatch(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	applied := mustSignerRotationApplyResult(t, bundle)
+	ledger := mustSignerRotationActivationAuditLedger(t, bundle)
+	report := mustSignerRotationActivationAuditReconcileReport(t, ledger, applied.AppliedPolicy)
+	report.LatestReceiptID = "rotation-other-20260424t000000z"
+	_, err = SignerRotationActivationAuditExport(SignerRotationActivationAuditExportRequest{
+		Ledger:         ledger,
+		Policy:         applied.AppliedPolicy,
+		Reconciliation: report,
+		PolicyPath:     "config/governance/checkpoint-signers.json",
+	})
+	if err == nil || !strings.Contains(err.Error(), "activation audit reconciliation latest_receipt_id mismatch") {
+		t.Fatalf("expected latest receipt mismatch error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a deterministic activation audit export package with baseline snapshot and continuity report
- expose the export path through 0aid and Makefile operator targets
- document the export workflow and add regression coverage for contradictory inputs

## Verification
- make validate
- make go-test
- make go-build
- python -m unittest discover -s tests -v
- GOCACHE=/home/oai/Hancock/projects/0ai-assurance-network/.cache/go-build GOMODCACHE=/home/oai/Hancock/projects/0ai-assurance-network/.cache/go-mod go run ./cmd/0aid signer-rotation-ledger-export --root . --ledger build/rotation/activation-audit-ledger.json --policy build/rotation/governance-chair-applied-policy.json --out build/rotation/governance-chair-audit-export.json

Closes #38