### PR TITLE
Add audit export verification and archive index manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append signer-rotation-ledger-reconcile signer-rotation-ledger-export init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append signer-rotation-ledger-reconcile signer-rotation-ledger-export signer-rotation-ledger-verify-export signer-rotation-ledger-archive-index init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -33,6 +33,8 @@ help:
 	@echo "  signer-rotation-ledger-append Append a verified activation record into the audit ledger"
 	@echo "  signer-rotation-ledger-reconcile Reconcile the activation audit ledger against the current signer policy"
 	@echo "  signer-rotation-ledger-export Export the activation audit ledger with baseline snapshot and continuity report"
+	@echo "  signer-rotation-ledger-verify-export Verify an exported activation audit package for archive retention"
+	@echo "  signer-rotation-ledger-archive-index Build an archive index manifest over exported audit packages"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -134,6 +136,14 @@ signer-rotation-ledger-reconcile:
 
 signer-rotation-ledger-export:
 	./0aid signer-rotation-ledger-export --root . $(if $(LEDGER),--ledger $(LEDGER),) $(if $(POLICY),--policy $(POLICY),) $(if $(RECONCILE),--reconcile $(RECONCILE),) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-ledger-verify-export:
+	@test -n "$(EXPORT)" || (echo "Usage: make signer-rotation-ledger-verify-export EXPORT=build/rotation/governance-chair-audit-export.json" && exit 1)
+	./0aid signer-rotation-ledger-verify-export --export $(EXPORT) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-ledger-archive-index:
+	@test -n "$(EXPORTS)" || (echo "Usage: make signer-rotation-ledger-archive-index EXPORTS=build/rotation/current-audit-export.json,build/rotation/governance-chair-audit-export.json" && exit 1)
+	./0aid signer-rotation-ledger-archive-index --exports $(EXPORTS) $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ make -C projects/0ai-assurance-network signer-rotation-verify PLAN=build/rotatio
 make -C projects/0ai-assurance-network signer-rotation-ledger-append APPLY=build/rotation/governance-chair-apply-result.json VERIFICATION=build/rotation/governance-chair-verification.json LEDGER_OUT=build/rotation/activation-audit-ledger.json
 make -C projects/0ai-assurance-network signer-rotation-ledger-reconcile LEDGER=build/rotation/activation-audit-ledger.json POLICY=build/rotation/governance-chair-applied-policy.json
 make -C projects/0ai-assurance-network signer-rotation-ledger-export LEDGER=build/rotation/activation-audit-ledger.json POLICY=build/rotation/governance-chair-applied-policy.json OUT=build/rotation/governance-chair-audit-export.json
+make -C projects/0ai-assurance-network signer-rotation-ledger-verify-export EXPORT=build/rotation/governance-chair-audit-export.json OUT=build/rotation/governance-chair-audit-export-verify.json
+make -C projects/0ai-assurance-network signer-rotation-ledger-archive-index EXPORTS=build/rotation/current-audit-export.json,build/rotation/governance-chair-audit-export.json OUT=build/rotation/activation-audit-archive-index.json
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -250,6 +252,17 @@ Exports fail closed when the reconciliation report contradicts the ledger or
 current policy digests, so operators cannot archive a self-inconsistent bundle
 as if it were a valid baseline.
 
+`signer-rotation-ledger-verify-export` replays that package deterministically
+and emits a machine-readable archive readiness report. Verification stays local
+to the exported payload: it reruns reconciliation, regenerates the expected
+baseline snapshot, and rejects any bundle whose embedded digests or lineage
+metadata drift from the recomputed state.
+
+`signer-rotation-ledger-archive-index` builds a compact archive manifest over a
+set of retained export packages. The index summarizes current policy versions,
+latest receipt lineage, archive readiness, and duplicate or contradictory
+baseline metadata across the retained package set.
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -271,6 +284,8 @@ currently supports:
 - `signer-rotation-ledger-append`
 - `signer-rotation-ledger-reconcile`
 - `signer-rotation-ledger-export`
+- `signer-rotation-ledger-verify-export`
+- `signer-rotation-ledger-archive-index`
 - `show-plan`
 - `init-genesis`
 - `render-validator`

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -489,6 +489,68 @@ func run(args []string) error {
 			return printJSON(exportPackage)
 		}
 		return project.WriteJSON(filepath.Clean(*out), exportPackage)
+	case "signer-rotation-ledger-verify-export":
+		fs := flag.NewFlagSet("signer-rotation-ledger-verify-export", flag.ContinueOnError)
+		exportPath := fs.String("export", "", "activation audit export package path")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *exportPath == "" {
+			return errors.New("signer-rotation-ledger-verify-export requires --export")
+		}
+		var exportPackage project.SignerRotationActivationAuditExportPackage
+		if err := readJSONFile(filepath.Clean(*exportPath), &exportPackage); err != nil {
+			return err
+		}
+		report, err := project.SignerRotationActivationAuditVerifyExport(project.SignerRotationActivationAuditExportVerificationRequest{
+			ExportPackage: exportPackage,
+		})
+		if err != nil {
+			return err
+		}
+		if *out != "" {
+			if err := project.WriteJSON(filepath.Clean(*out), report); err != nil {
+				return err
+			}
+		} else if err := printJSON(report); err != nil {
+			return err
+		}
+		if report.Status == "invalid" {
+			return errors.New("activation audit export verification failed")
+		}
+		return nil
+	case "signer-rotation-ledger-archive-index":
+		fs := flag.NewFlagSet("signer-rotation-ledger-archive-index", flag.ContinueOnError)
+		exportPaths := fs.String("exports", "", "comma-separated activation audit export package paths")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if strings.TrimSpace(*exportPaths) == "" {
+			return errors.New("signer-rotation-ledger-archive-index requires --exports")
+		}
+		packages, err := readActivationAuditExportPackages(*exportPaths)
+		if err != nil {
+			return err
+		}
+		index, err := project.BuildSignerRotationActivationAuditArchiveIndex(project.SignerRotationActivationAuditArchiveIndexRequest{
+			Packages: packages,
+		})
+		if err != nil {
+			return err
+		}
+		if *out != "" {
+			if err := project.WriteJSON(filepath.Clean(*out), index); err != nil {
+				return err
+			}
+		} else if err := printJSON(index); err != nil {
+			return err
+		}
+		if index.Status == "invalid" {
+			return errors.New("activation audit archive index verification failed")
+		}
+		return nil
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -657,7 +719,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|signer-rotation-ledger-reconcile|signer-rotation-ledger-export|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|signer-rotation-ledger-reconcile|signer-rotation-ledger-export|signer-rotation-ledger-verify-export|signer-rotation-ledger-archive-index|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 
@@ -688,6 +750,29 @@ func readActivationAuditLedger(path string) (project.SignerRotationActivationAud
 		return ledger, fmt.Errorf("parse %s: %w", path, err)
 	}
 	return ledger, nil
+}
+
+func readActivationAuditExportPackages(path string) ([]project.SignerRotationActivationAuditArchivePackage, error) {
+	paths := strings.Split(path, ",")
+	collected := make([]project.SignerRotationActivationAuditArchivePackage, 0, len(paths))
+	for _, rawPath := range paths {
+		cleanPath := filepath.Clean(strings.TrimSpace(rawPath))
+		if cleanPath == "" {
+			continue
+		}
+		var exportPackage project.SignerRotationActivationAuditExportPackage
+		if err := readJSONFile(cleanPath, &exportPackage); err != nil {
+			return nil, err
+		}
+		collected = append(collected, project.SignerRotationActivationAuditArchivePackage{
+			PackagePath:   filepath.ToSlash(cleanPath),
+			ExportPackage: exportPackage,
+		})
+	}
+	if len(collected) == 0 {
+		return nil, fmt.Errorf("no activation audit export packages found in %s", path)
+	}
+	return collected, nil
 }
 
 func readSignerRotationApprovals(path string) ([]project.SignerRotationApproval, error) {

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -341,6 +341,49 @@ Operators may also pass `--reconcile` to reuse a saved reconciliation report.
 Export still fails closed when that report contradicts the supplied ledger or
 current policy digest.
 
+## Export verification
+
+`0aid signer-rotation-ledger-verify-export` validates one exported audit
+package for archive retention.
+
+Example:
+
+```bash
+./0aid signer-rotation-ledger-verify-export \
+  --export ./build/rotation/governance-chair-audit-export.json \
+  --out ./build/rotation/governance-chair-audit-export-verify.json
+```
+
+Verification reruns reconciliation from the embedded ledger and policy,
+rebuilds the expected export package, and compares the regenerated payload with
+the archived artifact. The verification report marks a bundle as
+`archive_ready` only when the recomputed export matches exactly and the
+embedded reconciliation status is still `consistent`.
+
+## Archive index manifests
+
+`0aid signer-rotation-ledger-archive-index` builds a compact archive manifest
+over a retained set of export packages.
+
+Example:
+
+```bash
+./0aid signer-rotation-ledger-archive-index \
+  --exports ./build/rotation/current-audit-export.json,./build/rotation/governance-chair-audit-export.json \
+  --out ./build/rotation/activation-audit-archive-index.json
+```
+
+The archive index includes:
+
+- package path, policy version, digest, and latest receipt lineage for each retained export
+- per-package archive readiness and verification issues
+- aggregate chain and policy path continuity
+- latest retained baseline summary
+
+Index generation fails closed when retained packages overlap on the same
+current policy version, reuse the same latest receipt id, or disagree on chain
+or policy path metadata.
+
 ## Operator workflow
 
 1. Render the current signer manifest and identify any `expiring` signers.
@@ -363,3 +406,5 @@ current policy digest.
     treating the rotation lineage as continuous and complete.
 13. Export the policy, ledger, and reconciliation state into a stable audit
     package before archiving the rotation baseline.
+14. Verify that archived export package before accepting it as a retained baseline.
+15. Rebuild the archive index manifest whenever a new retained baseline is added.

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -390,6 +390,60 @@ type SignerRotationActivationAuditExportPackage struct {
 	Reconciliation   SignerRotationActivationAuditReconcileReport  `json:"reconciliation"`
 }
 
+type SignerRotationActivationAuditExportVerificationRequest struct {
+	ExportPackage SignerRotationActivationAuditExportPackage
+}
+
+type SignerRotationActivationAuditExportVerificationReport struct {
+	Version              string   `json:"version"`
+	Status               string   `json:"status"`
+	ArchiveReady         bool     `json:"archive_ready"`
+	ChainID              string   `json:"chain_id"`
+	PolicyPath           string   `json:"policy_path"`
+	CurrentPolicyVersion string   `json:"current_policy_version"`
+	CurrentPolicyDigest  string   `json:"current_policy_digest"`
+	EntryCount           int      `json:"entry_count"`
+	LatestReceiptID      string   `json:"latest_receipt_id,omitempty"`
+	LatestTargetVersion  string   `json:"latest_target_policy_version,omitempty"`
+	VerificationIssues   []string `json:"verification_issues"`
+}
+
+type SignerRotationActivationAuditArchivePackage struct {
+	PackagePath   string
+	ExportPackage SignerRotationActivationAuditExportPackage
+}
+
+type SignerRotationActivationAuditArchiveIndexRequest struct {
+	Packages []SignerRotationActivationAuditArchivePackage
+}
+
+type SignerRotationActivationAuditArchiveIndexEntry struct {
+	PackagePath          string   `json:"package_path"`
+	Status               string   `json:"status"`
+	ArchiveReady         bool     `json:"archive_ready"`
+	ChainID              string   `json:"chain_id"`
+	PolicyPath           string   `json:"policy_path"`
+	CurrentPolicyVersion string   `json:"current_policy_version"`
+	CurrentPolicyDigest  string   `json:"current_policy_digest"`
+	EntryCount           int      `json:"entry_count"`
+	LatestReceiptID      string   `json:"latest_receipt_id,omitempty"`
+	LatestTargetVersion  string   `json:"latest_target_policy_version,omitempty"`
+	VerificationIssues   []string `json:"verification_issues,omitempty"`
+}
+
+type SignerRotationActivationAuditArchiveIndex struct {
+	Version                    string                                           `json:"version"`
+	Status                     string                                           `json:"status"`
+	PackageCount               int                                              `json:"package_count"`
+	ArchiveReadyCount          int                                              `json:"archive_ready_count"`
+	ChainID                    string                                           `json:"chain_id"`
+	PolicyPath                 string                                           `json:"policy_path"`
+	LatestCurrentPolicyVersion string                                           `json:"latest_current_policy_version,omitempty"`
+	LatestCurrentPolicyDigest  string                                           `json:"latest_current_policy_digest,omitempty"`
+	Entries                    []SignerRotationActivationAuditArchiveIndexEntry `json:"entries"`
+	Issues                     []string                                         `json:"issues"`
+}
+
 type parsedSignerEntry struct {
 	ActorID           string
 	SignerID          string
@@ -2415,6 +2469,178 @@ func SignerRotationActivationAuditExport(
 		Ledger:         request.Ledger,
 		Reconciliation: report,
 	}, nil
+}
+
+func SignerRotationActivationAuditVerifyExport(
+	request SignerRotationActivationAuditExportVerificationRequest,
+) (SignerRotationActivationAuditExportVerificationReport, error) {
+	pkg := request.ExportPackage
+	report := SignerRotationActivationAuditExportVerificationReport{
+		Version:              "1.0.0",
+		Status:               "consistent",
+		ArchiveReady:         false,
+		ChainID:              pkg.ChainID,
+		PolicyPath:           pkg.PolicyPath,
+		CurrentPolicyVersion: pkg.CurrentPolicy.Version,
+		EntryCount:           len(pkg.Ledger.Entries),
+		LatestReceiptID:      pkg.BaselineSnapshot.LatestReceiptID,
+		LatestTargetVersion:  pkg.BaselineSnapshot.LatestTargetVersion,
+		VerificationIssues:   []string{},
+	}
+	policyDigest, err := checkpointSignerPolicyDigest(pkg.CurrentPolicy)
+	if err != nil {
+		return SignerRotationActivationAuditExportVerificationReport{}, err
+	}
+	report.CurrentPolicyDigest = policyDigest
+	if pkg.Version != "1.0.0" {
+		report.VerificationIssues = append(report.VerificationIssues, fmt.Sprintf("unexpected activation audit export package version: %s", pkg.Version))
+	}
+	expectedReconciliation, err := SignerRotationActivationAuditReconcile(SignerRotationActivationAuditReconcileRequest{
+		Ledger:     pkg.Ledger,
+		Policy:     pkg.CurrentPolicy,
+		PolicyPath: pkg.PolicyPath,
+	})
+	if err != nil {
+		report.VerificationIssues = append(report.VerificationIssues, err.Error())
+	} else {
+		expectedExport, err := SignerRotationActivationAuditExport(SignerRotationActivationAuditExportRequest{
+			Ledger:         pkg.Ledger,
+			Policy:         pkg.CurrentPolicy,
+			Reconciliation: expectedReconciliation,
+			PolicyPath:     pkg.PolicyPath,
+		})
+		if err != nil {
+			report.VerificationIssues = append(report.VerificationIssues, err.Error())
+		} else {
+			expectedJSON, err := json.Marshal(expectedExport)
+			if err != nil {
+				return SignerRotationActivationAuditExportVerificationReport{}, fmt.Errorf("marshal expected activation audit export package: %w", err)
+			}
+			actualJSON, err := json.Marshal(pkg)
+			if err != nil {
+				return SignerRotationActivationAuditExportVerificationReport{}, fmt.Errorf("marshal actual activation audit export package: %w", err)
+			}
+			if !bytesEqual(expectedJSON, actualJSON) {
+				report.VerificationIssues = append(report.VerificationIssues, "activation audit export package drift detected")
+			}
+		}
+	}
+	if len(report.VerificationIssues) > 0 {
+		report.Status = "invalid"
+		return report, nil
+	}
+	if pkg.Reconciliation.Status == "consistent" {
+		report.ArchiveReady = true
+		report.Status = "consistent"
+		return report, nil
+	}
+	report.Status = "review"
+	return report, nil
+}
+
+func BuildSignerRotationActivationAuditArchiveIndex(
+	request SignerRotationActivationAuditArchiveIndexRequest,
+) (SignerRotationActivationAuditArchiveIndex, error) {
+	if len(request.Packages) == 0 {
+		return SignerRotationActivationAuditArchiveIndex{}, fmt.Errorf("activation audit archive index requires at least one export package")
+	}
+	index := SignerRotationActivationAuditArchiveIndex{
+		Version:    "1.0.0",
+		Status:     "consistent",
+		ChainID:    "",
+		PolicyPath: "",
+		Entries:    []SignerRotationActivationAuditArchiveIndexEntry{},
+		Issues:     []string{},
+	}
+	type indexedEntry struct {
+		entry       SignerRotationActivationAuditArchiveIndexEntry
+		latestOrder string
+	}
+	indexedEntries := make([]indexedEntry, 0, len(request.Packages))
+	seenVersions := make(map[string]string, len(request.Packages))
+	seenReceipts := make(map[string]string, len(request.Packages))
+	for _, item := range request.Packages {
+		verification, err := SignerRotationActivationAuditVerifyExport(SignerRotationActivationAuditExportVerificationRequest{
+			ExportPackage: item.ExportPackage,
+		})
+		if err != nil {
+			return SignerRotationActivationAuditArchiveIndex{}, err
+		}
+		if index.ChainID == "" {
+			index.ChainID = verification.ChainID
+		} else if verification.ChainID != "" && verification.ChainID != index.ChainID {
+			index.Issues = append(index.Issues, fmt.Sprintf("archive package %s chain_id mismatch", item.PackagePath))
+		}
+		if index.PolicyPath == "" {
+			index.PolicyPath = verification.PolicyPath
+		} else if verification.PolicyPath != "" && verification.PolicyPath != index.PolicyPath {
+			index.Issues = append(index.Issues, fmt.Sprintf("archive package %s policy_path mismatch", item.PackagePath))
+		}
+		if existing, exists := seenVersions[verification.CurrentPolicyVersion]; exists && verification.CurrentPolicyVersion != "" {
+			index.Issues = append(index.Issues, fmt.Sprintf("duplicate archive current_policy_version %s in %s and %s", verification.CurrentPolicyVersion, existing, item.PackagePath))
+		} else if verification.CurrentPolicyVersion != "" {
+			seenVersions[verification.CurrentPolicyVersion] = item.PackagePath
+		}
+		if existing, exists := seenReceipts[verification.LatestReceiptID]; exists && verification.LatestReceiptID != "" {
+			index.Issues = append(index.Issues, fmt.Sprintf("duplicate archive latest_receipt_id %s in %s and %s", verification.LatestReceiptID, existing, item.PackagePath))
+		} else if verification.LatestReceiptID != "" {
+			seenReceipts[verification.LatestReceiptID] = item.PackagePath
+		}
+		entry := SignerRotationActivationAuditArchiveIndexEntry{
+			PackagePath:          item.PackagePath,
+			Status:               verification.Status,
+			ArchiveReady:         verification.ArchiveReady,
+			ChainID:              verification.ChainID,
+			PolicyPath:           verification.PolicyPath,
+			CurrentPolicyVersion: verification.CurrentPolicyVersion,
+			CurrentPolicyDigest:  verification.CurrentPolicyDigest,
+			EntryCount:           verification.EntryCount,
+			LatestReceiptID:      verification.LatestReceiptID,
+			LatestTargetVersion:  verification.LatestTargetVersion,
+			VerificationIssues:   append([]string(nil), verification.VerificationIssues...),
+		}
+		if verification.ArchiveReady {
+			index.ArchiveReadyCount++
+		}
+		indexedEntries = append(indexedEntries, indexedEntry{
+			entry:       entry,
+			latestOrder: archiveEntrySortKey(item.ExportPackage),
+		})
+	}
+	sort.Slice(indexedEntries, func(i, j int) bool {
+		if indexedEntries[i].latestOrder == indexedEntries[j].latestOrder {
+			return indexedEntries[i].entry.PackagePath < indexedEntries[j].entry.PackagePath
+		}
+		return indexedEntries[i].latestOrder < indexedEntries[j].latestOrder
+	})
+	for _, item := range indexedEntries {
+		index.Entries = append(index.Entries, item.entry)
+	}
+	index.PackageCount = len(index.Entries)
+	if len(index.Entries) > 0 {
+		latest := index.Entries[len(index.Entries)-1]
+		index.LatestCurrentPolicyVersion = latest.CurrentPolicyVersion
+		index.LatestCurrentPolicyDigest = latest.CurrentPolicyDigest
+	}
+	if len(index.Issues) > 0 {
+		index.Status = "invalid"
+		return index, nil
+	}
+	for _, entry := range index.Entries {
+		if !entry.ArchiveReady {
+			index.Status = "review"
+			return index, nil
+		}
+	}
+	index.Status = "consistent"
+	return index, nil
+}
+
+func archiveEntrySortKey(pkg SignerRotationActivationAuditExportPackage) string {
+	if pkg.BaselineSnapshot.LatestEntry != nil {
+		return pkg.BaselineSnapshot.LatestEntry.EffectiveAt + "|" + pkg.CurrentPolicy.Version
+	}
+	return "0000-00-00T00:00:00Z|" + pkg.CurrentPolicy.Version
 }
 
 func recommendedRotationAction(rotationStatus string) string {

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -950,3 +950,156 @@ func TestSignerRotationActivationAuditExportFailsOnLatestReceiptMismatch(t *test
 		t.Fatalf("expected latest receipt mismatch error, got %v", err)
 	}
 }
+
+func mustCurrentSignerRotationActivationAuditExportPackage(
+	t *testing.T,
+	bundle Bundle,
+) SignerRotationActivationAuditExportPackage {
+	t.Helper()
+
+	currentPolicy, err := currentSignerPolicy(bundle)
+	if err != nil {
+		t.Fatalf("currentSignerPolicy failed: %v", err)
+	}
+	ledger := SignerRotationActivationAuditLedger{
+		Version:    "1.0.0",
+		Status:     "active",
+		ChainID:    "0ai-assurance-1",
+		PolicyPath: "config/governance/checkpoint-signers.json",
+		Entries:    []SignerRotationActivationAuditEntry{},
+		EntryCount: 0,
+	}
+	report := mustSignerRotationActivationAuditReconcileReport(t, ledger, currentPolicy)
+	exportPackage, err := SignerRotationActivationAuditExport(SignerRotationActivationAuditExportRequest{
+		Ledger:         ledger,
+		Policy:         currentPolicy,
+		Reconciliation: report,
+		PolicyPath:     "config/governance/checkpoint-signers.json",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditExport failed: %v", err)
+	}
+	return exportPackage
+}
+
+func mustRotatedSignerRotationActivationAuditExportPackage(
+	t *testing.T,
+	bundle Bundle,
+) SignerRotationActivationAuditExportPackage {
+	t.Helper()
+
+	applied := mustSignerRotationApplyResult(t, bundle)
+	ledger := mustSignerRotationActivationAuditLedger(t, bundle)
+	report := mustSignerRotationActivationAuditReconcileReport(t, ledger, applied.AppliedPolicy)
+	exportPackage, err := SignerRotationActivationAuditExport(SignerRotationActivationAuditExportRequest{
+		Ledger:         ledger,
+		Policy:         applied.AppliedPolicy,
+		Reconciliation: report,
+		PolicyPath:     "config/governance/checkpoint-signers.json",
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditExport failed: %v", err)
+	}
+	return exportPackage
+}
+
+func TestSignerRotationActivationAuditVerifyExport(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	exportPackage := mustRotatedSignerRotationActivationAuditExportPackage(t, bundle)
+	report, err := SignerRotationActivationAuditVerifyExport(SignerRotationActivationAuditExportVerificationRequest{
+		ExportPackage: exportPackage,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditVerifyExport failed: %v", err)
+	}
+	if report.Status != "consistent" {
+		t.Fatalf("unexpected verification status: %s", report.Status)
+	}
+	if !report.ArchiveReady {
+		t.Fatal("expected export package to be archive ready")
+	}
+	if len(report.VerificationIssues) != 0 {
+		t.Fatalf("expected no verification issues, got %+v", report.VerificationIssues)
+	}
+}
+
+func TestSignerRotationActivationAuditVerifyExportFlagsTamper(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	exportPackage := mustRotatedSignerRotationActivationAuditExportPackage(t, bundle)
+	exportPackage.BaselineSnapshot.CurrentPolicyDigest = "deadbeef"
+	report, err := SignerRotationActivationAuditVerifyExport(SignerRotationActivationAuditExportVerificationRequest{
+		ExportPackage: exportPackage,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditVerifyExport failed: %v", err)
+	}
+	if report.Status != "invalid" {
+		t.Fatalf("expected invalid verification status, got %s", report.Status)
+	}
+	if report.ArchiveReady {
+		t.Fatal("expected tampered export package to be non-archive-ready")
+	}
+	if len(report.VerificationIssues) == 0 || !strings.Contains(report.VerificationIssues[0], "activation audit export package drift detected") {
+		t.Fatalf("expected export drift issue, got %+v", report.VerificationIssues)
+	}
+}
+
+func TestSignerRotationActivationAuditArchiveIndex(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	currentExport := mustCurrentSignerRotationActivationAuditExportPackage(t, bundle)
+	rotatedExport := mustRotatedSignerRotationActivationAuditExportPackage(t, bundle)
+	index, err := BuildSignerRotationActivationAuditArchiveIndex(SignerRotationActivationAuditArchiveIndexRequest{
+		Packages: []SignerRotationActivationAuditArchivePackage{
+			{PackagePath: "build/rotation/current-audit-export.json", ExportPackage: currentExport},
+			{PackagePath: "build/rotation/governance-chair-audit-export.json", ExportPackage: rotatedExport},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditArchiveIndex failed: %v", err)
+	}
+	if index.Status != "consistent" {
+		t.Fatalf("unexpected archive index status: %s", index.Status)
+	}
+	if index.PackageCount != 2 || index.ArchiveReadyCount != 2 {
+		t.Fatalf("unexpected archive counts: %+v", index)
+	}
+	if index.LatestCurrentPolicyVersion != rotatedExport.CurrentPolicy.Version {
+		t.Fatalf("unexpected latest archive policy version: %s", index.LatestCurrentPolicyVersion)
+	}
+}
+
+func TestSignerRotationActivationAuditArchiveIndexFlagsDuplicateBaseline(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	rotatedExport := mustRotatedSignerRotationActivationAuditExportPackage(t, bundle)
+	index, err := BuildSignerRotationActivationAuditArchiveIndex(SignerRotationActivationAuditArchiveIndexRequest{
+		Packages: []SignerRotationActivationAuditArchivePackage{
+			{PackagePath: "build/rotation/export-a.json", ExportPackage: rotatedExport},
+			{PackagePath: "build/rotation/export-b.json", ExportPackage: rotatedExport},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditArchiveIndex failed: %v", err)
+	}
+	if index.Status != "invalid" {
+		t.Fatalf("expected invalid archive index status, got %s", index.Status)
+	}
+	if len(index.Issues) == 0 || !strings.Contains(index.Issues[0], "duplicate archive current_policy_version") {
+		t.Fatalf("expected duplicate baseline issue, got %+v", index.Issues)
+	}
+}


### PR DESCRIPTION
## Summary
- add deterministic verification reports for activation audit export packages
- add archive index manifests over retained activation audit exports
- document the archive workflow and add regression coverage for tamper and duplicate-baseline cases

## Verification
- make validate
- make go-test
- make go-build
- python -m unittest discover -s tests -v
- GOCACHE=/home/oai/Hancock/projects/0ai-assurance-network/.cache/go-build GOMODCACHE=/home/oai/Hancock/projects/0ai-assurance-network/.cache/go-mod go run ./cmd/0aid signer-rotation-ledger-export --root . --ledger build/rotation/current-empty-ledger.json --out build/rotation/current-audit-export.json
- GOCACHE=/home/oai/Hancock/projects/0ai-assurance-network/.cache/go-build GOMODCACHE=/home/oai/Hancock/projects/0ai-assurance-network/.cache/go-mod go run ./cmd/0aid signer-rotation-ledger-verify-export --export build/rotation/governance-chair-audit-export.json --out build/rotation/governance-chair-audit-export-verify.json
- GOCACHE=/home/oai/Hancock/projects/0ai-assurance-network/.cache/go-build GOMODCACHE=/home/oai/Hancock/projects/0ai-assurance-network/.cache/go-mod go run ./cmd/0aid signer-rotation-ledger-archive-index --exports build/rotation/current-audit-export.json,build/rotation/governance-chair-audit-export.json --out build/rotation/activation-audit-archive-index.json

Closes #40