### PR TITLE
Add archive promotion receipts and retained attestations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/*.json
 /0aid
 __pycache__/
 *.pyc
+*.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append signer-rotation-ledger-reconcile signer-rotation-ledger-export signer-rotation-ledger-verify-export signer-rotation-ledger-archive-index init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append signer-rotation-ledger-reconcile signer-rotation-ledger-export signer-rotation-ledger-verify-export signer-rotation-ledger-archive-index signer-rotation-ledger-promote init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -35,6 +35,7 @@ help:
 	@echo "  signer-rotation-ledger-export Export the activation audit ledger with baseline snapshot and continuity report"
 	@echo "  signer-rotation-ledger-verify-export Verify an exported activation audit package for archive retention"
 	@echo "  signer-rotation-ledger-archive-index Build an archive index manifest over exported audit packages"
+	@echo "  signer-rotation-ledger-promote Emit archive promotion receipts and retained-baseline attestations"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -144,6 +145,14 @@ signer-rotation-ledger-verify-export:
 signer-rotation-ledger-archive-index:
 	@test -n "$(EXPORTS)" || (echo "Usage: make signer-rotation-ledger-archive-index EXPORTS=build/rotation/current-audit-export.json,build/rotation/governance-chair-audit-export.json" && exit 1)
 	./0aid signer-rotation-ledger-archive-index --exports $(EXPORTS) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-ledger-promote:
+	@test -n "$(EXPORT)" || (echo "Usage: make signer-rotation-ledger-promote EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTED_AT=2026-04-24T00:20:00Z PROMOTED_BY=governance-archive-bot" && exit 1)
+	@test -n "$(VERIFY)" || (echo "Usage: make signer-rotation-ledger-promote EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTED_AT=2026-04-24T00:20:00Z PROMOTED_BY=governance-archive-bot" && exit 1)
+	@test -n "$(INDEX)" || (echo "Usage: make signer-rotation-ledger-promote EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTED_AT=2026-04-24T00:20:00Z PROMOTED_BY=governance-archive-bot" && exit 1)
+	@test -n "$(PROMOTED_AT)" || (echo "Usage: make signer-rotation-ledger-promote EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTED_AT=2026-04-24T00:20:00Z PROMOTED_BY=governance-archive-bot" && exit 1)
+	@test -n "$(PROMOTED_BY)" || (echo "Usage: make signer-rotation-ledger-promote EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTED_AT=2026-04-24T00:20:00Z PROMOTED_BY=governance-archive-bot" && exit 1)
+	./0aid signer-rotation-ledger-promote --export $(EXPORT) --verify $(VERIFY) --index $(INDEX) --promoted-at $(PROMOTED_AT) --promoted-by $(PROMOTED_BY) $(if $(OUT),--out $(OUT),) $(if $(RECEIPT_OUT),--receipt-out $(RECEIPT_OUT),) $(if $(ATTESTATION_OUT),--attestation-out $(ATTESTATION_OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ make -C projects/0ai-assurance-network signer-rotation-ledger-reconcile LEDGER=b
 make -C projects/0ai-assurance-network signer-rotation-ledger-export LEDGER=build/rotation/activation-audit-ledger.json POLICY=build/rotation/governance-chair-applied-policy.json OUT=build/rotation/governance-chair-audit-export.json
 make -C projects/0ai-assurance-network signer-rotation-ledger-verify-export EXPORT=build/rotation/governance-chair-audit-export.json OUT=build/rotation/governance-chair-audit-export-verify.json
 make -C projects/0ai-assurance-network signer-rotation-ledger-archive-index EXPORTS=build/rotation/current-audit-export.json,build/rotation/governance-chair-audit-export.json OUT=build/rotation/activation-audit-archive-index.json
+make -C projects/0ai-assurance-network signer-rotation-ledger-promote EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTED_AT=2026-04-24T00:20:00Z PROMOTED_BY=governance-archive-bot OUT=build/rotation/governance-chair-archive-promotion.json RECEIPT_OUT=build/rotation/governance-chair-archive-promotion-receipt.json ATTESTATION_OUT=build/rotation/governance-chair-retained-baseline-attestation.json
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -263,6 +264,17 @@ set of retained export packages. The index summarizes current policy versions,
 latest receipt lineage, archive readiness, and duplicate or contradictory
 baseline metadata across the retained package set.
 
+`signer-rotation-ledger-promote` is the retained-baseline gate. It requires a
+verified export package plus a consistent archive index, then emits:
+
+- a deterministic archive promotion receipt
+- a retained-baseline attestation bound to the archive index entry
+- digests for the export package, verification report, archive index, and entry lineage
+
+Promotion fails closed when the supplied verification report drifts from the
+recomputed export verification, the archive index is not `consistent`, or the
+indexed retained baseline does not exactly match the verified export lineage.
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -286,6 +298,7 @@ currently supports:
 - `signer-rotation-ledger-export`
 - `signer-rotation-ledger-verify-export`
 - `signer-rotation-ledger-archive-index`
+- `signer-rotation-ledger-promote`
 - `show-plan`
 - `init-genesis`
 - `render-validator`

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -551,6 +551,81 @@ func run(args []string) error {
 			return errors.New("activation audit archive index verification failed")
 		}
 		return nil
+	case "signer-rotation-ledger-promote":
+		fs := flag.NewFlagSet("signer-rotation-ledger-promote", flag.ContinueOnError)
+		exportPath := fs.String("export", "", "activation audit export package path")
+		verifyPath := fs.String("verify", "", "activation audit export verification report path")
+		indexPath := fs.String("index", "", "activation audit archive index path")
+		promotedAt := fs.String("promoted-at", "", "promotion timestamp (RFC3339)")
+		promotedBy := fs.String("promoted-by", "", "operator or automation actor recording promotion")
+		out := fs.String("out", "", "output file path")
+		receiptOut := fs.String("receipt-out", "", "promotion receipt output file path")
+		attestationOut := fs.String("attestation-out", "", "retained baseline attestation output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *exportPath == "" {
+			return errors.New("signer-rotation-ledger-promote requires --export")
+		}
+		if *verifyPath == "" {
+			return errors.New("signer-rotation-ledger-promote requires --verify")
+		}
+		if *indexPath == "" {
+			return errors.New("signer-rotation-ledger-promote requires --index")
+		}
+		if *promotedAt == "" {
+			return errors.New("signer-rotation-ledger-promote requires --promoted-at")
+		}
+		if *promotedBy == "" {
+			return errors.New("signer-rotation-ledger-promote requires --promoted-by")
+		}
+		cleanExportPath := filepath.ToSlash(filepath.Clean(*exportPath))
+		var exportPackage project.SignerRotationActivationAuditExportPackage
+		if err := readJSONFile(cleanExportPath, &exportPackage); err != nil {
+			return err
+		}
+		var verificationReport project.SignerRotationActivationAuditExportVerificationReport
+		if err := readJSONFile(filepath.Clean(*verifyPath), &verificationReport); err != nil {
+			return err
+		}
+		var archiveIndex project.SignerRotationActivationAuditArchiveIndex
+		if err := readJSONFile(filepath.Clean(*indexPath), &archiveIndex); err != nil {
+			return err
+		}
+		promotion, err := project.BuildSignerRotationActivationAuditArchivePromotion(project.SignerRotationActivationAuditArchivePromotionRequest{
+			PackagePath:        cleanExportPath,
+			ExportPackage:      exportPackage,
+			VerificationReport: verificationReport,
+			ArchiveIndex:       archiveIndex,
+			PromotedAt:         *promotedAt,
+			PromotedBy:         *promotedBy,
+		})
+		if err != nil {
+			return err
+		}
+		if *receiptOut != "" {
+			if err := project.WriteJSON(filepath.Clean(*receiptOut), promotion.PromotionReceipt); err != nil {
+				return err
+			}
+		}
+		if *attestationOut != "" {
+			if err := project.WriteJSON(filepath.Clean(*attestationOut), promotion.RetainedBaselineAttestation); err != nil {
+				return err
+			}
+		}
+		if *out != "" {
+			if err := project.WriteJSON(filepath.Clean(*out), promotion); err != nil {
+				return err
+			}
+		} else if *receiptOut == "" && *attestationOut == "" {
+			if err := printJSON(promotion); err != nil {
+				return err
+			}
+		}
+		if promotion.Status != "promoted" {
+			return errors.New("activation audit archive promotion failed")
+		}
+		return nil
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -719,7 +794,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|signer-rotation-ledger-reconcile|signer-rotation-ledger-export|signer-rotation-ledger-verify-export|signer-rotation-ledger-archive-index|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|signer-rotation-ledger-reconcile|signer-rotation-ledger-export|signer-rotation-ledger-verify-export|signer-rotation-ledger-archive-index|signer-rotation-ledger-promote|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -384,6 +384,40 @@ Index generation fails closed when retained packages overlap on the same
 current policy version, reuse the same latest receipt id, or disagree on chain
 or policy path metadata.
 
+## Archive promotion receipts
+
+`0aid signer-rotation-ledger-promote` turns a verified export package plus a
+consistent archive index into retained-baseline proof artifacts.
+
+Example:
+
+```bash
+./0aid signer-rotation-ledger-promote \
+  --export ./build/rotation/governance-chair-audit-export.json \
+  --verify ./build/rotation/governance-chair-audit-export-verify.json \
+  --index ./build/rotation/activation-audit-archive-index.json \
+  --promoted-at 2026-04-24T00:20:00Z \
+  --promoted-by governance-archive-bot \
+  --out ./build/rotation/governance-chair-archive-promotion.json \
+  --receipt-out ./build/rotation/governance-chair-archive-promotion-receipt.json \
+  --attestation-out ./build/rotation/governance-chair-retained-baseline-attestation.json
+```
+
+Promotion emits:
+
+- a deterministic archive promotion receipt bound to the package path
+- a retained-baseline attestation tied to the matching archive index entry
+- digests for the export package, verification report, archive index, and
+  retained entry lineage
+
+Promotion fails closed when:
+
+- the verification report does not match a recomputed export verification
+- the export package is not `archive_ready`
+- the archive index is not `consistent`
+- the requested package path does not exist in the archive index
+- the archive index entry drifts on policy version, digest, receipt lineage, or entry count
+
 ## Operator workflow
 
 1. Render the current signer manifest and identify any `expiring` signers.
@@ -408,3 +442,5 @@ or policy path metadata.
     package before archiving the rotation baseline.
 14. Verify that archived export package before accepting it as a retained baseline.
 15. Rebuild the archive index manifest whenever a new retained baseline is added.
+16. Promote the retained baseline only after the verified export and archive
+    index entry produce a matching promotion receipt and attestation pair.

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -444,6 +444,65 @@ type SignerRotationActivationAuditArchiveIndex struct {
 	Issues                     []string                                         `json:"issues"`
 }
 
+type SignerRotationActivationAuditArchivePromotionRequest struct {
+	PackagePath        string
+	ExportPackage      SignerRotationActivationAuditExportPackage
+	VerificationReport SignerRotationActivationAuditExportVerificationReport
+	ArchiveIndex       SignerRotationActivationAuditArchiveIndex
+	PromotedAt         string
+	PromotedBy         string
+}
+
+type SignerRotationActivationAuditArchivePromotionReceipt struct {
+	Version              string `json:"version"`
+	Status               string `json:"status"`
+	ReceiptID            string `json:"receipt_id"`
+	PackagePath          string `json:"package_path"`
+	PromotedAt           string `json:"promoted_at"`
+	PromotedBy           string `json:"promoted_by"`
+	ChainID              string `json:"chain_id"`
+	PolicyPath           string `json:"policy_path"`
+	CurrentPolicyVersion string `json:"current_policy_version"`
+	CurrentPolicyDigest  string `json:"current_policy_digest"`
+	EntryCount           int    `json:"entry_count"`
+	LatestReceiptID      string `json:"latest_receipt_id,omitempty"`
+	LatestTargetVersion  string `json:"latest_target_policy_version,omitempty"`
+	ExportPackageDigest  string `json:"export_package_digest"`
+	VerificationDigest   string `json:"verification_digest"`
+	ArchiveIndexDigest   string `json:"archive_index_digest"`
+	ArchiveEntryDigest   string `json:"archive_entry_digest"`
+}
+
+type SignerRotationActivationAuditRetainedBaselineAttestation struct {
+	Version              string   `json:"version"`
+	Status               string   `json:"status"`
+	AttestationID        string   `json:"attestation_id"`
+	PromotionReceiptID   string   `json:"promotion_receipt_id"`
+	PackagePath          string   `json:"package_path"`
+	ArchiveEntryIndex    int      `json:"archive_entry_index"`
+	PromotedAt           string   `json:"promoted_at"`
+	PromotedBy           string   `json:"promoted_by"`
+	ChainID              string   `json:"chain_id"`
+	PolicyPath           string   `json:"policy_path"`
+	CurrentPolicyVersion string   `json:"current_policy_version"`
+	CurrentPolicyDigest  string   `json:"current_policy_digest"`
+	LatestReceiptID      string   `json:"latest_receipt_id,omitempty"`
+	LatestTargetVersion  string   `json:"latest_target_policy_version,omitempty"`
+	ExportPackageDigest  string   `json:"export_package_digest"`
+	VerificationDigest   string   `json:"verification_digest"`
+	ArchiveIndexDigest   string   `json:"archive_index_digest"`
+	ArchiveEntryDigest   string   `json:"archive_entry_digest"`
+	Claims               []string `json:"claims"`
+}
+
+type SignerRotationActivationAuditArchivePromotionResult struct {
+	Version                     string                                                   `json:"version"`
+	Status                      string                                                   `json:"status"`
+	PromotionReceipt            SignerRotationActivationAuditArchivePromotionReceipt     `json:"promotion_receipt"`
+	RetainedBaselineAttestation SignerRotationActivationAuditRetainedBaselineAttestation `json:"retained_baseline_attestation"`
+	Issues                      []string                                                 `json:"issues"`
+}
+
 type parsedSignerEntry struct {
 	ActorID           string
 	SignerID          string
@@ -1360,6 +1419,25 @@ func checkpointSignerPolicyDigest(policy CheckpointSignerPolicyOutput) (string, 
 	}
 	sum := sha256.Sum256(encoded)
 	return hex.EncodeToString(sum[:]), nil
+}
+
+func digestJSON(value any, description string) (string, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("marshal %s: %w", description, err)
+	}
+	sum := sha256.Sum256(encoded)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func deterministicArtifactID(prefix string, values ...string) string {
+	joined := strings.Join(values, "|")
+	sum := sha256.Sum256([]byte(joined))
+	digest := hex.EncodeToString(sum[:])
+	if len(digest) > 16 {
+		digest = digest[:16]
+	}
+	return prefix + "-" + digest
 }
 
 func signerRotationVerificationMessage(
@@ -2641,6 +2719,201 @@ func archiveEntrySortKey(pkg SignerRotationActivationAuditExportPackage) string 
 		return pkg.BaselineSnapshot.LatestEntry.EffectiveAt + "|" + pkg.CurrentPolicy.Version
 	}
 	return "0000-00-00T00:00:00Z|" + pkg.CurrentPolicy.Version
+}
+
+func BuildSignerRotationActivationAuditArchivePromotion(
+	request SignerRotationActivationAuditArchivePromotionRequest,
+) (SignerRotationActivationAuditArchivePromotionResult, error) {
+	packagePath := strings.TrimSpace(request.PackagePath)
+	if packagePath == "" {
+		return SignerRotationActivationAuditArchivePromotionResult{}, fmt.Errorf("activation audit archive promotion package_path must be set")
+	}
+	promotedAt, err := parseRFC3339(request.PromotedAt, "activation audit archive promotion promoted_at")
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionResult{}, err
+	}
+	promotedBy := strings.TrimSpace(request.PromotedBy)
+	if promotedBy == "" {
+		return SignerRotationActivationAuditArchivePromotionResult{}, fmt.Errorf("activation audit archive promotion promoted_by must be set")
+	}
+
+	result := SignerRotationActivationAuditArchivePromotionResult{
+		Version: "1.0.0",
+		Status:  "invalid",
+		Issues:  []string{},
+	}
+
+	expectedVerification, err := SignerRotationActivationAuditVerifyExport(SignerRotationActivationAuditExportVerificationRequest{
+		ExportPackage: request.ExportPackage,
+	})
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionResult{}, err
+	}
+	expectedVerificationJSON, err := json.Marshal(expectedVerification)
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionResult{}, fmt.Errorf("marshal expected activation audit export verification report: %w", err)
+	}
+	actualVerificationJSON, err := json.Marshal(request.VerificationReport)
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionResult{}, fmt.Errorf("marshal provided activation audit export verification report: %w", err)
+	}
+	if !bytesEqual(expectedVerificationJSON, actualVerificationJSON) {
+		result.Issues = append(result.Issues, "activation audit export verification report drift detected")
+	}
+	if expectedVerification.Status != "consistent" || !expectedVerification.ArchiveReady {
+		result.Issues = append(result.Issues, "activation audit export package is not archive_ready")
+	}
+	if request.ArchiveIndex.Status != "consistent" {
+		result.Issues = append(result.Issues, fmt.Sprintf("activation audit archive index status must be consistent, got %s", request.ArchiveIndex.Status))
+	}
+	if request.ArchiveIndex.PackageCount != len(request.ArchiveIndex.Entries) {
+		result.Issues = append(result.Issues, "activation audit archive index package_count does not match entries")
+	}
+	if len(request.ArchiveIndex.Entries) == 0 {
+		result.Issues = append(result.Issues, "activation audit archive index must include at least one entry")
+	}
+	if request.ArchiveIndex.ChainID != "" && request.ArchiveIndex.ChainID != expectedVerification.ChainID {
+		result.Issues = append(result.Issues, "activation audit archive index chain_id mismatch")
+	}
+	if request.ArchiveIndex.PolicyPath != "" && request.ArchiveIndex.PolicyPath != expectedVerification.PolicyPath {
+		result.Issues = append(result.Issues, "activation audit archive index policy_path mismatch")
+	}
+	if len(request.ArchiveIndex.Entries) > 0 {
+		latestEntry := request.ArchiveIndex.Entries[len(request.ArchiveIndex.Entries)-1]
+		if request.ArchiveIndex.LatestCurrentPolicyVersion != latestEntry.CurrentPolicyVersion {
+			result.Issues = append(result.Issues, "activation audit archive index latest_current_policy_version mismatch")
+		}
+		if request.ArchiveIndex.LatestCurrentPolicyDigest != latestEntry.CurrentPolicyDigest {
+			result.Issues = append(result.Issues, "activation audit archive index latest_current_policy_digest mismatch")
+		}
+	}
+
+	matchedIndex := -1
+	for idx, entry := range request.ArchiveIndex.Entries {
+		if entry.PackagePath == packagePath {
+			matchedIndex = idx
+			break
+		}
+	}
+	if matchedIndex == -1 {
+		result.Issues = append(result.Issues, fmt.Sprintf("archive package path %s not found in archive index", packagePath))
+	}
+
+	var matchedEntry SignerRotationActivationAuditArchiveIndexEntry
+	if matchedIndex >= 0 {
+		matchedEntry = request.ArchiveIndex.Entries[matchedIndex]
+		if matchedEntry.Status != expectedVerification.Status {
+			result.Issues = append(result.Issues, "archive index entry status mismatch")
+		}
+		if matchedEntry.ArchiveReady != expectedVerification.ArchiveReady {
+			result.Issues = append(result.Issues, "archive index entry archive_ready mismatch")
+		}
+		if matchedEntry.ChainID != expectedVerification.ChainID {
+			result.Issues = append(result.Issues, "archive index entry chain_id mismatch")
+		}
+		if matchedEntry.PolicyPath != expectedVerification.PolicyPath {
+			result.Issues = append(result.Issues, "archive index entry policy_path mismatch")
+		}
+		if matchedEntry.CurrentPolicyVersion != expectedVerification.CurrentPolicyVersion {
+			result.Issues = append(result.Issues, "archive index entry current_policy_version mismatch")
+		}
+		if matchedEntry.CurrentPolicyDigest != expectedVerification.CurrentPolicyDigest {
+			result.Issues = append(result.Issues, "archive index entry current_policy_digest mismatch")
+		}
+		if matchedEntry.EntryCount != expectedVerification.EntryCount {
+			result.Issues = append(result.Issues, "archive index entry entry_count mismatch")
+		}
+		if matchedEntry.LatestReceiptID != expectedVerification.LatestReceiptID {
+			result.Issues = append(result.Issues, "archive index entry latest_receipt_id mismatch")
+		}
+		if matchedEntry.LatestTargetVersion != expectedVerification.LatestTargetVersion {
+			result.Issues = append(result.Issues, "archive index entry latest_target_policy_version mismatch")
+		}
+	}
+
+	if len(result.Issues) > 0 {
+		return result, nil
+	}
+
+	exportPackageDigest, err := digestJSON(request.ExportPackage, "activation audit export package")
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionResult{}, err
+	}
+	verificationDigest, err := digestJSON(expectedVerification, "activation audit export verification report")
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionResult{}, err
+	}
+	archiveIndexDigest, err := digestJSON(request.ArchiveIndex, "activation audit archive index")
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionResult{}, err
+	}
+	archiveEntryDigest, err := digestJSON(matchedEntry, "activation audit archive index entry")
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionResult{}, err
+	}
+
+	receiptID := deterministicArtifactID(
+		"archive-promotion",
+		packagePath,
+		expectedVerification.CurrentPolicyVersion,
+		expectedVerification.CurrentPolicyDigest,
+		promotedAt.Format(time.RFC3339),
+		promotedBy,
+		archiveIndexDigest,
+	)
+	attestationID := deterministicArtifactID(
+		"retained-baseline",
+		receiptID,
+		archiveEntryDigest,
+		verificationDigest,
+	)
+
+	result.PromotionReceipt = SignerRotationActivationAuditArchivePromotionReceipt{
+		Version:              "1.0.0",
+		Status:               "promoted",
+		ReceiptID:            receiptID,
+		PackagePath:          packagePath,
+		PromotedAt:           promotedAt.Format(time.RFC3339),
+		PromotedBy:           promotedBy,
+		ChainID:              expectedVerification.ChainID,
+		PolicyPath:           expectedVerification.PolicyPath,
+		CurrentPolicyVersion: expectedVerification.CurrentPolicyVersion,
+		CurrentPolicyDigest:  expectedVerification.CurrentPolicyDigest,
+		EntryCount:           expectedVerification.EntryCount,
+		LatestReceiptID:      expectedVerification.LatestReceiptID,
+		LatestTargetVersion:  expectedVerification.LatestTargetVersion,
+		ExportPackageDigest:  exportPackageDigest,
+		VerificationDigest:   verificationDigest,
+		ArchiveIndexDigest:   archiveIndexDigest,
+		ArchiveEntryDigest:   archiveEntryDigest,
+	}
+	result.RetainedBaselineAttestation = SignerRotationActivationAuditRetainedBaselineAttestation{
+		Version:              "1.0.0",
+		Status:               "retained",
+		AttestationID:        attestationID,
+		PromotionReceiptID:   receiptID,
+		PackagePath:          packagePath,
+		ArchiveEntryIndex:    matchedIndex,
+		PromotedAt:           promotedAt.Format(time.RFC3339),
+		PromotedBy:           promotedBy,
+		ChainID:              expectedVerification.ChainID,
+		PolicyPath:           expectedVerification.PolicyPath,
+		CurrentPolicyVersion: expectedVerification.CurrentPolicyVersion,
+		CurrentPolicyDigest:  expectedVerification.CurrentPolicyDigest,
+		LatestReceiptID:      expectedVerification.LatestReceiptID,
+		LatestTargetVersion:  expectedVerification.LatestTargetVersion,
+		ExportPackageDigest:  exportPackageDigest,
+		VerificationDigest:   verificationDigest,
+		ArchiveIndexDigest:   archiveIndexDigest,
+		ArchiveEntryDigest:   archiveEntryDigest,
+		Claims: []string{
+			"verified export package matches the retained archive entry",
+			"archive index lineage matches the promoted export verification report",
+			"retained baseline promotion is bound to the current policy digest and receipt lineage",
+		},
+	}
+	result.Status = "promoted"
+	return result, nil
 }
 
 func recommendedRotationAction(rotationStatus string) string {

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -1103,3 +1103,104 @@ func TestSignerRotationActivationAuditArchiveIndexFlagsDuplicateBaseline(t *test
 		t.Fatalf("expected duplicate baseline issue, got %+v", index.Issues)
 	}
 }
+
+func TestSignerRotationActivationAuditArchivePromotion(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	currentExport := mustCurrentSignerRotationActivationAuditExportPackage(t, bundle)
+	rotatedExport := mustRotatedSignerRotationActivationAuditExportPackage(t, bundle)
+	verification, err := SignerRotationActivationAuditVerifyExport(SignerRotationActivationAuditExportVerificationRequest{
+		ExportPackage: rotatedExport,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditVerifyExport failed: %v", err)
+	}
+	index, err := BuildSignerRotationActivationAuditArchiveIndex(SignerRotationActivationAuditArchiveIndexRequest{
+		Packages: []SignerRotationActivationAuditArchivePackage{
+			{PackagePath: "build/rotation/current-audit-export.json", ExportPackage: currentExport},
+			{PackagePath: "build/rotation/governance-chair-audit-export.json", ExportPackage: rotatedExport},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchiveIndex failed: %v", err)
+	}
+
+	promotion, err := BuildSignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionRequest{
+		PackagePath:        "build/rotation/governance-chair-audit-export.json",
+		ExportPackage:      rotatedExport,
+		VerificationReport: verification,
+		ArchiveIndex:       index,
+		PromotedAt:         "2026-04-24T00:20:00Z",
+		PromotedBy:         "governance-archive-bot",
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchivePromotion failed: %v", err)
+	}
+	if promotion.Status != "promoted" {
+		t.Fatalf("unexpected promotion status: %s", promotion.Status)
+	}
+	if promotion.PromotionReceipt.Status != "promoted" {
+		t.Fatalf("unexpected promotion receipt status: %s", promotion.PromotionReceipt.Status)
+	}
+	if promotion.RetainedBaselineAttestation.Status != "retained" {
+		t.Fatalf("unexpected retained baseline attestation status: %s", promotion.RetainedBaselineAttestation.Status)
+	}
+	if promotion.PromotionReceipt.PackagePath != "build/rotation/governance-chair-audit-export.json" {
+		t.Fatalf("unexpected promotion receipt package path: %s", promotion.PromotionReceipt.PackagePath)
+	}
+	if promotion.RetainedBaselineAttestation.ArchiveEntryIndex != 1 {
+		t.Fatalf("unexpected archive entry index: %d", promotion.RetainedBaselineAttestation.ArchiveEntryIndex)
+	}
+	if promotion.PromotionReceipt.ExportPackageDigest == "" || promotion.PromotionReceipt.ArchiveIndexDigest == "" {
+		t.Fatalf("expected populated promotion digests, got %+v", promotion.PromotionReceipt)
+	}
+	if promotion.RetainedBaselineAttestation.PromotionReceiptID != promotion.PromotionReceipt.ReceiptID {
+		t.Fatalf("attestation receipt binding mismatch: %+v", promotion)
+	}
+}
+
+func TestSignerRotationActivationAuditArchivePromotionFailsOnLineageMismatch(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	currentExport := mustCurrentSignerRotationActivationAuditExportPackage(t, bundle)
+	rotatedExport := mustRotatedSignerRotationActivationAuditExportPackage(t, bundle)
+	verification, err := SignerRotationActivationAuditVerifyExport(SignerRotationActivationAuditExportVerificationRequest{
+		ExportPackage: currentExport,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditVerifyExport failed: %v", err)
+	}
+	index, err := BuildSignerRotationActivationAuditArchiveIndex(SignerRotationActivationAuditArchiveIndexRequest{
+		Packages: []SignerRotationActivationAuditArchivePackage{
+			{PackagePath: "build/rotation/current-audit-export.json", ExportPackage: currentExport},
+			{PackagePath: "build/rotation/governance-chair-audit-export.json", ExportPackage: rotatedExport},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchiveIndex failed: %v", err)
+	}
+
+	promotion, err := BuildSignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionRequest{
+		PackagePath:        "build/rotation/governance-chair-audit-export.json",
+		ExportPackage:      rotatedExport,
+		VerificationReport: verification,
+		ArchiveIndex:       index,
+		PromotedAt:         "2026-04-24T00:20:00Z",
+		PromotedBy:         "governance-archive-bot",
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchivePromotion failed: %v", err)
+	}
+	if promotion.Status != "invalid" {
+		t.Fatalf("expected invalid promotion status, got %s", promotion.Status)
+	}
+	if len(promotion.Issues) == 0 || !strings.Contains(strings.Join(promotion.Issues, " | "), "verification report drift detected") {
+		t.Fatalf("expected verification drift issue, got %+v", promotion.Issues)
+	}
+}


### PR DESCRIPTION
## Summary
- add deterministic archive promotion receipts for retained export packages
- add retained-baseline attestations bound to archive index entries
- fail closed when promotion lineage drifts from verified export or archive index state

## Testing
- python -m unittest discover -s tests -v
- make validate
- make go-test
- make go-build
- ./0aid signer-rotation-ledger-promote --export build/rotation/governance-chair-audit-export.json --verify build/rotation/governance-chair-audit-export-verify.json --index build/rotation/activation-audit-archive-index.json --promoted-at 2026-04-24T00:20:00Z --promoted-by governance-archive-bot --out build/rotation/governance-chair-archive-promotion.json --receipt-out build/rotation/governance-chair-archive-promotion-receipt.json --attestation-out build/rotation/governance-chair-retained-baseline-attestation.json

Closes #42