### PR TITLE
Add archive promotion verification and inventory snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON ?= python3
 GOCACHE ?= $(CURDIR)/.cache/go-build
 GOMODCACHE ?= $(CURDIR)/.cache/go-mod
 
-.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append signer-rotation-ledger-reconcile signer-rotation-ledger-export signer-rotation-ledger-verify-export signer-rotation-ledger-archive-index signer-rotation-ledger-promote init-node collect-validator assemble-genesis assemble-localnet clean
+.PHONY: help validate render-localnet readiness governance-sim governance-queue governance-trends governance-remediation governance-replay governance-drift go-build go-test module-plan identity-plan signer-manifest signer-rotation-receipt signer-rotation-approve signer-rotation-finalize signer-rotation-activate signer-rotation-apply signer-rotation-verify signer-rotation-ledger-append signer-rotation-ledger-reconcile signer-rotation-ledger-export signer-rotation-ledger-verify-export signer-rotation-ledger-archive-index signer-rotation-ledger-promote signer-rotation-ledger-verify-promotion signer-rotation-ledger-retained-inventory init-node collect-validator assemble-genesis assemble-localnet clean
 
 help:
 	@echo ""
@@ -36,6 +36,8 @@ help:
 	@echo "  signer-rotation-ledger-verify-export Verify an exported activation audit package for archive retention"
 	@echo "  signer-rotation-ledger-archive-index Build an archive index manifest over exported audit packages"
 	@echo "  signer-rotation-ledger-promote Emit archive promotion receipts and retained-baseline attestations"
+	@echo "  signer-rotation-ledger-verify-promotion Verify promoted retained baselines and emit verification receipts"
+	@echo "  signer-rotation-ledger-retained-inventory Build a retained inventory snapshot over verified promoted baselines"
 	@echo "  init-node        Generate a development node bundle: make init-node ID=val-1"
 	@echo "  collect-validator Normalize a node bundle into a collected manifest"
 	@echo "  assemble-genesis Merge collected manifests into a deterministic genesis plan"
@@ -153,6 +155,20 @@ signer-rotation-ledger-promote:
 	@test -n "$(PROMOTED_AT)" || (echo "Usage: make signer-rotation-ledger-promote EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTED_AT=2026-04-24T00:20:00Z PROMOTED_BY=governance-archive-bot" && exit 1)
 	@test -n "$(PROMOTED_BY)" || (echo "Usage: make signer-rotation-ledger-promote EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTED_AT=2026-04-24T00:20:00Z PROMOTED_BY=governance-archive-bot" && exit 1)
 	./0aid signer-rotation-ledger-promote --export $(EXPORT) --verify $(VERIFY) --index $(INDEX) --promoted-at $(PROMOTED_AT) --promoted-by $(PROMOTED_BY) $(if $(OUT),--out $(OUT),) $(if $(RECEIPT_OUT),--receipt-out $(RECEIPT_OUT),) $(if $(ATTESTATION_OUT),--attestation-out $(ATTESTATION_OUT),)
+
+signer-rotation-ledger-verify-promotion:
+	@test -n "$(EXPORT)" || (echo "Usage: make signer-rotation-ledger-verify-promotion EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTION=build/rotation/governance-chair-archive-promotion.json VERIFIED_AT=2026-04-24T00:25:00Z VERIFIED_BY=governance-audit-bot" && exit 1)
+	@test -n "$(VERIFY)" || (echo "Usage: make signer-rotation-ledger-verify-promotion EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTION=build/rotation/governance-chair-archive-promotion.json VERIFIED_AT=2026-04-24T00:25:00Z VERIFIED_BY=governance-audit-bot" && exit 1)
+	@test -n "$(INDEX)" || (echo "Usage: make signer-rotation-ledger-verify-promotion EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTION=build/rotation/governance-chair-archive-promotion.json VERIFIED_AT=2026-04-24T00:25:00Z VERIFIED_BY=governance-audit-bot" && exit 1)
+	@test -n "$(PROMOTION)" || (echo "Usage: make signer-rotation-ledger-verify-promotion EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTION=build/rotation/governance-chair-archive-promotion.json VERIFIED_AT=2026-04-24T00:25:00Z VERIFIED_BY=governance-audit-bot" && exit 1)
+	@test -n "$(VERIFIED_AT)" || (echo "Usage: make signer-rotation-ledger-verify-promotion EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTION=build/rotation/governance-chair-archive-promotion.json VERIFIED_AT=2026-04-24T00:25:00Z VERIFIED_BY=governance-audit-bot" && exit 1)
+	@test -n "$(VERIFIED_BY)" || (echo "Usage: make signer-rotation-ledger-verify-promotion EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTION=build/rotation/governance-chair-archive-promotion.json VERIFIED_AT=2026-04-24T00:25:00Z VERIFIED_BY=governance-audit-bot" && exit 1)
+	./0aid signer-rotation-ledger-verify-promotion --export $(EXPORT) --verify $(VERIFY) --index $(INDEX) --promotion $(PROMOTION) --verified-at $(VERIFIED_AT) --verified-by $(VERIFIED_BY) $(if $(OUT),--out $(OUT),)
+
+signer-rotation-ledger-retained-inventory:
+	@test -n "$(PROMOTIONS)" || (echo "Usage: make signer-rotation-ledger-retained-inventory PROMOTIONS=build/rotation/governance-chair-archive-promotion.json VERIFICATION_RECEIPTS=build/rotation/governance-chair-archive-verification.json" && exit 1)
+	@test -n "$(VERIFICATION_RECEIPTS)" || (echo "Usage: make signer-rotation-ledger-retained-inventory PROMOTIONS=build/rotation/governance-chair-archive-promotion.json VERIFICATION_RECEIPTS=build/rotation/governance-chair-archive-verification.json" && exit 1)
+	./0aid signer-rotation-ledger-retained-inventory --promotions $(PROMOTIONS) --verification-receipts $(VERIFICATION_RECEIPTS) $(if $(OUT),--out $(OUT),)
 
 init-node:
 	@test -n "$(ID)" || (echo "Usage: make init-node ID=val-1" && exit 1)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ make -C projects/0ai-assurance-network signer-rotation-ledger-export LEDGER=buil
 make -C projects/0ai-assurance-network signer-rotation-ledger-verify-export EXPORT=build/rotation/governance-chair-audit-export.json OUT=build/rotation/governance-chair-audit-export-verify.json
 make -C projects/0ai-assurance-network signer-rotation-ledger-archive-index EXPORTS=build/rotation/current-audit-export.json,build/rotation/governance-chair-audit-export.json OUT=build/rotation/activation-audit-archive-index.json
 make -C projects/0ai-assurance-network signer-rotation-ledger-promote EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTED_AT=2026-04-24T00:20:00Z PROMOTED_BY=governance-archive-bot OUT=build/rotation/governance-chair-archive-promotion.json RECEIPT_OUT=build/rotation/governance-chair-archive-promotion-receipt.json ATTESTATION_OUT=build/rotation/governance-chair-retained-baseline-attestation.json
+make -C projects/0ai-assurance-network signer-rotation-ledger-verify-promotion EXPORT=build/rotation/governance-chair-audit-export.json VERIFY=build/rotation/governance-chair-audit-export-verify.json INDEX=build/rotation/activation-audit-archive-index.json PROMOTION=build/rotation/governance-chair-archive-promotion.json VERIFIED_AT=2026-04-24T00:25:00Z VERIFIED_BY=governance-audit-bot OUT=build/rotation/governance-chair-archive-verification.json
+make -C projects/0ai-assurance-network signer-rotation-ledger-retained-inventory PROMOTIONS=build/rotation/governance-chair-archive-promotion.json VERIFICATION_RECEIPTS=build/rotation/governance-chair-archive-verification.json OUT=build/rotation/retained-archive-inventory.json
 make -C projects/0ai-assurance-network init-node ID=val-3
 make -C projects/0ai-assurance-network collect-validator BUNDLE=build/nodes/val-3 OUT=build/collection/val-3.json
 make -C projects/0ai-assurance-network assemble-genesis COLLECTION=build/collection OUT=build/assembled/genesis-plan.json
@@ -275,6 +277,17 @@ Promotion fails closed when the supplied verification report drifts from the
 recomputed export verification, the archive index is not `consistent`, or the
 indexed retained baseline does not exactly match the verified export lineage.
 
+`signer-rotation-ledger-verify-promotion` independently replays that promotion
+lineage and emits a deterministic verification receipt over the promoted
+retained baseline. It only succeeds when the promotion result can be
+recomputed exactly from the supplied export package, export verification
+report, and archive index.
+
+`signer-rotation-ledger-retained-inventory` builds a stable retained inventory
+snapshot over one or more verified promoted baselines. It fails closed when
+verification receipts drift from the promoted receipt/attestation lineage or
+when retained entries collide on policy version, receipt id, or attestation id.
+
 The generated compose file assumes a future `0aid` chain binary packaged in a
 container image. It is intentionally parameterized so the image and binary path
 can change without rewriting topology data.
@@ -299,6 +312,8 @@ currently supports:
 - `signer-rotation-ledger-verify-export`
 - `signer-rotation-ledger-archive-index`
 - `signer-rotation-ledger-promote`
+- `signer-rotation-ledger-verify-promotion`
+- `signer-rotation-ledger-retained-inventory`
 - `show-plan`
 - `init-genesis`
 - `render-validator`

--- a/cmd/0aid/main.go
+++ b/cmd/0aid/main.go
@@ -626,6 +626,111 @@ func run(args []string) error {
 			return errors.New("activation audit archive promotion failed")
 		}
 		return nil
+	case "signer-rotation-ledger-verify-promotion":
+		fs := flag.NewFlagSet("signer-rotation-ledger-verify-promotion", flag.ContinueOnError)
+		exportPath := fs.String("export", "", "activation audit export package path")
+		verifyPath := fs.String("verify", "", "activation audit export verification report path")
+		indexPath := fs.String("index", "", "activation audit archive index path")
+		promotionPath := fs.String("promotion", "", "archive promotion result path")
+		verifiedAt := fs.String("verified-at", "", "verification timestamp (RFC3339)")
+		verifiedBy := fs.String("verified-by", "", "operator or automation actor recording verification")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if *exportPath == "" {
+			return errors.New("signer-rotation-ledger-verify-promotion requires --export")
+		}
+		if *verifyPath == "" {
+			return errors.New("signer-rotation-ledger-verify-promotion requires --verify")
+		}
+		if *indexPath == "" {
+			return errors.New("signer-rotation-ledger-verify-promotion requires --index")
+		}
+		if *promotionPath == "" {
+			return errors.New("signer-rotation-ledger-verify-promotion requires --promotion")
+		}
+		if *verifiedAt == "" {
+			return errors.New("signer-rotation-ledger-verify-promotion requires --verified-at")
+		}
+		if *verifiedBy == "" {
+			return errors.New("signer-rotation-ledger-verify-promotion requires --verified-by")
+		}
+		cleanExportPath := filepath.ToSlash(filepath.Clean(*exportPath))
+		var exportPackage project.SignerRotationActivationAuditExportPackage
+		if err := readJSONFile(cleanExportPath, &exportPackage); err != nil {
+			return err
+		}
+		var verificationReport project.SignerRotationActivationAuditExportVerificationReport
+		if err := readJSONFile(filepath.Clean(*verifyPath), &verificationReport); err != nil {
+			return err
+		}
+		var archiveIndex project.SignerRotationActivationAuditArchiveIndex
+		if err := readJSONFile(filepath.Clean(*indexPath), &archiveIndex); err != nil {
+			return err
+		}
+		var promotion project.SignerRotationActivationAuditArchivePromotionResult
+		if err := readJSONFile(filepath.Clean(*promotionPath), &promotion); err != nil {
+			return err
+		}
+		receipt, err := project.VerifySignerRotationActivationAuditArchivePromotion(project.SignerRotationActivationAuditArchivePromotionVerificationRequest{
+			PackagePath:        cleanExportPath,
+			ExportPackage:      exportPackage,
+			VerificationReport: verificationReport,
+			ArchiveIndex:       archiveIndex,
+			PromotionResult:    promotion,
+			VerifiedAt:         *verifiedAt,
+			VerifiedBy:         *verifiedBy,
+		})
+		if err != nil {
+			return err
+		}
+		if *out != "" {
+			if err := project.WriteJSON(filepath.Clean(*out), receipt); err != nil {
+				return err
+			}
+		} else if err := printJSON(receipt); err != nil {
+			return err
+		}
+		if receipt.Status != "verified" {
+			return errors.New("activation audit archive promotion verification failed")
+		}
+		return nil
+	case "signer-rotation-ledger-retained-inventory":
+		fs := flag.NewFlagSet("signer-rotation-ledger-retained-inventory", flag.ContinueOnError)
+		promotionPaths := fs.String("promotions", "", "comma-separated archive promotion result paths")
+		verificationPaths := fs.String("verification-receipts", "", "comma-separated archive promotion verification receipt paths")
+		out := fs.String("out", "", "output file path")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		if strings.TrimSpace(*promotionPaths) == "" {
+			return errors.New("signer-rotation-ledger-retained-inventory requires --promotions")
+		}
+		if strings.TrimSpace(*verificationPaths) == "" {
+			return errors.New("signer-rotation-ledger-retained-inventory requires --verification-receipts")
+		}
+		packages, err := readActivationAuditPromotionPackages(*promotionPaths, *verificationPaths)
+		if err != nil {
+			return err
+		}
+		snapshot, err := project.BuildSignerRotationActivationAuditRetainedInventorySnapshot(project.SignerRotationActivationAuditRetainedInventorySnapshotRequest{
+			Packages: packages,
+		})
+		if err != nil {
+			return err
+		}
+		if *out != "" {
+			if err := project.WriteJSON(filepath.Clean(*out), snapshot); err != nil {
+				return err
+			}
+		} else if err := printJSON(snapshot); err != nil {
+			return err
+		}
+		if snapshot.Status != "consistent" {
+			return errors.New("retained inventory snapshot verification failed")
+		}
+		return nil
 	case "show-plan":
 		fs := flag.NewFlagSet("show-plan", flag.ContinueOnError)
 		root := fs.String("root", ".", "project root")
@@ -794,7 +899,7 @@ func run(args []string) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|signer-rotation-ledger-reconcile|signer-rotation-ledger-export|signer-rotation-ledger-verify-export|signer-rotation-ledger-archive-index|signer-rotation-ledger-promote|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
+		"usage: 0aid <version|module-map|module-plan|identity-plan|signer-manifest|signer-rotation-receipt|signer-rotation-approve|signer-rotation-finalize|signer-rotation-activate|signer-rotation-apply|signer-rotation-verify|signer-rotation-ledger-append|signer-rotation-ledger-reconcile|signer-rotation-ledger-export|signer-rotation-ledger-verify-export|signer-rotation-ledger-archive-index|signer-rotation-ledger-promote|signer-rotation-ledger-verify-promotion|signer-rotation-ledger-retained-inventory|show-plan|init-genesis|render-validator|render-identity|init-node|collect-validator|assemble-genesis|assemble-localnet> [flags]",
 	)
 }
 
@@ -846,6 +951,39 @@ func readActivationAuditExportPackages(path string) ([]project.SignerRotationAct
 	}
 	if len(collected) == 0 {
 		return nil, fmt.Errorf("no activation audit export packages found in %s", path)
+	}
+	return collected, nil
+}
+
+func readActivationAuditPromotionPackages(promotionPaths string, verificationPaths string) ([]project.SignerRotationActivationAuditRetainedInventoryPackage, error) {
+	promotions := strings.Split(promotionPaths, ",")
+	verifications := strings.Split(verificationPaths, ",")
+	if len(promotions) != len(verifications) {
+		return nil, fmt.Errorf("promotion and verification receipt path counts must match")
+	}
+	collected := make([]project.SignerRotationActivationAuditRetainedInventoryPackage, 0, len(promotions))
+	for idx := range promotions {
+		promotionPath := filepath.Clean(strings.TrimSpace(promotions[idx]))
+		verificationPath := filepath.Clean(strings.TrimSpace(verifications[idx]))
+		if promotionPath == "" || verificationPath == "" {
+			return nil, fmt.Errorf("promotion and verification receipt paths must not be empty")
+		}
+		var promotion project.SignerRotationActivationAuditArchivePromotionResult
+		if err := readJSONFile(promotionPath, &promotion); err != nil {
+			return nil, err
+		}
+		var verification project.SignerRotationActivationAuditArchivePromotionVerificationReceipt
+		if err := readJSONFile(verificationPath, &verification); err != nil {
+			return nil, err
+		}
+		collected = append(collected, project.SignerRotationActivationAuditRetainedInventoryPackage{
+			PromotionPath:       filepath.ToSlash(promotionPath),
+			PromotionResult:     promotion,
+			VerificationReceipt: verification,
+		})
+	}
+	if len(collected) == 0 {
+		return nil, fmt.Errorf("no activation audit archive promotions found")
 	}
 	return collected, nil
 }

--- a/docs/signer-manifests.md
+++ b/docs/signer-manifests.md
@@ -418,6 +418,65 @@ Promotion fails closed when:
 - the requested package path does not exist in the archive index
 - the archive index entry drifts on policy version, digest, receipt lineage, or entry count
 
+## Promotion verification receipts
+
+`0aid signer-rotation-ledger-verify-promotion` independently verifies a
+promoted retained baseline and emits a stable verification receipt.
+
+Example:
+
+```bash
+./0aid signer-rotation-ledger-verify-promotion \
+  --export ./build/rotation/governance-chair-audit-export.json \
+  --verify ./build/rotation/governance-chair-audit-export-verify.json \
+  --index ./build/rotation/activation-audit-archive-index.json \
+  --promotion ./build/rotation/governance-chair-archive-promotion.json \
+  --verified-at 2026-04-24T00:25:00Z \
+  --verified-by governance-audit-bot \
+  --out ./build/rotation/governance-chair-archive-verification.json
+```
+
+The verification receipt includes:
+
+- the promoted receipt and retained attestation identifiers
+- digests for the full promotion result, promotion receipt, and attestation
+- the current policy version/digest and latest receipt lineage
+- a deterministic verification receipt id bound to the promotion lineage
+
+Verification fails closed when:
+
+- the supplied promotion result drifts from a recomputed promotion
+- the promotion result is not `promoted`
+- the retained attestation no longer matches the promotion receipt lineage
+
+## Retained archive inventory snapshots
+
+`0aid signer-rotation-ledger-retained-inventory` builds a stable snapshot over
+verified promoted baselines.
+
+Example:
+
+```bash
+./0aid signer-rotation-ledger-retained-inventory \
+  --promotions ./build/rotation/governance-chair-archive-promotion.json \
+  --verification-receipts ./build/rotation/governance-chair-archive-verification.json \
+  --out ./build/rotation/retained-archive-inventory.json
+```
+
+The retained inventory snapshot includes:
+
+- promotion and verification receipt ids for each retained baseline
+- current policy version/digest and latest receipt lineage
+- promotion and verification digests for each retained entry
+- a stable latest retained baseline summary across the verified set
+
+Inventory generation fails closed when:
+
+- verification receipts are not `verified`
+- verification receipts drift from promoted receipt or attestation metadata
+- retained entries collide on policy version, promotion receipt id, attestation id, or verification receipt id
+- retained entries disagree on chain or policy path metadata
+
 ## Operator workflow
 
 1. Render the current signer manifest and identify any `expiring` signers.
@@ -444,3 +503,6 @@ Promotion fails closed when:
 15. Rebuild the archive index manifest whenever a new retained baseline is added.
 16. Promote the retained baseline only after the verified export and archive
     index entry produce a matching promotion receipt and attestation pair.
+17. Verify the promoted retained baseline and retain the verification receipt.
+18. Rebuild the retained inventory snapshot whenever a new promoted baseline is
+    independently verified.

--- a/internal/project/signers.go
+++ b/internal/project/signers.go
@@ -503,6 +503,84 @@ type SignerRotationActivationAuditArchivePromotionResult struct {
 	Issues                      []string                                                 `json:"issues"`
 }
 
+type SignerRotationActivationAuditArchivePromotionVerificationRequest struct {
+	PackagePath        string
+	ExportPackage      SignerRotationActivationAuditExportPackage
+	VerificationReport SignerRotationActivationAuditExportVerificationReport
+	ArchiveIndex       SignerRotationActivationAuditArchiveIndex
+	PromotionResult    SignerRotationActivationAuditArchivePromotionResult
+	VerifiedAt         string
+	VerifiedBy         string
+}
+
+type SignerRotationActivationAuditArchivePromotionVerificationReceipt struct {
+	Version                string   `json:"version"`
+	Status                 string   `json:"status"`
+	VerificationReceiptID  string   `json:"verification_receipt_id"`
+	PackagePath            string   `json:"package_path"`
+	VerifiedAt             string   `json:"verified_at"`
+	VerifiedBy             string   `json:"verified_by"`
+	PromotionReceiptID     string   `json:"promotion_receipt_id"`
+	AttestationID          string   `json:"attestation_id"`
+	ChainID                string   `json:"chain_id"`
+	PolicyPath             string   `json:"policy_path"`
+	CurrentPolicyVersion   string   `json:"current_policy_version"`
+	CurrentPolicyDigest    string   `json:"current_policy_digest"`
+	LatestReceiptID        string   `json:"latest_receipt_id,omitempty"`
+	LatestTargetVersion    string   `json:"latest_target_policy_version,omitempty"`
+	PromotionResultDigest  string   `json:"promotion_result_digest"`
+	PromotionReceiptDigest string   `json:"promotion_receipt_digest"`
+	AttestationDigest      string   `json:"attestation_digest"`
+	ArchiveIndexDigest     string   `json:"archive_index_digest"`
+	ArchiveEntryDigest     string   `json:"archive_entry_digest"`
+	VerificationIssues     []string `json:"verification_issues"`
+}
+
+type SignerRotationActivationAuditRetainedInventoryPackage struct {
+	PromotionPath       string
+	PromotionResult     SignerRotationActivationAuditArchivePromotionResult
+	VerificationReceipt SignerRotationActivationAuditArchivePromotionVerificationReceipt
+}
+
+type SignerRotationActivationAuditRetainedInventorySnapshotRequest struct {
+	Packages []SignerRotationActivationAuditRetainedInventoryPackage
+}
+
+type SignerRotationActivationAuditRetainedInventorySnapshotEntry struct {
+	PromotionPath             string   `json:"promotion_path"`
+	Status                    string   `json:"status"`
+	Verified                  bool     `json:"verified"`
+	VerificationReceiptID     string   `json:"verification_receipt_id"`
+	PromotionReceiptID        string   `json:"promotion_receipt_id"`
+	AttestationID             string   `json:"attestation_id"`
+	ChainID                   string   `json:"chain_id"`
+	PolicyPath                string   `json:"policy_path"`
+	CurrentPolicyVersion      string   `json:"current_policy_version"`
+	CurrentPolicyDigest       string   `json:"current_policy_digest"`
+	LatestReceiptID           string   `json:"latest_receipt_id,omitempty"`
+	LatestTargetVersion       string   `json:"latest_target_policy_version,omitempty"`
+	PromotedAt                string   `json:"promoted_at"`
+	PromotedBy                string   `json:"promoted_by"`
+	VerifiedAt                string   `json:"verified_at"`
+	VerifiedBy                string   `json:"verified_by"`
+	PromotionResultDigest     string   `json:"promotion_result_digest"`
+	VerificationReceiptDigest string   `json:"verification_receipt_digest"`
+	VerificationIssues        []string `json:"verification_issues,omitempty"`
+}
+
+type SignerRotationActivationAuditRetainedInventorySnapshot struct {
+	Version                    string                                                        `json:"version"`
+	Status                     string                                                        `json:"status"`
+	PackageCount               int                                                           `json:"package_count"`
+	VerifiedCount              int                                                           `json:"verified_count"`
+	ChainID                    string                                                        `json:"chain_id"`
+	PolicyPath                 string                                                        `json:"policy_path"`
+	LatestCurrentPolicyVersion string                                                        `json:"latest_current_policy_version,omitempty"`
+	LatestCurrentPolicyDigest  string                                                        `json:"latest_current_policy_digest,omitempty"`
+	Entries                    []SignerRotationActivationAuditRetainedInventorySnapshotEntry `json:"entries"`
+	Issues                     []string                                                      `json:"issues"`
+}
+
 type parsedSignerEntry struct {
 	ActorID           string
 	SignerID          string
@@ -2914,6 +2992,285 @@ func BuildSignerRotationActivationAuditArchivePromotion(
 	}
 	result.Status = "promoted"
 	return result, nil
+}
+
+func VerifySignerRotationActivationAuditArchivePromotion(
+	request SignerRotationActivationAuditArchivePromotionVerificationRequest,
+) (SignerRotationActivationAuditArchivePromotionVerificationReceipt, error) {
+	packagePath := strings.TrimSpace(request.PackagePath)
+	if packagePath == "" {
+		return SignerRotationActivationAuditArchivePromotionVerificationReceipt{}, fmt.Errorf("activation audit archive promotion verification package_path must be set")
+	}
+	verifiedAt, err := parseRFC3339(request.VerifiedAt, "activation audit archive promotion verification verified_at")
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionVerificationReceipt{}, err
+	}
+	verifiedBy := strings.TrimSpace(request.VerifiedBy)
+	if verifiedBy == "" {
+		return SignerRotationActivationAuditArchivePromotionVerificationReceipt{}, fmt.Errorf("activation audit archive promotion verification verified_by must be set")
+	}
+
+	receipt := SignerRotationActivationAuditArchivePromotionVerificationReceipt{
+		Version:            "1.0.0",
+		Status:             "invalid",
+		PackagePath:        packagePath,
+		VerifiedAt:         verifiedAt.Format(time.RFC3339),
+		VerifiedBy:         verifiedBy,
+		VerificationIssues: []string{},
+	}
+
+	expectedPromotion, err := BuildSignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionRequest{
+		PackagePath:        packagePath,
+		ExportPackage:      request.ExportPackage,
+		VerificationReport: request.VerificationReport,
+		ArchiveIndex:       request.ArchiveIndex,
+		PromotedAt:         request.PromotionResult.PromotionReceipt.PromotedAt,
+		PromotedBy:         request.PromotionResult.PromotionReceipt.PromotedBy,
+	})
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionVerificationReceipt{}, err
+	}
+	expectedJSON, err := json.Marshal(expectedPromotion)
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionVerificationReceipt{}, fmt.Errorf("marshal expected activation audit archive promotion: %w", err)
+	}
+	actualJSON, err := json.Marshal(request.PromotionResult)
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionVerificationReceipt{}, fmt.Errorf("marshal actual activation audit archive promotion: %w", err)
+	}
+	if !bytesEqual(expectedJSON, actualJSON) {
+		receipt.VerificationIssues = append(receipt.VerificationIssues, "activation audit archive promotion drift detected")
+	}
+	if expectedPromotion.Status != "promoted" {
+		receipt.VerificationIssues = append(receipt.VerificationIssues, "activation audit archive promotion is not promoted")
+	}
+
+	promotionResultDigest, err := digestJSON(request.PromotionResult, "activation audit archive promotion result")
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionVerificationReceipt{}, err
+	}
+	promotionReceiptDigest, err := digestJSON(request.PromotionResult.PromotionReceipt, "activation audit archive promotion receipt")
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionVerificationReceipt{}, err
+	}
+	attestationDigest, err := digestJSON(request.PromotionResult.RetainedBaselineAttestation, "activation audit retained baseline attestation")
+	if err != nil {
+		return SignerRotationActivationAuditArchivePromotionVerificationReceipt{}, err
+	}
+
+	receipt.PromotionReceiptID = request.PromotionResult.PromotionReceipt.ReceiptID
+	receipt.AttestationID = request.PromotionResult.RetainedBaselineAttestation.AttestationID
+	receipt.ChainID = request.PromotionResult.PromotionReceipt.ChainID
+	receipt.PolicyPath = request.PromotionResult.PromotionReceipt.PolicyPath
+	receipt.CurrentPolicyVersion = request.PromotionResult.PromotionReceipt.CurrentPolicyVersion
+	receipt.CurrentPolicyDigest = request.PromotionResult.PromotionReceipt.CurrentPolicyDigest
+	receipt.LatestReceiptID = request.PromotionResult.PromotionReceipt.LatestReceiptID
+	receipt.LatestTargetVersion = request.PromotionResult.PromotionReceipt.LatestTargetVersion
+	receipt.PromotionResultDigest = promotionResultDigest
+	receipt.PromotionReceiptDigest = promotionReceiptDigest
+	receipt.AttestationDigest = attestationDigest
+	receipt.ArchiveIndexDigest = request.PromotionResult.PromotionReceipt.ArchiveIndexDigest
+	receipt.ArchiveEntryDigest = request.PromotionResult.PromotionReceipt.ArchiveEntryDigest
+
+	if request.PromotionResult.PromotionReceipt.Status != "promoted" {
+		receipt.VerificationIssues = append(receipt.VerificationIssues, "promotion receipt status must be promoted")
+	}
+	if request.PromotionResult.RetainedBaselineAttestation.Status != "retained" {
+		receipt.VerificationIssues = append(receipt.VerificationIssues, "retained baseline attestation status must be retained")
+	}
+	if request.PromotionResult.RetainedBaselineAttestation.PromotionReceiptID != request.PromotionResult.PromotionReceipt.ReceiptID {
+		receipt.VerificationIssues = append(receipt.VerificationIssues, "retained baseline attestation promotion_receipt_id mismatch")
+	}
+	if request.PromotionResult.RetainedBaselineAttestation.ArchiveIndexDigest != request.PromotionResult.PromotionReceipt.ArchiveIndexDigest {
+		receipt.VerificationIssues = append(receipt.VerificationIssues, "retained baseline attestation archive_index_digest mismatch")
+	}
+	if request.PromotionResult.RetainedBaselineAttestation.ArchiveEntryDigest != request.PromotionResult.PromotionReceipt.ArchiveEntryDigest {
+		receipt.VerificationIssues = append(receipt.VerificationIssues, "retained baseline attestation archive_entry_digest mismatch")
+	}
+	if request.PromotionResult.RetainedBaselineAttestation.ExportPackageDigest != request.PromotionResult.PromotionReceipt.ExportPackageDigest {
+		receipt.VerificationIssues = append(receipt.VerificationIssues, "retained baseline attestation export_package_digest mismatch")
+	}
+	if request.PromotionResult.RetainedBaselineAttestation.VerificationDigest != request.PromotionResult.PromotionReceipt.VerificationDigest {
+		receipt.VerificationIssues = append(receipt.VerificationIssues, "retained baseline attestation verification_digest mismatch")
+	}
+
+	if len(receipt.VerificationIssues) > 0 {
+		return receipt, nil
+	}
+	receipt.VerificationReceiptID = deterministicArtifactID(
+		"archive-verification",
+		receipt.PromotionReceiptID,
+		receipt.AttestationID,
+		packagePath,
+		receipt.CurrentPolicyVersion,
+		receipt.VerifiedAt,
+		receipt.VerifiedBy,
+	)
+	receipt.Status = "verified"
+	return receipt, nil
+}
+
+func BuildSignerRotationActivationAuditRetainedInventorySnapshot(
+	request SignerRotationActivationAuditRetainedInventorySnapshotRequest,
+) (SignerRotationActivationAuditRetainedInventorySnapshot, error) {
+	if len(request.Packages) == 0 {
+		return SignerRotationActivationAuditRetainedInventorySnapshot{}, fmt.Errorf("retained inventory snapshot requires at least one promoted package")
+	}
+	snapshot := SignerRotationActivationAuditRetainedInventorySnapshot{
+		Version: "1.0.0",
+		Status:  "consistent",
+		Entries: []SignerRotationActivationAuditRetainedInventorySnapshotEntry{},
+		Issues:  []string{},
+	}
+	type orderedEntry struct {
+		entry   SignerRotationActivationAuditRetainedInventorySnapshotEntry
+		sortKey string
+	}
+	ordered := make([]orderedEntry, 0, len(request.Packages))
+	seenPolicyVersions := make(map[string]string, len(request.Packages))
+	seenPromotionReceipts := make(map[string]string, len(request.Packages))
+	seenAttestations := make(map[string]string, len(request.Packages))
+	seenVerificationReceipts := make(map[string]string, len(request.Packages))
+	for _, item := range request.Packages {
+		verificationReceipt := item.VerificationReceipt
+		promotion := item.PromotionResult
+		path := strings.TrimSpace(item.PromotionPath)
+		if path == "" {
+			snapshot.Issues = append(snapshot.Issues, "retained inventory promotion_path must be set")
+			continue
+		}
+		promotionResultDigest, err := digestJSON(promotion, "activation audit archive promotion result")
+		if err != nil {
+			return SignerRotationActivationAuditRetainedInventorySnapshot{}, err
+		}
+		promotionReceiptDigest, err := digestJSON(promotion.PromotionReceipt, "activation audit archive promotion receipt")
+		if err != nil {
+			return SignerRotationActivationAuditRetainedInventorySnapshot{}, err
+		}
+		attestationDigest, err := digestJSON(promotion.RetainedBaselineAttestation, "activation audit retained baseline attestation")
+		if err != nil {
+			return SignerRotationActivationAuditRetainedInventorySnapshot{}, err
+		}
+		verificationReceiptDigest, err := digestJSON(verificationReceipt, "activation audit archive promotion verification receipt")
+		if err != nil {
+			return SignerRotationActivationAuditRetainedInventorySnapshot{}, err
+		}
+		entry := SignerRotationActivationAuditRetainedInventorySnapshotEntry{
+			PromotionPath:             path,
+			Status:                    verificationReceipt.Status,
+			Verified:                  verificationReceipt.Status == "verified",
+			VerificationReceiptID:     verificationReceipt.VerificationReceiptID,
+			PromotionReceiptID:        promotion.PromotionReceipt.ReceiptID,
+			AttestationID:             promotion.RetainedBaselineAttestation.AttestationID,
+			ChainID:                   promotion.PromotionReceipt.ChainID,
+			PolicyPath:                promotion.PromotionReceipt.PolicyPath,
+			CurrentPolicyVersion:      promotion.PromotionReceipt.CurrentPolicyVersion,
+			CurrentPolicyDigest:       promotion.PromotionReceipt.CurrentPolicyDigest,
+			LatestReceiptID:           promotion.PromotionReceipt.LatestReceiptID,
+			LatestTargetVersion:       promotion.PromotionReceipt.LatestTargetVersion,
+			PromotedAt:                promotion.PromotionReceipt.PromotedAt,
+			PromotedBy:                promotion.PromotionReceipt.PromotedBy,
+			VerifiedAt:                verificationReceipt.VerifiedAt,
+			VerifiedBy:                verificationReceipt.VerifiedBy,
+			PromotionResultDigest:     promotionResultDigest,
+			VerificationReceiptDigest: verificationReceiptDigest,
+			VerificationIssues:        append([]string(nil), verificationReceipt.VerificationIssues...),
+		}
+		if verificationReceipt.Status != "verified" {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s is not verified", path))
+		}
+		if verificationReceipt.PromotionResultDigest != promotionResultDigest {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s promotion_result_digest mismatch", path))
+		}
+		if verificationReceipt.PromotionReceiptDigest != promotionReceiptDigest {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s promotion_receipt_digest mismatch", path))
+		}
+		if verificationReceipt.AttestationDigest != attestationDigest {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s attestation_digest mismatch", path))
+		}
+		if verificationReceipt.PromotionReceiptID != promotion.PromotionReceipt.ReceiptID {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s promotion_receipt_id mismatch", path))
+		}
+		if verificationReceipt.AttestationID != promotion.RetainedBaselineAttestation.AttestationID {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s attestation_id mismatch", path))
+		}
+		if verificationReceipt.ChainID != promotion.PromotionReceipt.ChainID {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s chain_id mismatch", path))
+		}
+		if verificationReceipt.PolicyPath != promotion.PromotionReceipt.PolicyPath {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s policy_path mismatch", path))
+		}
+		if verificationReceipt.CurrentPolicyVersion != promotion.PromotionReceipt.CurrentPolicyVersion {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s current_policy_version mismatch", path))
+		}
+		if verificationReceipt.CurrentPolicyDigest != promotion.PromotionReceipt.CurrentPolicyDigest {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s current_policy_digest mismatch", path))
+		}
+		if verificationReceipt.ArchiveIndexDigest != promotion.PromotionReceipt.ArchiveIndexDigest {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s archive_index_digest mismatch", path))
+		}
+		if verificationReceipt.ArchiveEntryDigest != promotion.PromotionReceipt.ArchiveEntryDigest {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s archive_entry_digest mismatch", path))
+		}
+		if existing, exists := seenPolicyVersions[entry.CurrentPolicyVersion]; exists && entry.CurrentPolicyVersion != "" {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("duplicate retained inventory current_policy_version %s in %s and %s", entry.CurrentPolicyVersion, existing, path))
+		} else if entry.CurrentPolicyVersion != "" {
+			seenPolicyVersions[entry.CurrentPolicyVersion] = path
+		}
+		if existing, exists := seenPromotionReceipts[entry.PromotionReceiptID]; exists && entry.PromotionReceiptID != "" {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("duplicate retained inventory promotion_receipt_id %s in %s and %s", entry.PromotionReceiptID, existing, path))
+		} else if entry.PromotionReceiptID != "" {
+			seenPromotionReceipts[entry.PromotionReceiptID] = path
+		}
+		if existing, exists := seenAttestations[entry.AttestationID]; exists && entry.AttestationID != "" {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("duplicate retained inventory attestation_id %s in %s and %s", entry.AttestationID, existing, path))
+		} else if entry.AttestationID != "" {
+			seenAttestations[entry.AttestationID] = path
+		}
+		if existing, exists := seenVerificationReceipts[entry.VerificationReceiptID]; exists && entry.VerificationReceiptID != "" {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("duplicate retained inventory verification_receipt_id %s in %s and %s", entry.VerificationReceiptID, existing, path))
+		} else if entry.VerificationReceiptID != "" {
+			seenVerificationReceipts[entry.VerificationReceiptID] = path
+		}
+		if snapshot.ChainID == "" {
+			snapshot.ChainID = entry.ChainID
+		} else if entry.ChainID != "" && snapshot.ChainID != entry.ChainID {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s chain_id mismatch", path))
+		}
+		if snapshot.PolicyPath == "" {
+			snapshot.PolicyPath = entry.PolicyPath
+		} else if entry.PolicyPath != "" && snapshot.PolicyPath != entry.PolicyPath {
+			snapshot.Issues = append(snapshot.Issues, fmt.Sprintf("retained inventory package %s policy_path mismatch", path))
+		}
+		if entry.Verified {
+			snapshot.VerifiedCount++
+		}
+		ordered = append(ordered, orderedEntry{
+			entry:   entry,
+			sortKey: entry.PromotedAt + "|" + entry.CurrentPolicyVersion,
+		})
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].sortKey == ordered[j].sortKey {
+			return ordered[i].entry.PromotionPath < ordered[j].entry.PromotionPath
+		}
+		return ordered[i].sortKey < ordered[j].sortKey
+	})
+	for _, item := range ordered {
+		snapshot.Entries = append(snapshot.Entries, item.entry)
+	}
+	snapshot.PackageCount = len(snapshot.Entries)
+	if len(snapshot.Entries) > 0 {
+		latest := snapshot.Entries[len(snapshot.Entries)-1]
+		snapshot.LatestCurrentPolicyVersion = latest.CurrentPolicyVersion
+		snapshot.LatestCurrentPolicyDigest = latest.CurrentPolicyDigest
+	}
+	if len(snapshot.Issues) > 0 {
+		snapshot.Status = "invalid"
+		return snapshot, nil
+	}
+	snapshot.Status = "consistent"
+	return snapshot, nil
 }
 
 func recommendedRotationAction(rotationStatus string) string {

--- a/internal/project/signers_test.go
+++ b/internal/project/signers_test.go
@@ -1204,3 +1204,255 @@ func TestSignerRotationActivationAuditArchivePromotionFailsOnLineageMismatch(t *
 		t.Fatalf("expected verification drift issue, got %+v", promotion.Issues)
 	}
 }
+
+func TestVerifySignerRotationActivationAuditArchivePromotion(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	currentExport := mustCurrentSignerRotationActivationAuditExportPackage(t, bundle)
+	rotatedExport := mustRotatedSignerRotationActivationAuditExportPackage(t, bundle)
+	verification, err := SignerRotationActivationAuditVerifyExport(SignerRotationActivationAuditExportVerificationRequest{
+		ExportPackage: rotatedExport,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditVerifyExport failed: %v", err)
+	}
+	index, err := BuildSignerRotationActivationAuditArchiveIndex(SignerRotationActivationAuditArchiveIndexRequest{
+		Packages: []SignerRotationActivationAuditArchivePackage{
+			{PackagePath: "build/rotation/current-audit-export.json", ExportPackage: currentExport},
+			{PackagePath: "build/rotation/governance-chair-audit-export.json", ExportPackage: rotatedExport},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchiveIndex failed: %v", err)
+	}
+	promotion, err := BuildSignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionRequest{
+		PackagePath:        "build/rotation/governance-chair-audit-export.json",
+		ExportPackage:      rotatedExport,
+		VerificationReport: verification,
+		ArchiveIndex:       index,
+		PromotedAt:         "2026-04-24T00:20:00Z",
+		PromotedBy:         "governance-archive-bot",
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchivePromotion failed: %v", err)
+	}
+
+	receipt, err := VerifySignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionVerificationRequest{
+		PackagePath:        "build/rotation/governance-chair-audit-export.json",
+		ExportPackage:      rotatedExport,
+		VerificationReport: verification,
+		ArchiveIndex:       index,
+		PromotionResult:    promotion,
+		VerifiedAt:         "2026-04-24T00:25:00Z",
+		VerifiedBy:         "governance-audit-bot",
+	})
+	if err != nil {
+		t.Fatalf("VerifySignerRotationActivationAuditArchivePromotion failed: %v", err)
+	}
+	if receipt.Status != "verified" {
+		t.Fatalf("unexpected promotion verification status: %s", receipt.Status)
+	}
+	if receipt.VerificationReceiptID == "" || receipt.PromotionResultDigest == "" {
+		t.Fatalf("expected populated verification receipt digests, got %+v", receipt)
+	}
+	if receipt.PromotionReceiptID != promotion.PromotionReceipt.ReceiptID {
+		t.Fatalf("unexpected promotion receipt binding: %+v", receipt)
+	}
+}
+
+func TestVerifySignerRotationActivationAuditArchivePromotionFlagsDrift(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	currentExport := mustCurrentSignerRotationActivationAuditExportPackage(t, bundle)
+	rotatedExport := mustRotatedSignerRotationActivationAuditExportPackage(t, bundle)
+	verification, err := SignerRotationActivationAuditVerifyExport(SignerRotationActivationAuditExportVerificationRequest{
+		ExportPackage: rotatedExport,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditVerifyExport failed: %v", err)
+	}
+	index, err := BuildSignerRotationActivationAuditArchiveIndex(SignerRotationActivationAuditArchiveIndexRequest{
+		Packages: []SignerRotationActivationAuditArchivePackage{
+			{PackagePath: "build/rotation/current-audit-export.json", ExportPackage: currentExport},
+			{PackagePath: "build/rotation/governance-chair-audit-export.json", ExportPackage: rotatedExport},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchiveIndex failed: %v", err)
+	}
+	promotion, err := BuildSignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionRequest{
+		PackagePath:        "build/rotation/governance-chair-audit-export.json",
+		ExportPackage:      rotatedExport,
+		VerificationReport: verification,
+		ArchiveIndex:       index,
+		PromotedAt:         "2026-04-24T00:20:00Z",
+		PromotedBy:         "governance-archive-bot",
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchivePromotion failed: %v", err)
+	}
+	promotion.PromotionReceipt.CurrentPolicyDigest = "deadbeef"
+
+	receipt, err := VerifySignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionVerificationRequest{
+		PackagePath:        "build/rotation/governance-chair-audit-export.json",
+		ExportPackage:      rotatedExport,
+		VerificationReport: verification,
+		ArchiveIndex:       index,
+		PromotionResult:    promotion,
+		VerifiedAt:         "2026-04-24T00:25:00Z",
+		VerifiedBy:         "governance-audit-bot",
+	})
+	if err != nil {
+		t.Fatalf("VerifySignerRotationActivationAuditArchivePromotion failed: %v", err)
+	}
+	if receipt.Status != "invalid" {
+		t.Fatalf("expected invalid promotion verification status, got %s", receipt.Status)
+	}
+	if len(receipt.VerificationIssues) == 0 || !strings.Contains(strings.Join(receipt.VerificationIssues, " | "), "promotion drift detected") {
+		t.Fatalf("expected promotion drift issue, got %+v", receipt.VerificationIssues)
+	}
+}
+
+func TestSignerRotationActivationAuditRetainedInventorySnapshot(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	currentExport := mustCurrentSignerRotationActivationAuditExportPackage(t, bundle)
+	rotatedExport := mustRotatedSignerRotationActivationAuditExportPackage(t, bundle)
+	verification, err := SignerRotationActivationAuditVerifyExport(SignerRotationActivationAuditExportVerificationRequest{
+		ExportPackage: rotatedExport,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditVerifyExport failed: %v", err)
+	}
+	index, err := BuildSignerRotationActivationAuditArchiveIndex(SignerRotationActivationAuditArchiveIndexRequest{
+		Packages: []SignerRotationActivationAuditArchivePackage{
+			{PackagePath: "build/rotation/current-audit-export.json", ExportPackage: currentExport},
+			{PackagePath: "build/rotation/governance-chair-audit-export.json", ExportPackage: rotatedExport},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchiveIndex failed: %v", err)
+	}
+	promotion, err := BuildSignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionRequest{
+		PackagePath:        "build/rotation/governance-chair-audit-export.json",
+		ExportPackage:      rotatedExport,
+		VerificationReport: verification,
+		ArchiveIndex:       index,
+		PromotedAt:         "2026-04-24T00:20:00Z",
+		PromotedBy:         "governance-archive-bot",
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchivePromotion failed: %v", err)
+	}
+	receipt, err := VerifySignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionVerificationRequest{
+		PackagePath:        "build/rotation/governance-chair-audit-export.json",
+		ExportPackage:      rotatedExport,
+		VerificationReport: verification,
+		ArchiveIndex:       index,
+		PromotionResult:    promotion,
+		VerifiedAt:         "2026-04-24T00:25:00Z",
+		VerifiedBy:         "governance-audit-bot",
+	})
+	if err != nil {
+		t.Fatalf("VerifySignerRotationActivationAuditArchivePromotion failed: %v", err)
+	}
+
+	snapshot, err := BuildSignerRotationActivationAuditRetainedInventorySnapshot(SignerRotationActivationAuditRetainedInventorySnapshotRequest{
+		Packages: []SignerRotationActivationAuditRetainedInventoryPackage{
+			{
+				PromotionPath:       "build/rotation/governance-chair-archive-promotion.json",
+				PromotionResult:     promotion,
+				VerificationReceipt: receipt,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditRetainedInventorySnapshot failed: %v", err)
+	}
+	if snapshot.Status != "consistent" {
+		t.Fatalf("unexpected retained inventory status: %s", snapshot.Status)
+	}
+	if snapshot.PackageCount != 1 || snapshot.VerifiedCount != 1 {
+		t.Fatalf("unexpected retained inventory counts: %+v", snapshot)
+	}
+	if snapshot.LatestCurrentPolicyVersion != promotion.PromotionReceipt.CurrentPolicyVersion {
+		t.Fatalf("unexpected retained inventory latest policy version: %s", snapshot.LatestCurrentPolicyVersion)
+	}
+}
+
+func TestSignerRotationActivationAuditRetainedInventorySnapshotFlagsReceiptMismatch(t *testing.T) {
+	bundle, err := LoadBundle("../..")
+	if err != nil {
+		t.Fatalf("LoadBundle failed: %v", err)
+	}
+
+	currentExport := mustCurrentSignerRotationActivationAuditExportPackage(t, bundle)
+	rotatedExport := mustRotatedSignerRotationActivationAuditExportPackage(t, bundle)
+	verification, err := SignerRotationActivationAuditVerifyExport(SignerRotationActivationAuditExportVerificationRequest{
+		ExportPackage: rotatedExport,
+	})
+	if err != nil {
+		t.Fatalf("SignerRotationActivationAuditVerifyExport failed: %v", err)
+	}
+	index, err := BuildSignerRotationActivationAuditArchiveIndex(SignerRotationActivationAuditArchiveIndexRequest{
+		Packages: []SignerRotationActivationAuditArchivePackage{
+			{PackagePath: "build/rotation/current-audit-export.json", ExportPackage: currentExport},
+			{PackagePath: "build/rotation/governance-chair-audit-export.json", ExportPackage: rotatedExport},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchiveIndex failed: %v", err)
+	}
+	promotion, err := BuildSignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionRequest{
+		PackagePath:        "build/rotation/governance-chair-audit-export.json",
+		ExportPackage:      rotatedExport,
+		VerificationReport: verification,
+		ArchiveIndex:       index,
+		PromotedAt:         "2026-04-24T00:20:00Z",
+		PromotedBy:         "governance-archive-bot",
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditArchivePromotion failed: %v", err)
+	}
+	receipt, err := VerifySignerRotationActivationAuditArchivePromotion(SignerRotationActivationAuditArchivePromotionVerificationRequest{
+		PackagePath:        "build/rotation/governance-chair-audit-export.json",
+		ExportPackage:      rotatedExport,
+		VerificationReport: verification,
+		ArchiveIndex:       index,
+		PromotionResult:    promotion,
+		VerifiedAt:         "2026-04-24T00:25:00Z",
+		VerifiedBy:         "governance-audit-bot",
+	})
+	if err != nil {
+		t.Fatalf("VerifySignerRotationActivationAuditArchivePromotion failed: %v", err)
+	}
+	receipt.CurrentPolicyDigest = "deadbeef"
+
+	snapshot, err := BuildSignerRotationActivationAuditRetainedInventorySnapshot(SignerRotationActivationAuditRetainedInventorySnapshotRequest{
+		Packages: []SignerRotationActivationAuditRetainedInventoryPackage{
+			{
+				PromotionPath:       "build/rotation/governance-chair-archive-promotion.json",
+				PromotionResult:     promotion,
+				VerificationReceipt: receipt,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildSignerRotationActivationAuditRetainedInventorySnapshot failed: %v", err)
+	}
+	if snapshot.Status != "invalid" {
+		t.Fatalf("expected invalid retained inventory status, got %s", snapshot.Status)
+	}
+	if len(snapshot.Issues) == 0 || !strings.Contains(strings.Join(snapshot.Issues, " | "), "current_policy_digest mismatch") {
+		t.Fatalf("expected retained inventory digest mismatch issue, got %+v", snapshot.Issues)
+	}
+}


### PR DESCRIPTION
## Summary
- add deterministic verification receipts for promoted retained baselines
- add retained archive inventory snapshots over verified promoted baselines
- fail closed when verification receipts drift from promotion lineage or retained inventory state

## Testing
- python -m unittest discover -s tests -v
- make validate
- make go-test
- make go-build
- ./0aid signer-rotation-ledger-promote --export build/rotation/governance-chair-audit-export.json --verify build/rotation/governance-chair-audit-export-verify.json --index build/rotation/activation-audit-archive-index.json --promoted-at 2026-04-24T00:20:00Z --promoted-by governance-archive-bot --out build/rotation/governance-chair-archive-promotion.json --receipt-out build/rotation/governance-chair-archive-promotion-receipt.json --attestation-out build/rotation/governance-chair-retained-baseline-attestation.json
- ./0aid signer-rotation-ledger-verify-promotion --export build/rotation/governance-chair-audit-export.json --verify build/rotation/governance-chair-audit-export-verify.json --index build/rotation/activation-audit-archive-index.json --promotion build/rotation/governance-chair-archive-promotion.json --verified-at 2026-04-24T00:25:00Z --verified-by governance-audit-bot --out build/rotation/governance-chair-archive-verification.json
- ./0aid signer-rotation-ledger-retained-inventory --promotions build/rotation/governance-chair-archive-promotion.json --verification-receipts build/rotation/governance-chair-archive-verification.json --out build/rotation/retained-archive-inventory.json

Closes #45