### PR TITLE
Test Peachtree recursive learning validation loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Validate funding configuration
         run: make funding-validate
 
+      - name: Validate Peachtree recursive learning fixtures
+        run: python scripts/validate_peachtree_recursive_learning.py tests/fixtures/peachtree-recursive-learning
+
   go:
     name: Go Build
     runs-on: ubuntu-latest

--- a/docs/peachtree-recursive-learning-test.md
+++ b/docs/peachtree-recursive-learning-test.md
@@ -1,0 +1,118 @@
+# Peachtree Recursive Learning Validation Plan
+
+This document defines a safe, deterministic test plan for the Peachtree recursive learning loop across 0AI Assurance Network governance artifacts.
+
+The plan is intentionally **generate-only** and **human-in-the-loop**. It does not perform autonomous on-chain actions, token issuance, production key usage, public deployment, or unsandboxed fuzzing.
+
+## Objective
+
+Validate that a governance artifact can pass through a controlled recursive learning loop:
+
+```text
+Governance artifact
+  -> static validation
+  -> governance simulation or threat scan
+  -> fuzz/edge-case classification
+  -> sanitized dataset row
+  -> self-improvement recommendation
+  -> next-cycle seed candidate
+```
+
+## Test scope
+
+Supported first-wave artifacts:
+
+- governance proposal JSON
+- signer-rotation receipt JSON
+- signer approval bundle JSON
+- activation audit ledger JSON
+- localnet render summary JSON
+- funding deployment dry-run artifact
+
+Out of scope:
+
+- real signing
+- real token issuance
+- live chain deployment
+- production keys
+- unsandboxed fuzz execution
+- non-owned or third-party targets
+
+## Recursive learning invariants
+
+A valid recursive learning cycle must satisfy all invariants:
+
+1. **Deterministic input identity**: every input artifact has a stable SHA-256 digest.
+2. **Sandbox boundary**: any execution command is represented as a dry-run or sandbox-required command.
+3. **Policy gate**: every cycle has a `policy_decision` of `allow_dry_run`, `human_review_required`, or `blocked`.
+4. **Dataset hygiene**: generated dataset rows do not include secrets, production keys, live endpoints, or raw private telemetry.
+5. **Improvement traceability**: every self-improvement recommendation links to the input digest, finding ID, and next-cycle seed candidate.
+6. **No autonomous promotion**: no generated seed, dataset, or patch is promoted without human review.
+
+## Canonical test record
+
+```json
+{
+  "schema_version": "peachtree.recursive_learning.v1",
+  "cycle_id": "cycle-0001",
+  "artifact_type": "governance_proposal",
+  "artifact_path": "examples/proposals/emergency-pause.json",
+  "artifact_sha256": "sha256:REPLACE_WITH_DIGEST",
+  "validation_commands": [
+    "make validate",
+    "make governance-sim PROPOSAL=examples/proposals/emergency-pause.json",
+    "make governance-threat-scan PROPOSAL=examples/proposals/emergency-pause.json"
+  ],
+  "sandbox_required": true,
+  "policy_decision": "human_review_required",
+  "findings": [
+    {
+      "finding_id": "gov-edge-0001",
+      "severity": "medium",
+      "class": "governance_edge_case",
+      "summary": "Proposal requires deterministic simulation and threat-scan review before dataset promotion."
+    }
+  ],
+  "dataset_candidate": {
+    "dataset_name": "governance_fuzz_v1.jsonl",
+    "privacy_tier": "restricted",
+    "dataset_action": "human_review",
+    "labels": ["governance", "fuzzing", "peachtree", "recursive-learning"]
+  },
+  "self_improvement": {
+    "recommendation": "Add this artifact shape to the next governance fuzz seed set after maintainer review.",
+    "next_cycle_seed_candidate": true,
+    "requires_human_approval": true
+  }
+}
+```
+
+## Suggested local dry-run commands
+
+```bash
+make validate
+make readiness
+make governance-sim PROPOSAL=examples/proposals/emergency-pause.json
+make governance-threat-scan PROPOSAL=examples/proposals/emergency-pause.json
+make governance-queue REGISTRY=examples/proposals/registry.json
+make governance-trends REGISTRY=examples/proposals/registry.json HISTORY=examples/proposals/history.json
+```
+
+## Acceptance criteria
+
+- The recursive learning record has a stable schema version.
+- Every artifact includes digest/provenance metadata.
+- Every execution command is dry-run or sandbox-required.
+- Every high-risk promotion is marked `human_review_required` or `blocked`.
+- Dataset candidates include privacy, label, and promotion status fields.
+- The final output includes a next-cycle recommendation but does not self-apply it.
+
+## GitHub CI extension
+
+A future CI job may validate fixture records with a command like:
+
+```bash
+python scripts/validate_peachtree_recursive_learning.py tests/fixtures/peachtree-recursive-learning/*.json
+```
+
+That validator should only check schema, policy posture, and redaction invariants. It should not run long fuzzing or training in pull-request CI.

--- a/scripts/validate_peachtree_recursive_learning.py
+++ b/scripts/validate_peachtree_recursive_learning.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Validate Peachtree recursive learning fixture records.
+
+This validator is intentionally conservative. It checks schema, policy posture,
+and redaction invariants only. It does not execute fuzzing, training, signing, or
+network actions.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ALLOWED_SCHEMA_VERSION = "peachtree.recursive_learning.v1"
+ALLOWED_POLICY_DECISIONS = {"allow_dry_run", "human_review_required", "blocked"}
+ALLOWED_DATASET_ACTIONS = {"retain", "hash_only", "discard", "human_review"}
+BLOCKED_SUBSTRINGS = (
+    "private_key",
+    "secret_key",
+    "api_key",
+    "bearer ",
+    "password",
+    "token=",
+    "authorization:",
+    "cookie:",
+)
+
+
+def _fail(path: Path, message: str) -> str:
+    return f"{path}: {message}"
+
+
+def _contains_blocked_secret(value: Any) -> bool:
+    serialized = json.dumps(value, sort_keys=True).lower()
+    return any(item in serialized for item in BLOCKED_SUBSTRINGS)
+
+
+def validate_record(path: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [_fail(path, f"invalid JSON: {exc}")]
+
+    if record.get("schema_version") != ALLOWED_SCHEMA_VERSION:
+        errors.append(_fail(path, "schema_version must be peachtree.recursive_learning.v1"))
+
+    required_fields = {
+        "cycle_id",
+        "artifact_type",
+        "artifact_path",
+        "artifact_sha256",
+        "validation_commands",
+        "sandbox_required",
+        "policy_decision",
+        "findings",
+        "dataset_candidate",
+        "self_improvement",
+    }
+    missing = sorted(required_fields - set(record))
+    if missing:
+        errors.append(_fail(path, f"missing required fields: {', '.join(missing)}"))
+
+    if not str(record.get("artifact_sha256", "")).startswith("sha256:"):
+        errors.append(_fail(path, "artifact_sha256 must start with sha256:"))
+
+    if record.get("sandbox_required") is not True:
+        errors.append(_fail(path, "sandbox_required must be true"))
+
+    if record.get("policy_decision") not in ALLOWED_POLICY_DECISIONS:
+        errors.append(_fail(path, "policy_decision is not allowed"))
+
+    commands = record.get("validation_commands", [])
+    if not isinstance(commands, list) or not commands:
+        errors.append(_fail(path, "validation_commands must be a non-empty list"))
+    elif any(not isinstance(command, str) for command in commands):
+        errors.append(_fail(path, "validation_commands must contain only strings"))
+
+    dataset = record.get("dataset_candidate", {})
+    if dataset.get("dataset_action") not in ALLOWED_DATASET_ACTIONS:
+        errors.append(_fail(path, "dataset_candidate.dataset_action is not allowed"))
+
+    if record.get("policy_decision") in {"human_review_required", "blocked"}:
+        if record.get("self_improvement", {}).get("requires_human_approval") is not True:
+            errors.append(_fail(path, "human-review or blocked records must require human approval"))
+
+    if _contains_blocked_secret(record):
+        errors.append(_fail(path, "record appears to contain a blocked secret/token marker"))
+
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: validate_peachtree_recursive_learning.py <file-or-directory> [...]")
+        return 2
+
+    paths: list[Path] = []
+    for arg in argv:
+        path = Path(arg)
+        if path.is_dir():
+            paths.extend(sorted(path.glob("*.json")))
+        else:
+            paths.append(path)
+
+    errors: list[str] = []
+    for path in paths:
+        errors.extend(validate_record(path))
+
+    if errors:
+        print("Peachtree recursive learning validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print(f"Validated {len(paths)} Peachtree recursive learning record(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/fixtures/peachtree-recursive-learning/governance-proposal-cycle.json
+++ b/tests/fixtures/peachtree-recursive-learning/governance-proposal-cycle.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": "peachtree.recursive_learning.v1",
+  "cycle_id": "cycle-0001",
+  "artifact_type": "governance_proposal",
+  "artifact_path": "examples/proposals/emergency-pause.json",
+  "artifact_sha256": "sha256:placeholder-digest-for-fixture",
+  "validation_commands": [
+    "make validate",
+    "make governance-sim PROPOSAL=examples/proposals/emergency-pause.json",
+    "make governance-threat-scan PROPOSAL=examples/proposals/emergency-pause.json"
+  ],
+  "sandbox_required": true,
+  "policy_decision": "human_review_required",
+  "findings": [
+    {
+      "finding_id": "gov-edge-0001",
+      "severity": "medium",
+      "class": "governance_edge_case",
+      "summary": "Proposal requires deterministic simulation and threat-scan review before dataset promotion."
+    }
+  ],
+  "dataset_candidate": {
+    "dataset_name": "governance_fuzz_v1.jsonl",
+    "privacy_tier": "restricted",
+    "dataset_action": "human_review",
+    "labels": [
+      "governance",
+      "fuzzing",
+      "peachtree",
+      "recursive-learning"
+    ]
+  },
+  "self_improvement": {
+    "recommendation": "Add this artifact shape to the next governance fuzz seed set after maintainer review.",
+    "next_cycle_seed_candidate": true,
+    "requires_human_approval": true
+  }
+}


### PR DESCRIPTION
## Summary

Adds a safe, deterministic recursive-learning validation path for Peachtree governance artifacts.

## Changes

- Adds `docs/peachtree-recursive-learning-test.md` with the recursive learning validation plan.
- Adds a fixture record at `tests/fixtures/peachtree-recursive-learning/governance-proposal-cycle.json`.
- Adds `scripts/validate_peachtree_recursive_learning.py` to validate schema, policy posture, human-review gates, and blocked secret markers.
- Extends CI to validate Peachtree recursive learning fixtures.

## Safety posture

This is generate-only and validation-only. It does not perform autonomous chain actions, token issuance, production signing, live deployment, long fuzzing, training, or network scanning.

## Test command

```bash
python scripts/validate_peachtree_recursive_learning.py tests/fixtures/peachtree-recursive-learning
```

## Acceptance criteria

- Recursive learning records have a stable schema version.
- Every artifact includes digest/provenance metadata.
- Every execution command is dry-run or sandbox-required.
- High-risk promotions require human review or are blocked.
- Dataset candidates include privacy, labels, and promotion status.
- The loop produces a next-cycle recommendation but does not self-apply it.